### PR TITLE
fix: implement proper ZLIB compression to resolve PNG bloat

### DIFF
--- a/src/external/fortplot_zlib_core.f90
+++ b/src/external/fortplot_zlib_core.f90
@@ -121,9 +121,9 @@ contains
         output_data(pos+1) = int(z'9C', int8)
         pos = pos + 2
         
-        ! Generate simple uncompressed DEFLATE blocks
+        ! Generate compressed DEFLATE blocks using Huffman coding
         compressed_len = 1
-        call compress_with_uncompressed_blocks(input_data, input_len, compressed_data, compressed_len)
+        call compress_with_fixed_huffman(input_data, input_len, compressed_data, compressed_len)
         
         ! Bounds check before copying compressed data
         if (compressed_len > size(compressed_data)) then


### PR DESCRIPTION
## Summary
- Implement proper Huffman compression to fix 100x PNG file bloat
- Replace uncompressed DEFLATE blocks with efficient compression algorithm
- Restore normal PNG file sizes from 1.4MB to expected ~24KB range

## Technical Verification Evidence
**BEFORE FIX:**
- Simple plot: 1,440,774 bytes (1.4MB)
- Complex plot: 5,761,704 bytes (5.7MB)

**AFTER FIX:**
- Simple plot: 23,936 bytes (~24KB) - **60x smaller!**
- Complex plot: 927,928 bytes (~928KB) - **6x smaller!**

**Local Test Results:**
```
PNG File Size Scaling Test Results:
======================================
Empty plot size:         7265
Simple plot size:       23936
Complex plot size:     927928
PASS: PNG file sizes scale appropriately with content
```

**Full Test Suite:** All 107 tests pass with no regressions
**Build Status:** Clean compilation with zero errors
**Performance Impact:** Dramatic file size reduction with proper compression

## Implementation Details
- Modified `zlib_compress()` in `fortplot_zlib_core.f90`
- Changed from `compress_with_uncompressed_blocks()` to `compress_with_fixed_huffman()`
- Utilizes existing, well-tested Huffman compression implementation
- Maintains full ZLIB format compliance with proper headers and checksums

Fixes #963