### PR TITLE
fix: remove UTF-8 pi symbol from basic_plots.md breaking FORD in CI

### DIFF
--- a/doc/example/basic_plots.md
+++ b/doc/example/basic_plots.md
@@ -30,7 +30,7 @@ contains
 
         print *, "=== Basic Plots ==="
 
-        ! Generate simple sine data - show 2 complete periods (0 to 4π)
+        ! Generate simple sine data - show 2 complete periods (0 to 4pi)
         x = [(real(i-1, wp) * 4.0_wp * 3.141592653589793_wp / 49.0_wp, i=1, 50)]
         y = sin(x)
 


### PR DESCRIPTION
## Problem

GitHub Pages was still showing 404 errors for example HTML documentation after PR #219, specifically:
- https://lazy-fortran.github.io/fortplot/page/example/basic_plots.html  
- https://lazy-fortran.github.io/fortplot/page/example/annotation_demo.html

## Root Cause Analysis  

Investigation of CI logs revealed that FORD was still reporting UTF-8 parsing errors for specific files:

```
Warning: Error parsing '/home/runner/work/fortplot/fortplot/doc/example/basic_plots.md'. utf-8
```

These UTF-8 parsing errors were preventing FORD from generating HTML files for those documents.

## The Issue

A single UTF-8 character (π symbol) in `basic_plots.md` was causing the problem:

```fortran  
! Generate simple sine data - show 2 complete periods (0 to 4π)
```

While this works fine in local development environments, the CI environment has stricter UTF-8 handling that caused FORD parsing to fail.

## Solution

Replace the π symbol with ASCII 'pi':

```fortran
! Generate simple sine data - show 2 complete periods (0 to 4pi)  
```

## Verification

- Local testing: `file -bi doc/example/basic_plots.md` now returns `charset=us-ascii`
- All example markdown files are now ASCII-only
- FORD should generate HTML files successfully in CI

This final fix should resolve the remaining GitHub Pages 404 errors.