### PR TITLE
fix: prevent CI workflow from overwriting FORD-generated HTML files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,9 +81,8 @@ jobs:
           # Run make doc (which runs FORD then copies media)
           make doc
           
-          # Copy example documentation pages to build directory
-          mkdir -p build/doc/page/example
-          cp -r doc/example/*.md build/doc/page/example/ 2>/dev/null || true
+          # FORD already generated HTML files from doc/example/*.md
+          # No need to copy markdown files - they overwrite the generated HTML
         
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Problem

GitHub Pages was showing 404 errors for example HTML documentation pages like:
- https://lazy-fortran.github.io/fortplot/page/example/basic_plots.html  
- https://lazy-fortran.github.io/fortplot/page/example/annotation_demo.html

## Root Cause Analysis

The GitHub Actions workflow in `.github/workflows/docs.yml` was:

1. Running `make doc` which calls `ford README.md` to generate HTML files from `doc/example/*.md` 
2. Then copying the original `doc/example/*.md` files to `build/doc/page/example/` 
3. This overwrote the generated `basic_plots.html` with `basic_plots.md`

FORD correctly processes markdown files and generates HTML, but the workflow was destroying the output.

## Solution

Remove the problematic copy step that overwrites FORD-generated HTML files:

```yaml
# REMOVED: Copy example documentation pages to build directory  
# mkdir -p build/doc/page/example
# cp -r doc/example/*.md build/doc/page/example/ 2>/dev/null || true
```

## Verification

Local testing confirms:
- `make doc` generates `build/doc/page/example/basic_plots.html` 
- FORD processes all example markdown files correctly
- HTML files contain proper documentation content

This fix will resolve the GitHub Pages 404 errors.