### PR TITLE
test: Add comprehensive PDF content regression tests for Issue #97

### DIFF
--- a/test/test_pdf_content_regression.f90
+++ b/test/test_pdf_content_regression.f90
@@ -1,0 +1,343 @@
+program test_pdf_content_regression
+    !! Test PDF content integrity and format validation for Issue #97
+    !! Given: PDF files should contain proper PDF content structure
+    !! When: We generate PDF files using fortplot
+    !! Then: Files should contain PDF headers and NOT PNG data
+    use fortplot
+    use fortplot_security, only: safe_remove_file
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+    
+    call test_pdf_header_validation()
+    call test_pdf_not_png_content()
+    call test_pdf_structure_integrity()
+    call test_pdf_content_format_various_scenarios()
+    
+    print *, "All PDF content regression tests completed!"
+    
+contains
+
+    subroutine test_pdf_header_validation()
+        !! Given: PDF files must start with valid PDF header
+        !! When: We create a simple PDF plot
+        !! Then: File should start with "%PDF-" header
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(5) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+        real(wp), parameter :: y_data(5) = [1.0_wp, 4.0_wp, 2.0_wp, 8.0_wp, 5.0_wp]
+        character(len=200) :: test_file
+        character(len=8) :: pdf_header
+        integer :: file_unit, ios
+        logical :: has_pdf_header, remove_success
+        
+        print *, "=== Testing PDF header validation ==="
+        
+        test_file = "output/test/test_pdf_header_validation.pdf"
+        
+        call fig%initialize(640, 480)
+        call fig%add_plot(x_data, y_data)
+        call fig%set_title("PDF Header Test")
+        call fig%savefig(test_file)
+        
+        ! Read first 8 bytes to check PDF header
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PDF file for header validation"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) pdf_header
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PDF header"
+            return
+        end if
+        
+        ! Check if header starts with "%PDF-"
+        has_pdf_header = (pdf_header(1:5) == '%PDF-')
+        
+        print *, "PDF header found: ", pdf_header(1:8)
+        print *, "Valid PDF header: ", has_pdf_header
+        
+        if (.not. has_pdf_header) then
+            print *, "*** CRITICAL FAILURE: PDF file does not have valid PDF header ***"
+            print *, "Expected: %PDF-, Found: ", pdf_header(1:5)
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_pdf_header_validation
+    
+    subroutine test_pdf_not_png_content()
+        !! Given: PDF files should not contain PNG data
+        !! When: We create a PDF plot  
+        !! Then: File should NOT contain PNG signature bytes
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(3) = [0.0_wp, 1.0_wp, 2.0_wp]
+        real(wp), parameter :: y_data(3) = [0.0_wp, 1.0_wp, 0.5_wp]
+        character(len=200) :: test_file
+        character(len=512) :: file_buffer
+        integer :: file_unit, ios, file_size
+        logical :: contains_png_signature, remove_success
+        
+        print *, "=== Testing PDF does not contain PNG data ==="
+        
+        test_file = "output/test/test_pdf_not_png.pdf"
+        
+        call fig%initialize(800, 600)
+        call fig%add_plot(x_data, y_data, label="Test Data")
+        call fig%legend()
+        call fig%savefig(test_file)
+        
+        ! Check file size first
+        inquire(file=test_file, size=file_size)
+        print *, "Generated PDF file size: ", file_size, " bytes"
+        
+        ! Read beginning of file to check for PNG signature
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PDF file for PNG signature check"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) file_buffer
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PDF file content"
+            return
+        end if
+        
+        ! Check for PNG signature: 89 50 4E 47 0D 0A 1A 0A (\211PNG\r\n\032\n)
+        contains_png_signature = check_png_signature_in_buffer(file_buffer)
+        
+        print *, "Contains PNG signature: ", contains_png_signature
+        
+        if (contains_png_signature) then
+            print *, "*** CRITICAL FAILURE: PDF file contains PNG data ***"
+            print *, "This indicates Issue #97 regression - PNG output in PDF files"
+        else
+            print *, "PASS: PDF file does not contain PNG data"
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_pdf_not_png_content
+    
+    subroutine test_pdf_structure_integrity()
+        !! Given: PDF files must have proper internal structure
+        !! When: We create a PDF with various elements
+        !! Then: File should contain PDF objects, xref table, and trailer
+        type(figure_t) :: fig
+        real(wp), parameter :: n = 20
+        real(wp) :: x_data(20), y_data(20)
+        character(len=200) :: test_file
+        character(len=2048) :: file_content
+        integer :: file_unit, ios, i
+        logical :: has_pdf_objects, has_xref_table, has_trailer, remove_success
+        
+        print *, "=== Testing PDF structure integrity ==="
+        
+        test_file = "output/test/test_pdf_structure.pdf"
+        
+        ! Generate test data
+        do i = 1, 20
+            x_data(i) = real(i - 1, wp) * 0.1_wp
+            y_data(i) = sin(x_data(i) * 6.28_wp) * exp(-x_data(i))
+        end do
+        
+        call fig%initialize(640, 480)
+        call fig%add_plot(x_data, y_data)
+        call fig%set_title("PDF Structure Test")
+        call fig%set_xlabel("Time (s)")
+        call fig%set_ylabel("Amplitude")
+        call fig%savefig(test_file)
+        
+        ! Read file content to check internal structure
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PDF file for structure validation"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) file_content
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PDF file structure"
+            return
+        end if
+        
+        ! Check for essential PDF structure elements
+        has_pdf_objects = index(file_content, ' 0 obj') > 0
+        has_xref_table = index(file_content, 'xref') > 0
+        has_trailer = index(file_content, 'trailer') > 0
+        
+        print *, "Has PDF objects: ", has_pdf_objects
+        print *, "Has xref table: ", has_xref_table  
+        print *, "Has trailer: ", has_trailer
+        
+        if (.not. (has_pdf_objects .and. has_xref_table .and. has_trailer)) then
+            print *, "*** CRITICAL FAILURE: PDF file missing essential structure elements ***"
+            if (.not. has_pdf_objects) print *, "Missing: PDF objects"
+            if (.not. has_xref_table) print *, "Missing: xref table"
+            if (.not. has_trailer) print *, "Missing: trailer"
+        else
+            print *, "PASS: PDF structure integrity verified"
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_pdf_structure_integrity
+    
+    subroutine test_pdf_content_format_various_scenarios()
+        !! Given: PDF content should be consistent across different plot types
+        !! When: We create various PDF plots (scatter, line, contour)
+        !! Then: All should have valid PDF format, not PNG content
+        character(len=200) :: scatter_file, line_file, contour_file
+        logical :: all_valid_pdfs, remove_success
+        
+        print *, "=== Testing PDF format across various scenarios ==="
+        
+        scatter_file = "output/test/test_pdf_scatter.pdf"
+        line_file = "output/test/test_pdf_line.pdf"
+        contour_file = "output/test/test_pdf_contour.pdf"
+        
+        ! Create scatter plot PDF
+        call create_test_scatter_pdf(scatter_file)
+        
+        ! Create line plot PDF
+        call create_test_line_pdf(line_file)
+        
+        ! Create contour plot PDF  
+        call create_test_contour_pdf(contour_file)
+        
+        ! Validate all files
+        all_valid_pdfs = validate_pdf_format(scatter_file) .and. &
+                        validate_pdf_format(line_file) .and. &
+                        validate_pdf_format(contour_file)
+        
+        print *, "All PDFs have valid format: ", all_valid_pdfs
+        
+        if (.not. all_valid_pdfs) then
+            print *, "*** CRITICAL FAILURE: One or more PDF files have invalid format ***"
+        else
+            print *, "PASS: All PDF scenarios have valid format"
+        end if
+        
+        ! Cleanup
+        call safe_remove_file(scatter_file, remove_success)
+        call safe_remove_file(line_file, remove_success)
+        call safe_remove_file(contour_file, remove_success)
+    end subroutine test_pdf_content_format_various_scenarios
+    
+    subroutine create_test_scatter_pdf(filename)
+        character(len=*), intent(in) :: filename
+        type(figure_t) :: fig
+        real(wp) :: x_data(15), y_data(15)
+        integer :: i
+        
+        do i = 1, 15
+            x_data(i) = real(i, wp)
+            y_data(i) = x_data(i)**2 + real(i, wp) * 0.5_wp
+        end do
+        
+        call fig%initialize(600, 450)
+        call fig%add_scatter(x_data, y_data, marker='o')
+        call fig%set_title("PDF Scatter Test")
+        call fig%savefig(filename)
+    end subroutine create_test_scatter_pdf
+    
+    subroutine create_test_line_pdf(filename)
+        character(len=*), intent(in) :: filename
+        type(figure_t) :: fig
+        real(wp) :: x_data(25), y_data(25)
+        integer :: i
+        
+        do i = 1, 25
+            x_data(i) = real(i - 1, wp) * 0.2_wp
+            y_data(i) = cos(x_data(i) * 2.0_wp) + 0.5_wp * sin(x_data(i) * 5.0_wp)
+        end do
+        
+        call fig%initialize(800, 600)
+        call fig%add_plot(x_data, y_data, linestyle='-')
+        call fig%set_title("PDF Line Test")
+        call fig%savefig(filename)
+    end subroutine create_test_line_pdf
+    
+    subroutine create_test_contour_pdf(filename)
+        character(len=*), intent(in) :: filename
+        type(figure_t) :: fig
+        integer, parameter :: nx = 10, ny = 10
+        real(wp) :: x_data(nx), y_data(ny), z_data(nx, ny)
+        integer :: i, j
+        
+        do i = 1, nx
+            x_data(i) = real(i - 1, wp) * 0.1_wp
+        end do
+        
+        do j = 1, ny
+            y_data(j) = real(j - 1, wp) * 0.1_wp
+        end do
+        
+        do i = 1, nx
+            do j = 1, ny
+                z_data(i, j) = exp(-(x_data(i)**2 + y_data(j)**2))
+            end do
+        end do
+        
+        call fig%initialize(700, 500)
+        call fig%add_contour(x_data, y_data, z_data)
+        call fig%set_title("PDF Contour Test")
+        call fig%savefig(filename)
+    end subroutine create_test_contour_pdf
+    
+    function validate_pdf_format(filename) result(is_valid_pdf)
+        character(len=*), intent(in) :: filename
+        logical :: is_valid_pdf
+        character(len=128) :: file_buffer
+        integer :: file_unit, ios
+        logical :: has_pdf_header, no_png_content
+        
+        is_valid_pdf = .false.
+        
+        open(newunit=file_unit, file=filename, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) return
+        
+        read(file_unit, iostat=ios) file_buffer
+        close(file_unit)
+        
+        if (ios /= 0) return
+        
+        ! Check PDF header and absence of PNG content
+        has_pdf_header = (file_buffer(1:5) == '%PDF-')
+        no_png_content = .not. check_png_signature_in_buffer(file_buffer)
+        
+        is_valid_pdf = has_pdf_header .and. no_png_content
+        
+        if (.not. is_valid_pdf) then
+            print *, "INVALID PDF: ", trim(filename)
+            if (.not. has_pdf_header) print *, "  - Missing PDF header"
+            if (.not. no_png_content) print *, "  - Contains PNG content"
+        end if
+    end function validate_pdf_format
+    
+    function check_png_signature_in_buffer(buffer) result(has_png_sig)
+        character(len=*), intent(in) :: buffer
+        logical :: has_png_sig
+        integer :: i, buffer_len
+        
+        has_png_sig = .false.
+        buffer_len = len(buffer)
+        
+        ! Look for PNG signature: 89 50 4E 47 (decimal: 137 80 78 71)
+        ! This represents the byte sequence \211PNG
+        do i = 1, buffer_len - 3
+            if (iachar(buffer(i:i)) == 137 .and. &    ! 89 hex = 137 decimal
+                iachar(buffer(i+1:i+1)) == 80 .and. & ! 50 hex = 80 decimal  
+                iachar(buffer(i+2:i+2)) == 78 .and. & ! 4E hex = 78 decimal
+                iachar(buffer(i+3:i+3)) == 71) then   ! 47 hex = 71 decimal
+                has_png_sig = .true.
+                exit
+            end if
+        end do
+    end function check_png_signature_in_buffer
+
+end program test_pdf_content_regression

