### PR TITLE
fix: Add BT/ET blocks for mathtext rendering in PDF

### DIFF
--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -585,14 +585,20 @@ contains
         fs = PDF_LABEL_SIZE
         if (present(font_size)) fs = font_size
         
-        ! Initialize position - directly render without BT/ET for inline use
+        ! Initialize position
         current_x = x
         baseline_y = y
         
-        ! Render each element inline (for use within existing text objects like legends)
+        ! Start text block for mathtext rendering
+        this%stream_data = this%stream_data // "BT" // new_line('a')
+        
+        ! Render each element 
         do i = 1, size(elements)
             call render_mathtext_element_pdf_inline(this, elements(i), current_x, baseline_y, fs)
         end do
+        
+        ! End text block
+        this%stream_data = this%stream_data // "ET" // new_line('a')
         
         deallocate(elements)
     end subroutine draw_pdf_mathtext


### PR DESCRIPTION
## Summary
- Fixed missing BT/ET text blocks around mathtext rendering
- Superscripts and subscripts now render correctly in both titles and legends

## Root Cause
The `render_mathtext_element_pdf_inline` function was outputting PDF text positioning commands (Tm) and text output commands (Tj) without wrapping them in BT/ET text blocks. PDF requires all text commands to be inside BT...ET blocks.

## Solution
Added BT/ET wrapping around the mathtext element rendering loop in `draw_pdf_mathtext`.

## Test plan
- [x] Run `fpm test` - all tests pass
- [x] Test `test_superscript_debug.f90` - superscripts appear above baseline, subscripts below
- [x] Run `fpm run --example unicode_demo` - proper rendering of mathematical notation
- [x] Verified both titles and legends render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)