### PR TITLE
fix(example): use correct figure for animation frames (fixes #1085)

### DIFF
--- a/example/fortran/animation/save_animation_demo.f90
+++ b/example/fortran/animation/save_animation_demo.f90
@@ -5,7 +5,7 @@ program save_animation_demo
 
     integer, parameter :: NFRAMES = 60
     
-    type(figure_t) :: fig
+    type(figure_t), target :: fig
     type(animation_t) :: anim
     real(wp), dimension(100) :: x, y
     integer :: i
@@ -18,13 +18,14 @@ program save_animation_demo
     ! Initial y data
     y = sin(x)
     
-    call figure(figsize=[8.0_wp, 6.0_wp])
-    call add_plot(x, y, label='animated wave')
-    call title('Animation Save Demo')
-    call xlabel('x')
-    call ylabel('y')
-    call xlim(0.0_wp, 2.0_wp * 3.14159_wp)
-    call ylim(-1.5_wp, 1.5_wp)
+    ! Initialize local figure object and add content directly
+    call fig%initialize()
+    call fig%add_plot(x, y, label='animated wave')
+    call fig%set_title('Animation Save Demo')
+    call fig%set_xlabel('x')
+    call fig%set_ylabel('y')
+    call fig%set_xlim(0.0_wp, 2.0_wp * 3.14159_wp)
+    call fig%set_ylim(-1.5_wp, 1.5_wp)
     
     ! Create animation with figure reference
     anim = FuncAnimation(update_wave, frames=NFRAMES, interval=50, fig=fig)
@@ -46,8 +47,8 @@ contains
         ! Update y data with animated wave
         y = sin(x + phase) * cos(phase * 0.5_wp)
         
-        ! Update plot data
-        call set_ydata(y)  ! Note: plot index parameter not supported in pyplot API
+        ! Update plot data on the same figure used by the animation
+        call fig%set_ydata(1, y)
     end subroutine update_wave
     
     subroutine save_animation_with_error_handling(anim, filename, fps)


### PR DESCRIPTION
Summary
- Fix animation example to use the same figure context for plotting and rendering so frames contain the line plot, not just axes.

Scope
- example/fortran/animation/save_animation_demo.f90
  - Initialize a local figure (fig%initialize) and use fig%add_plot/fig%set_* APIs.
  - Pass this fig (with TARGET) into FuncAnimation.
  - Update frames with fig%set_ydata(1, y) instead of pyplot set_ydata.

Verification
- Local run: make example ARGS="save_animation_demo"
  - Before: MP4 ~6.5 KiB (axes only).
  - After: MP4 ~44 KiB with content.
  - ffprobe: 60 frames at 24 fps; file size 45,528 bytes.
- Docs link already fixed in main; CI now asserts presence of build/doc/page/media/examples/animation/animation.mp4.

Rationale
- Root cause: Mixed pyplot global figure for plotting and a separate, uninitialized local fig passed to FuncAnimation → animation rendered from a figure with no plots.
- Fix ensures one consistent figure object is used throughout and frames update the correct plot index.
