### PR TITLE
feat: Add support for multiple axes and subplots

### DIFF
--- a/example/fortran/ascii_heatmap/ascii_heatmap_demo.f90
+++ b/example/fortran/ascii_heatmap/ascii_heatmap_demo.f90
@@ -1,0 +1,81 @@
+program ascii_heatmap_demo
+    !! Demonstrate ASCII heatmap visualization with various 2D functions
+    use fortplot, only: figure_t, wp
+    implicit none
+    
+    type(figure_t) :: fig
+    real(wp), allocatable :: x(:), y(:), z1(:,:), z2(:,:), z3(:,:)
+    integer :: i, j, nx, ny
+    real(wp) :: r
+    
+    nx = 40
+    ny = 30
+    
+    allocate(x(nx), y(ny))
+    allocate(z1(nx, ny), z2(nx, ny), z3(nx, ny))
+    
+    ! Create coordinate arrays
+    do i = 1, nx
+        x(i) = -3.0_wp + 6.0_wp * (i - 1) / real(nx - 1, wp)
+    end do
+    
+    do j = 1, ny
+        y(j) = -2.0_wp + 4.0_wp * (j - 1) / real(ny - 1, wp)
+    end do
+    
+    ! Generate different 2D patterns
+    do i = 1, nx
+        do j = 1, ny
+            ! Pattern 1: Circular ripples
+            r = sqrt(x(i)**2 + y(j)**2)
+            z1(i, j) = sin(2.0_wp * r) / (1.0_wp + 0.1_wp * r)
+            
+            ! Pattern 2: Saddle point
+            z2(i, j) = x(i)**2 - y(j)**2
+            
+            ! Pattern 3: Four peaks
+            z3(i, j) = exp(-((x(i)-1)**2 + (y(j)-1)**2)) + &
+                      exp(-((x(i)+1)**2 + (y(j)-1)**2)) + &
+                      exp(-((x(i)-1)**2 + (y(j)+1)**2)) + &
+                      exp(-((x(i)+1)**2 + (y(j)+1)**2))
+        end do
+    end do
+    
+    ! Demo 1: Circular ripples with contour_filled
+    call fig%initialize(80, 25)
+    call fig%add_contour_filled(x, y, z1, label="Ripples")
+    call fig%set_title("ASCII Heatmap: Circular Ripples")
+    call fig%savefig('circular_ripples.txt')
+    
+    ! Demo 2: Saddle point with pcolormesh
+    block
+        real(wp), allocatable :: x_edges(:), y_edges(:)
+        allocate(x_edges(nx+1), y_edges(ny+1))
+        
+        ! Create edge coordinates
+        do i = 1, nx+1
+            x_edges(i) = -3.05_wp + 6.1_wp * (i - 1) / real(nx, wp)
+        end do
+        
+        do j = 1, ny+1
+            y_edges(j) = -2.05_wp + 4.1_wp * (j - 1) / real(ny, wp)
+        end do
+        
+        call fig%initialize(80, 25)
+        call fig%add_pcolormesh(x_edges, y_edges, transpose(z2))
+        call fig%set_title("ASCII Heatmap: Saddle Point")
+        call fig%savefig('saddle_point.txt')
+    end block
+    
+    ! Demo 3: Four peaks
+    call fig%initialize(80, 25)
+    call fig%add_contour_filled(x, y, z3, label="Four Peaks")
+    call fig%set_title("ASCII Heatmap: Four Gaussian Peaks")
+    call fig%savefig('four_peaks.txt')
+    
+    print *, "ASCII heatmap demos saved:"
+    print *, "  - circular_ripples.txt"
+    print *, "  - saddle_point.txt"
+    print *, "  - four_peaks.txt"
+    
+end program ascii_heatmap_demo

--- a/src/fortplot_figure_core.f90
+++ b/src/fortplot_figure_core.f90
@@ -1065,6 +1065,19 @@ contains
         z_min = minval(self%plots(plot_idx)%z_grid)
         z_max = maxval(self%plots(plot_idx)%z_grid)
         
+        ! For ASCII backend with colored contours, render as heatmap
+        select type (backend => self%backend)
+        type is (ascii_context)
+            if (self%plots(plot_idx)%use_color_levels) then
+                ! Render as heatmap for filled contours
+                call backend%fill_heatmap(self%plots(plot_idx)%x_grid, &
+                                        self%plots(plot_idx)%y_grid, &
+                                        self%plots(plot_idx)%z_grid, &
+                                        z_min, z_max)
+                return
+            end if
+        end select
+        
         ! Render each contour level that falls within data range
         if (allocated(self%plots(plot_idx)%contour_levels)) then
             do level_idx = 1, size(self%plots(plot_idx)%contour_levels)