--- a/test/test_png_content_validation.f90
+++ b/test/test_png_content_validation.f90
@@ -1,0 +1,273 @@
+program test_png_content_validation
+    !! Validate PNG content format integrity (complementary to PDF content regression tests)
+    !! Given: PNG files should contain proper PNG content and structure
+    !! When: We generate PNG files using fortplot
+    !! Then: Files should have PNG headers and proper PNG structure
+    use fortplot
+    use fortplot_security, only: safe_remove_file
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+    
+    call test_png_header_validation()
+    call test_png_structure_integrity()  
+    call test_png_size_validation()
+    call test_png_pixel_diversity()
+    
+    print *, "All PNG content validation tests completed!"
+    
+contains
+
+    subroutine test_png_header_validation()
+        !! Given: PNG files must start with PNG signature
+        !! When: We create a PNG plot
+        !! Then: File should start with PNG signature bytes
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        real(wp), parameter :: y_data(4) = [2.0_wp, 5.0_wp, 3.0_wp, 7.0_wp]
+        character(len=200) :: test_file
+        character(len=8) :: png_header
+        integer :: file_unit, ios
+        logical :: has_png_header, remove_success
+        
+        print *, "=== Testing PNG header validation ==="
+        
+        test_file = "output/test/test_png_header.png"
+        
+        call fig%initialize(640, 480)
+        call fig%add_plot(x_data, y_data)
+        call fig%set_title("PNG Header Test")
+        call fig%savefig(test_file)
+        
+        ! Read first 8 bytes to check PNG signature
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PNG file for header validation"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) png_header
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PNG header"
+            return
+        end if
+        
+        ! Check PNG signature: 89 50 4E 47 0D 0A 1A 0A
+        has_png_header = (iachar(png_header(1:1)) == 137 .and. &  ! 89 hex
+                         iachar(png_header(2:2)) == 80 .and. &   ! 50 hex (P)
+                         iachar(png_header(3:3)) == 78 .and. &   ! 4E hex (N)
+                         iachar(png_header(4:4)) == 71)          ! 47 hex (G)
+        
+        print *, "PNG signature found: ", has_png_header
+        if (has_png_header) then
+            print *, "First 4 signature bytes: ", iachar(png_header(1:1)), iachar(png_header(2:2)), &
+                     iachar(png_header(3:3)), iachar(png_header(4:4))
+        end if
+        
+        if (.not. has_png_header) then
+            print *, "*** FAILURE: PNG file does not have valid PNG signature ***"
+            print *, "Expected signature bytes: 137 80 78 71"
+        else
+            print *, "PASS: PNG header validation successful"
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_png_header_validation
+    
+    subroutine test_png_structure_integrity()
+        !! Given: PNG files must have proper chunk structure
+        !! When: We create a PNG plot with various elements
+        !! Then: File should contain IHDR, IDAT, and IEND chunks
+        type(figure_t) :: fig
+        real(wp) :: x_data(10), y_data(10)
+        character(len=200) :: test_file
+        character(len=1024) :: file_content
+        integer :: file_unit, ios, i
+        logical :: has_ihdr, has_idat, has_iend, remove_success
+        
+        print *, "=== Testing PNG structure integrity ==="
+        
+        test_file = "output/test/test_png_structure.png"
+        
+        ! Generate test data
+        do i = 1, 10
+            x_data(i) = real(i - 1, wp)
+            y_data(i) = x_data(i)**2 * 0.5_wp
+        end do
+        
+        call fig%initialize(500, 400)
+        call fig%add_scatter(x_data, y_data)
+        call fig%set_title("PNG Structure Test")
+        call fig%set_xlabel("Index")
+        call fig%set_ylabel("Value")
+        call fig%savefig(test_file)
+        
+        ! Read file content to check chunk structure
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PNG file for structure validation"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) file_content
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PNG file structure"
+            return
+        end if
+        
+        ! Check for essential PNG chunks
+        has_ihdr = index(file_content, 'IHDR') > 0
+        has_idat = index(file_content, 'IDAT') > 0
+        has_iend = index(file_content, 'IEND') > 0
+        
+        print *, "Has IHDR chunk: ", has_ihdr
+        print *, "Has IDAT chunk: ", has_idat
+        print *, "Has IEND chunk: ", has_iend
+        
+        if (.not. (has_ihdr .and. has_idat .and. has_iend)) then
+            print *, "*** FAILURE: PNG file missing essential chunks ***"
+            if (.not. has_ihdr) print *, "Missing: IHDR chunk"
+            if (.not. has_idat) print *, "Missing: IDAT chunk" 
+            if (.not. has_iend) print *, "Missing: IEND chunk"
+        else
+            print *, "PASS: PNG structure integrity verified"
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_png_structure_integrity
+    
+    subroutine test_png_size_validation()
+        !! Given: PNG files should have reasonable sizes for plot content
+        !! When: We create PNG plots of different complexities
+        !! Then: File sizes should be proportional to content complexity
+        type(figure_t) :: fig
+        real(wp) :: simple_x(3), simple_y(3), complex_x(50), complex_y(50)
+        character(len=200) :: simple_file, complex_file
+        integer :: simple_size, complex_size, i
+        logical :: size_proportional, remove_success
+        
+        print *, "=== Testing PNG size validation ==="
+        
+        simple_file = "output/test/test_png_simple.png"
+        complex_file = "output/test/test_png_complex.png"
+        
+        ! Simple plot
+        simple_x = [1.0_wp, 2.0_wp, 3.0_wp]
+        simple_y = [1.0_wp, 2.0_wp, 1.5_wp]
+        
+        call fig%initialize(400, 300)
+        call fig%add_plot(simple_x, simple_y)
+        call fig%savefig(simple_file)
+        
+        ! Complex plot
+        do i = 1, 50
+            complex_x(i) = real(i - 1, wp) * 0.1_wp
+            complex_y(i) = sin(complex_x(i) * 3.0_wp) * cos(complex_x(i) * 2.0_wp)
+        end do
+        
+        call fig%initialize(800, 600)
+        call fig%add_scatter(complex_x, complex_y)
+        call fig%set_title("Complex Plot with Many Points")
+        call fig%set_xlabel("Complex X Data")
+        call fig%set_ylabel("Complex Y Data")
+        call fig%legend()
+        call fig%savefig(complex_file)
+        
+        inquire(file=simple_file, size=simple_size)
+        inquire(file=complex_file, size=complex_size)
+        
+        print *, "Simple PNG size: ", simple_size, " bytes"
+        print *, "Complex PNG size: ", complex_size, " bytes"
+        
+        ! Complex plot should generally be larger (but not always guaranteed)
+        size_proportional = simple_size > 0 .and. complex_size > 0
+        
+        if (.not. size_proportional) then
+            print *, "*** FAILURE: PNG files have invalid sizes ***"
+        else
+            print *, "PASS: PNG size validation successful"
+        end if
+        
+        call safe_remove_file(simple_file, remove_success)
+        call safe_remove_file(complex_file, remove_success)
+    end subroutine test_png_size_validation
+    
+    subroutine test_png_pixel_diversity()
+        !! Given: PNG files should contain actual pixel data, not just solid colors
+        !! When: We create plots with varied visual content
+        !! Then: Files should contain diverse pixel information
+        type(figure_t) :: fig
+        real(wp) :: x_data(20), y_data(20)
+        character(len=200) :: test_file
+        character(len=2048) :: file_buffer
+        integer :: file_unit, ios, i, diversity_score
+        logical :: has_pixel_diversity, remove_success
+        
+        print *, "=== Testing PNG pixel diversity ==="
+        
+        test_file = "output/test/test_png_diversity.png"
+        
+        ! Create plot with varied visual content
+        do i = 1, 20
+            x_data(i) = real(i - 1, wp) * 0.3_wp
+            y_data(i) = sin(x_data(i)) + 0.5_wp * cos(x_data(i) * 3.0_wp)
+        end do
+        
+        call fig%initialize(600, 400)
+        call fig%add_plot(x_data, y_data)
+        call fig%set_title("Pixel Diversity Test Plot")
+        call fig%savefig(test_file)
+        
+        ! Read file content to analyze pixel diversity
+        open(newunit=file_unit, file=test_file, access='stream', form='unformatted', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open PNG file for diversity analysis"
+            return
+        end if
+        
+        read(file_unit, iostat=ios) file_buffer
+        close(file_unit)
+        
+        if (ios /= 0) then
+            print *, "ERROR: Could not read PNG file for diversity analysis"
+            return
+        end if
+        
+        ! Simple diversity check - count unique byte values
+        diversity_score = calculate_byte_diversity(file_buffer)
+        has_pixel_diversity = diversity_score > 10  ! Should have at least 10 different byte values
+        
+        print *, "Byte diversity score: ", diversity_score
+        print *, "Has sufficient pixel diversity: ", has_pixel_diversity
+        
+        if (.not. has_pixel_diversity) then
+            print *, "*** WARNING: PNG file may lack visual diversity ***"
+        else
+            print *, "PASS: PNG pixel diversity validation successful"
+        end if
+        
+        call safe_remove_file(test_file, remove_success)
+    end subroutine test_png_pixel_diversity
+    
+    function calculate_byte_diversity(buffer) result(diversity)
+        character(len=*), intent(in) :: buffer
+        integer :: diversity
+        logical :: byte_seen(0:255)
+        integer :: i, byte_val
+        
+        byte_seen = .false.
+        diversity = 0
+        
+        do i = 1, len(buffer)
+            byte_val = iachar(buffer(i:i))
+            if (.not. byte_seen(byte_val)) then
+                byte_seen(byte_val) = .true.
+                diversity = diversity + 1
+            end if
+        end do
+    end function calculate_byte_diversity
+
+end program test_png_content_validation


### PR DESCRIPTION
## Summary
- Added comprehensive PDF content regression tests that detect Issue #97: PDF files contain PNG output instead of PDF content
- Added complementary PNG validation tests to verify testing methodology
- Tests demonstrate critical format regression affecting all PDF output

## Test Coverage Added
- PDF header validation (detects PNG headers in PDF files)  
- PDF structure integrity (objects, xref table, trailer)
- PDF vs PNG content differentiation
- Multiple plot type scenarios (scatter, line, contour)
- PNG format validation as control group

## Test Results (RED Phase)
All PDF tests FAIL as expected, demonstrating:
- PDF files have PNG headers (`�PNG`) instead of PDF headers (`%PDF-`)
- PDF files contain PNG signature bytes
- PDF files lack essential PDF structure elements
- Issue affects all plot types consistently

PNG tests PASS, confirming:
- PNG format works correctly
- Test methodology is sound
- Issue is specifically PDF backend regression

🤖 Generated with [Claude Code](https://claude.ai/code)