### PR TITLE
fix: First colored contour plot example empty plot (fixes #1084)

### DIFF
--- a/src/plotting/fortplot_plot_contours.f90
+++ b/src/plotting/fortplot_plot_contours.f90
@@ -11,6 +11,7 @@ module fortplot_plot_contours
     use fortplot_figure_core, only: figure_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH
+    use fortplot_figure_plot_management, only: generate_default_contour_levels
     use fortplot_errors, only: fortplot_error_t, SUCCESS, ERROR_RESOURCE_LIMIT
     implicit none
     
@@ -88,6 +89,8 @@ contains
         if (present(levels)) then
             allocate(self%plots(plot_idx)%contour_levels(size(levels)))
             self%plots(plot_idx)%contour_levels = levels
+        else
+            call generate_default_contour_levels(self%plots(plot_idx))
         end if
         
         if (present(label) .and. len_trim(label) > 0) then
@@ -129,6 +132,8 @@ contains
         if (present(levels)) then
             allocate(self%plots(plot_idx)%contour_levels(size(levels)))
             self%plots(plot_idx)%contour_levels = levels
+        else
+            call generate_default_contour_levels(self%plots(plot_idx))
         end if
         
         ! Color properties

--- a/test/test_contour_default_levels_rendering.f90
+++ b/test/test_contour_default_levels_rendering.f90
@@ -1,0 +1,64 @@
+program test_contour_default_levels_rendering
+    !! Verify filled contours render with default levels (no levels provided)
+    use iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_validation, only: validation_result_t, validate_file_exists, validate_file_size
+    implicit none
+
+    call run_test()
+
+contains
+
+    subroutine run_test()
+        real(wp), dimension(20) :: x_grid, y_grid
+        real(wp), dimension(20,20) :: z_grid
+        integer :: i, j
+        type(validation_result_t) :: val
+        logical :: ok_png, ok_txt
+
+        ! Create a smooth 2D Gaussian surface
+        do i = 1, 20
+            x_grid(i) = -3.0_wp + real(i-1, wp) * 6.0_wp / 19.0_wp
+            y_grid(i) = -3.0_wp + real(i-1, wp) * 6.0_wp / 19.0_wp
+        end do
+
+        do i = 1, 20
+            do j = 1, 20
+                z_grid(i,j) = exp(-(x_grid(i)**2 + y_grid(j)**2))
+            end do
+        end do
+
+        call figure(figsize=[8.0_wp, 6.0_wp])
+        call title("Default contour levels rendering test")
+        call xlabel("x")
+        call ylabel("y")
+
+        ! No levels argument on purpose: should auto-generate sensible defaults
+        call add_contour_filled(x_grid, y_grid, z_grid)
+
+        call savefig('test/output/test_contour_default_levels.png')
+        call savefig('test/output/test_contour_default_levels.txt')
+
+        val = validate_file_exists('test/output/test_contour_default_levels.png')
+        ok_png = val%passed
+        if (ok_png) then
+            ! Size threshold indicates non-empty rendering content
+            val = validate_file_size('test/output/test_contour_default_levels.png', min_size=4000)
+            ok_png = val%passed
+        end if
+
+        val = validate_file_exists('test/output/test_contour_default_levels.txt')
+        ok_txt = val%passed
+
+        if (ok_png .and. ok_txt) then
+            print *, 'PASS: Default contour levels render (PNG+TXT present, PNG sizable)'
+        else
+            print *, 'FAIL: Default contour levels render verification failed'
+            if (.not. ok_png) print *, '  - PNG missing or too small'
+            if (.not. ok_txt) print *, '  - ASCII TXT missing'
+            error stop 1
+        end if
+    end subroutine run_test
+
+end program test_contour_default_levels_rendering
+


### PR DESCRIPTION
Summary
- Generate default contour levels when optional `levels` not provided, fixing empty filled-contour output in examples.

Scope
- src/plotting/fortplot_plot_contours.f90
- test/test_contour_default_levels_rendering.f90

Verification
- Local CI-fast tests pass (`make test-ci`).
- New test ensures PNG+TXT are produced and PNG exceeds a minimal size threshold.

Rationale
- Examples calling `add_contour_filled` without `levels` produced empty plots. Reusing existing `generate_default_contour_levels` ensures sensible defaults and deduplicates logic.
