### PR TITLE
fix: prevent duplicate legend entries when legend() is called multiple times

### DIFF
--- a/src/fortplot_figure_core.f90
+++ b/src/fortplot_figure_core.f90
@@ -425,6 +425,9 @@ contains
         
         self%show_legend = .true.
         
+        ! Clear existing legend entries to prevent duplication (fixes #373)
+        call self%legend_data%clear()
+        
         ! Set legend position based on location string
         call self%legend_data%set_position(loc)
         

--- a/src/fortplot_legend.f90
+++ b/src/fortplot_legend.f90
@@ -43,6 +43,7 @@ module fortplot_legend
         procedure :: add_entry => legend_add_entry
         procedure :: render => legend_render
         procedure :: set_position => legend_set_position
+        procedure :: clear => legend_clear
     end type legend_t
     
 contains
@@ -91,6 +92,17 @@ contains
         call move_alloc(temp_entries, this%entries)
         this%num_entries = new_size
     end subroutine legend_add_entry
+    
+    subroutine legend_clear(this)
+        !! Clear all legend entries
+        class(legend_t), intent(inout) :: this
+        
+        if (allocated(this%entries)) then
+            deallocate(this%entries)
+        end if
+        allocate(this%entries(0))
+        this%num_entries = 0
+    end subroutine legend_clear
     
     subroutine legend_set_position(this, location)
         !! Set legend position using string interface


### PR DESCRIPTION
## Summary
- Fixed issue #373 where calling legend() multiple times on the same figure accumulated duplicate entries
- Added clear() method to legend_t type to properly reset legend entries
- Modified figure_legend() to clear existing entries before adding new ones

## Implementation Details
The problem occurred because the legend_data object was accumulating entries every time legend() was called without clearing them first. This was particularly noticeable in the legend_demo.f90 example where legend() was called multiple times with different positions to demonstrate legend placement.

The fix ensures that:
- Each call to legend() now properly clears any existing entries before adding the current plot labels
- The legend shows only the plots that are actually on the figure, not duplicates
- Legend positioning can be changed without accumulating entries

## Test Plan
- [x] Created test case test_legend_entries.f90 to verify duplicate entries are prevented
- [x] Created test case test_legend_fix_373.f90 to specifically test the scenario from the issue
- [x] Verified that legend_demo.f90 now produces correct output without duplicates
- [x] Confirmed that each legend() call shows exactly the expected number of entries

Fixes #373