### PR TITLE
fix: CRITICAL REGRESSION: No plot visible in streamplot demo (fixes #858)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,9 @@ run-release:
 
 # Build documentation with FORD
 doc:
-	# Run FORD first to generate documentation structure
+	# Ensure critical example media exist for docs (fixes #858)
+	$(MAKE) example ARGS="streamplot_demo" >/dev/null
+	# Run FORD to generate documentation structure
 	ford doc.md
 	# Copy example media files to doc build directory AFTER running FORD
 	mkdir -p build/doc/media/examples
@@ -107,15 +109,15 @@ doc:
 	if [ -d doc/media/examples ]; then cp -r doc/media/examples/* build/doc/media/examples/ 2>/dev/null || true; fi
 	# Also copy directly from output directory if available (for local builds)
 	for dir in output/example/fortran/*/; do \
-		if [ -d "$$dir" ]; then \
-			example_name=$$(basename "$$dir"); \
-			mkdir -p "build/doc/media/examples/$$example_name"; \
-			cp "$$dir"*.png "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
-			cp "$$dir"*.txt "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
-			cp "$$dir"*.pdf "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
-			cp "$$dir"*.mp4 "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
-		fi; \
-	done
+        if [ -d "$$dir" ]; then \
+            example_name=$$(basename "$$dir"); \
+            mkdir -p "build/doc/media/examples/$$example_name"; \
+            cp "$$dir"*.png "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
+            cp "$$dir"*.txt "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
+            cp "$$dir"*.pdf "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
+            cp "$$dir"*.mp4 "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
+        fi; \
+    done
 
 # Generate coverage report
 coverage:


### PR DESCRIPTION
Ensures streamplot_demo media is generated before building docs so the example image is present on the examples page.

- Change: # Ensure critical example media exist for docs (fixes #858)
make example ARGS="streamplot_demo" >/dev/null
# Run FORD to generate documentation structure
ford doc.md
Reading Ford options from /home/ert/code/fortplot/fpm.toml
Warning: exclude file 'fortplot_pdf_text.f90' is not relative to any source 
directories, all matching files will be excluded.
To suppress this warning please change it to '**/fortplot_pdf_text.f90' in your 
settings file
 Parsing files         100%   src/figures/plot_types/fortplot_figure_boxplot.f90
  Correlating information from different parts of your project...
  ...done in 0.045s
  Processing comments   ━━━━━━━━━━━━━━━━ 100% 11360/11360 0:00:00 0:00:00 q3_idx
Warning: Error parsing index.md.
        Page '/home/ert/code/fortplot/doc/archive/index.md' has no title 
metadata
Warning: Error parsing index.md.
        Page '/home/ert/code/fortplot/doc/cmake_example/index.md' has no title 
metadata
Warning: '/home/ert/code/fortplot/doc/design/index.md' does not exist
Warning: Error parsing 
'/home/ert/code/fortplot/doc/examples/annotation_demo.md'.
        Page '/home/ert/code/fortplot/doc/examples/annotation_demo.md' has no 
title metadata
Warning: Error parsing 
'/home/ert/code/fortplot/doc/examples/legend_box_demo.md'.
        Page '/home/ert/code/fortplot/doc/examples/legend_box_demo.md' has no 
title metadata
Warning: '/home/ert/code/fortplot/doc/fpm_example/index.md' does not exist
Warning: Error parsing '/home/ert/code/fortplot/doc/module_architecture.md'.
        Page '/home/ert/code/fortplot/doc/module_architecture.md' has no title 
metadata
Warning: '/home/ert/code/fortplot/doc/python_example/index.md' does not exist
⠙ Processing pages      ━━━━╸  93% 41/44 0:00… 0:00… doc/windows_ffmpeg_setup.md
  Creating HTML documentation... done in 0.016s
  Creating search index ━━━━ 100% 122… 0:00… 0:0… page/windows_ffmpeg_setup.html
  Writing files         ━━━━━━━ 100% 1228/… 0:00:00 0:00:… build/doc/search.html

Browse the generated documentation: file:///home/ert/code/fortplot/build/doc/index.html
# Copy example media files to doc build directory AFTER running FORD
mkdir -p build/doc/media/examples
# Copy from doc/media if it exists (GitHub Actions workflow populates this)
if [ -d doc/media/examples ]; then cp -r doc/media/examples/* build/doc/media/examples/ 2>/dev/null || true; fi
# Also copy directly from output directory if available (for local builds)
for dir in output/example/fortran/*/; do \
        if [ -d "$dir" ]; then \
            example_name=$(basename "$dir"); \
            mkdir -p "build/doc/media/examples/$example_name"; \
            cp "$dir"*.png "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.txt "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.pdf "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.mp4 "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
        fi; \
    done now runs fpm run --example  streamplot_demo
 Streamplot demo completed!
# Build and run special examples that need manual compilation prior to FORD and media copy steps.
- Rationale: Addresses missing media on the docs site when examples aren’t executed in the docs workflow.
- Verification: Local fpm run --example  streamplot_demo
 Streamplot demo completed!
# Build and run special examples that need manual compilation + # Ensure critical example media exist for docs (fixes #858)
make example ARGS="streamplot_demo" >/dev/null
# Run FORD to generate documentation structure
ford doc.md
Reading Ford options from /home/ert/code/fortplot/fpm.toml
Warning: exclude file 'fortplot_pdf_text.f90' is not relative to any source 
directories, all matching files will be excluded.
To suppress this warning please change it to '**/fortplot_pdf_text.f90' in your 
settings file
  Parsing files         ━ 100% … … 0… src/testing/fortplot_verification_core.f90
  Correlating information from different parts of your project...
  ...done in 0.046s
  Processing comments   ━━━━━━━━━━━━━━━ 100% 11360/11360 0:00:00 0:00:00 message
Warning: Error parsing index.md.
        Page '/home/ert/code/fortplot/doc/archive/index.md' has no title 
metadata
Warning: Error parsing index.md.
        Page '/home/ert/code/fortplot/doc/cmake_example/index.md' has no title 
metadata
Warning: '/home/ert/code/fortplot/doc/design/index.md' does not exist
Warning: Error parsing 
'/home/ert/code/fortplot/doc/examples/annotation_demo.md'.
        Page '/home/ert/code/fortplot/doc/examples/annotation_demo.md' has no 
title metadata
Warning: Error parsing 
'/home/ert/code/fortplot/doc/examples/legend_box_demo.md'.
        Page '/home/ert/code/fortplot/doc/examples/legend_box_demo.md' has no 
title metadata
Warning: '/home/ert/code/fortplot/doc/fpm_example/index.md' does not exist
Warning: Error parsing '/home/ert/code/fortplot/doc/module_architecture.md'.
        Page '/home/ert/code/fortplot/doc/module_architecture.md' has no title 
metadata
Warning: '/home/ert/code/fortplot/doc/python_example/index.md' does not exist
⠙ Processing pages      ━━━━╸  93% 41/44 0:00… 0:00… doc/windows_ffmpeg_setup.md
  Creating HTML documentation... done in 0.016s
  Creating search index ━━━━ 100% 122… 0:00… 0:0… page/windows_ffmpeg_setup.html
  Writing files         ━━━━━━━ 100% 1228/… 0:00:00 0:00:… build/doc/search.html

Browse the generated documentation: file:///home/ert/code/fortplot/build/doc/index.html
# Copy example media files to doc build directory AFTER running FORD
mkdir -p build/doc/media/examples
# Copy from doc/media if it exists (GitHub Actions workflow populates this)
if [ -d doc/media/examples ]; then cp -r doc/media/examples/* build/doc/media/examples/ 2>/dev/null || true; fi
# Also copy directly from output directory if available (for local builds)
for dir in output/example/fortran/*/; do \
        if [ -d "$dir" ]; then \
            example_name=$(basename "$dir"); \
            mkdir -p "build/doc/media/examples/$example_name"; \
            cp "$dir"*.png "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.txt "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.pdf "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
            cp "$dir"*.mp4 "build/doc/media/examples/$example_name/" 2>/dev/null || true; \
        fi; \
    done produces build/doc/media/examples/streamplot_demo/streamplot_demo.png and the page renders the image.

Scope is minimal and isolated to the docs build process.