@@ -1101,6 +1114,37 @@ contains
         ! Get colormap range from pcolormesh data
         c_min = self%plots(plot_idx)%pcolormesh_data%vmin
         c_max = self%plots(plot_idx)%pcolormesh_data%vmax
+        
+        ! For ASCII backend, render as heatmap
+        select type (backend => self%backend)
+        type is (ascii_context)
+            block
+                real(wp), allocatable :: x_centers(:), y_centers(:)
+                integer :: nx, ny, i, j
+                
+                nx = self%plots(plot_idx)%pcolormesh_data%nx
+                ny = self%plots(plot_idx)%pcolormesh_data%ny
+                
+                allocate(x_centers(nx), y_centers(ny))
+                
+                ! Calculate cell centers from vertices
+                do i = 1, nx
+                    x_centers(i) = 0.5_wp * (self%plots(plot_idx)%pcolormesh_data%x_vertices(1, i) + &
+                                           self%plots(plot_idx)%pcolormesh_data%x_vertices(1, i+1))
+                end do
+                
+                do j = 1, ny
+                    y_centers(j) = 0.5_wp * (self%plots(plot_idx)%pcolormesh_data%y_vertices(j, 1) + &
+                                           self%plots(plot_idx)%pcolormesh_data%y_vertices(j+1, 1))
+                end do
+                
+                ! Render as heatmap using cell centers
+                call backend%fill_heatmap(x_centers, y_centers, &
+                                        self%plots(plot_idx)%pcolormesh_data%c_values, &
+                                        c_min, c_max)
+            end block
+            return
+        end select
         
         ! Render each quadrilateral
         do i = 1, self%plots(plot_idx)%pcolormesh_data%ny

--- a/test/test_ascii_heatmap.f90
+++ b/test/test_ascii_heatmap.f90
@@ -1,0 +1,46 @@
+program test_ascii_heatmap
+    use fortplot, only: figure_t, wp
+    implicit none
+    integer :: i, j
+    real(wp), allocatable :: x(:), y(:), z(:,:)
+    type(figure_t) :: fig
+    
+    ! Test data - 2D Gaussian
+    allocate(x(20), y(20), z(20,20))
+    do i = 1, 20
+        x(i) = -2.0_wp + 4.0_wp * (i - 1) / 19.0_wp
+        y(i) = -2.0_wp + 4.0_wp * (i - 1) / 19.0_wp
+    end do
+    
+    do i = 1, 20
+        do j = 1, 20
+            z(i,j) = exp(-(x(i)**2 + y(j)**2))
+        end do
+    end do
+    
+    ! Test contour_filled ASCII output
+    call fig%initialize(80, 25)
+    call fig%add_contour_filled(x, y, z, label="Gaussian")
+    call fig%savefig('test_contour_filled.txt')
+    
+    ! Test pcolormesh ASCII output - needs edge coordinates
+    block
+        real(wp), allocatable :: x_edges(:), y_edges(:)
+        integer :: i
+        
+        allocate(x_edges(21), y_edges(21))
+        
+        ! Create edge coordinates (one more than centers)
+        do i = 1, 21
+            x_edges(i) = -2.0_wp - 0.1_wp + 4.2_wp * (i - 1) / 20.0_wp
+            y_edges(i) = -2.0_wp - 0.1_wp + 4.2_wp * (i - 1) / 20.0_wp
+        end do
+        
+        call fig%initialize(80, 25)
+        call fig%add_pcolormesh(x_edges, y_edges, z)
+        call fig%savefig('test_pcolormesh.txt')
+    end block
+    
+    print *, "ASCII heatmap tests completed"
+    
+end program test_ascii_heatmap


### PR DESCRIPTION
## Summary
- Implement multiple axes and subplot functionality similar to matplotlib
- Maintain pyplot-fortran style API in Fortran
- Ensure matplotlib API compatibility in Python interface

## Motivation
Currently fortplotlib only supports single plots. This PR adds support for creating multiple axes and subplots within a single figure, bringing the library closer to matplotlib's functionality while keeping the clean Fortran API style from pyplot-fortran.

## Implementation Plan
- [ ] Add axes management to figure_t type
- [ ] Implement subplot creation methods (add_subplot, subplots)
- [ ] Update backends to handle multiple axes rendering
- [ ] Add pyplot-fortran style convenience functions
- [ ] Ensure Python interface maintains matplotlib compatibility
- [ ] Add comprehensive tests for multi-axes functionality
- [ ] Update examples to demonstrate subplot usage

## API Design Goals
1. **Fortran API**: Keep it clean and intuitive like pyplot-fortran
2. **Python API**: Maintain compatibility with matplotlib's subplot API
3. **Backend Support**: Ensure all backends (PNG, PDF, ASCII) support multiple axes

🤖 Generated with [Claude Code](https://claude.ai/code)