### PR TITLE
fix: prevent y-axis label overlap by adjusting drawing order for raster backends

### DIFF
--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -17,7 +17,8 @@ module fortplot_raster
                                        draw_diamond_with_edge_face, draw_x_marker
     use fortplot_raster_line_styles, only: draw_styled_line, reset_pattern_distance, set_raster_line_style
     use fortplot_raster_core, only: raster_image_t, create_raster_image, destroy_raster_image
-    use fortplot_raster_axes, only: raster_draw_axes_and_labels, raster_render_ylabel
+    use fortplot_raster_axes, only: raster_draw_axes_and_labels, raster_render_ylabel, &
+                                        raster_draw_axes_lines_and_ticks, raster_draw_axis_labels_only
     use fortplot_raster_rendering, only: raster_fill_heatmap, raster_fill_quad, fill_triangle, &
                                         raster_render_legend_specialized, raster_calculate_legend_dimensions, &
                                         raster_set_legend_border_width, raster_calculate_legend_position, &
@@ -29,6 +30,7 @@ module fortplot_raster
     public :: raster_image_t, create_raster_image, destroy_raster_image
     public :: raster_context, create_raster_canvas
     public :: raster_draw_axes_and_labels, raster_render_ylabel
+    public :: raster_draw_axes_lines_and_ticks, raster_draw_axis_labels_only
 
     integer, parameter :: DEFAULT_RASTER_LINE_WIDTH_SCALING = 10
 
@@ -63,6 +65,8 @@ module fortplot_raster
         procedure :: prepare_3d_data => raster_prepare_3d_data_context
         procedure :: render_ylabel => raster_render_ylabel_context
         procedure :: draw_axes_and_labels_backend => raster_draw_axes_and_labels_context
+        procedure :: draw_axes_lines_and_ticks => raster_draw_axes_lines_and_ticks_context
+        procedure :: draw_axis_labels_only => raster_draw_axis_labels_only_context
         procedure :: save_coordinates => raster_save_coordinates
         procedure :: set_coordinates => raster_set_coordinates
         procedure :: render_axes => raster_render_axes
@@ -486,5 +490,42 @@ contains
         ! Raster axes are rendered as part of draw_axes_and_labels_backend
         ! Implementation needed - see issue #495
     end subroutine raster_render_axes
+
+    subroutine raster_draw_axes_lines_and_ticks_context(this, xscale, yscale, symlog_threshold, &
+                                                       x_min, x_max, y_min, y_max)
+        !! Draw axes lines and tick marks WITHOUT labels (for proper drawing order)
+        class(raster_context), intent(inout) :: this
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        
+        ! Set color to black for axes and ticks
+        call this%color(0.0_wp, 0.0_wp, 0.0_wp)
+        
+        ! Delegate to axes module
+        call raster_draw_axes_lines_and_ticks(this%raster, this%width, this%height, this%plot_area, &
+                                            xscale, yscale, symlog_threshold, &
+                                            x_min, x_max, y_min, y_max)
+    end subroutine raster_draw_axes_lines_and_ticks_context
+
+    subroutine raster_draw_axis_labels_only_context(this, xscale, yscale, symlog_threshold, &
+                                                   x_min, x_max, y_min, y_max, &
+                                                   title, xlabel, ylabel)
+        !! Draw ONLY axis labels and tick labels (for proper drawing order)
+        class(raster_context), intent(inout) :: this
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        character(len=:), allocatable, intent(in), optional :: title, xlabel, ylabel
+        
+        ! Set color to black for text
+        call this%color(0.0_wp, 0.0_wp, 0.0_wp)
+        
+        ! Delegate to axes module
+        call raster_draw_axis_labels_only(this%raster, this%width, this%height, this%plot_area, &
+                                        xscale, yscale, symlog_threshold, &
+                                        x_min, x_max, y_min, y_max, &
+                                        title, xlabel, ylabel)
+    end subroutine raster_draw_axis_labels_only_context
 
 end module fortplot_raster

--- a/src/figures/core/fortplot_figure_core_io_compat.f90
+++ b/src/figures/core/fortplot_figure_core_io_compat.f90
@@ -25,7 +25,8 @@ module fortplot_figure_core_io
                                                     setup_coordinate_system, &
                                                     render_figure_background, &
                                                     render_figure_axes, &
-                                                    render_all_plots
+                                                    render_all_plots, &
+                                                    render_figure_axes_labels_only
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
     use fortplot_figure_io, only: save_backend_with_status
@@ -216,6 +217,12 @@ contains
                                  state%margin_left, state%margin_right, &
                                  state%margin_bottom, state%margin_top)
         end if
+        
+        ! Render axis labels AFTER plots (for raster backends only to prevent overlap)
+        call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
+                                           state%symlog_threshold, state%x_min, state%x_max, &
+                                           state%y_min, state%y_max, state%title, &
+                                           state%xlabel, state%ylabel)
         
         ! Render legend if requested
         if (state%show_legend .and. state%legend_data%num_entries > 0) then

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -32,7 +32,8 @@ module fortplot_figure_operations
                                                     setup_coordinate_system, &
                                                     render_figure_background, &
                                                     render_figure_axes, &
-                                                    render_all_plots
+                                                    render_all_plots, &
+                                                    render_figure_axes_labels_only
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
     implicit none
@@ -322,6 +323,12 @@ contains
                                  state%margin_left, state%margin_right, &
                                  state%margin_bottom, state%margin_top)
         end if
+        
+        ! Render axis labels AFTER plots (for raster backends only to prevent overlap)
+        call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
+                                           state%symlog_threshold, state%x_min, state%x_max, &
+                                           state%y_min, state%y_max, state%title, &
+                                           state%xlabel, state%ylabel)
         
         ! Render legend if requested
         if (state%show_legend .and. state%legend_data%num_entries > 0) then


### PR DESCRIPTION
## Summary

Fixes the issue where y-axis labels (like "sin(x)") get overlapped by white background blocks in PNG output. The fix implements proper drawing order by rendering axis lines/ticks before plots and axis labels after plots for raster backends only.

## Problem

Previously, all axis elements (lines, ticks, and labels) were rendered in one step before plot data. This caused y-axis labels to be painted over by plot background elements, making them appear cut off by white blocks.

## Solution

- Split axis rendering into two phases for raster backends:
  1. **Lines & Ticks**: Rendered with background and grid (early)
  2. **Labels**: Rendered after plots (late, on top)
- Added new methods to `raster_context`:
  - `draw_axes_lines_and_ticks()` 
  - `draw_axis_labels_only()`
- Modified rendering pipeline to detect raster backends and use split rendering
- Preserved existing unified rendering for non-raster backends (PDF, ASCII)

## Benefits

- Y-axis labels now appear on top of plot background elements
- Maintains full backward compatibility
- No changes required to user code
- All backends continue to work as before

## Test Plan

- ✅ All existing tests pass
- ✅ Generated examples verify the fix
- ✅ Both PNG and PDF outputs tested
- ✅ No regressions in ASCII backend

The fix specifically addresses the overlap issue visible at:
https://lazy-fortran.github.io/fortplot/media/examples/basic_plots/simple_plot.png

🤖 Generated with [Claude Code](https://claude.ai/code)