### PR TITLE
fix: bug: directory utilities truncate long paths (fixes #1391)

### DIFF
--- a/src/system/fortplot_file_operations.f90
+++ b/src/system/fortplot_file_operations.f90
@@ -34,11 +34,11 @@ contains
         logical, intent(out) :: success
         logical :: debug_enabled
         logical :: is_allowed_path
-        character(len=512) :: normalized_path
+        character(len=:), allocatable :: normalized_path
         
         success = .false.
         debug_enabled = is_debug_enabled()
-        normalized_path = path
+        normalized_path = trim(path)
         
         ! SECURITY LAYER 1: Basic path safety validation
         if (.not. is_basic_safe_path(normalized_path)) then
@@ -60,7 +60,7 @@ contains
         end if
         
         ! Try recursive directory creation approach
-        call create_directory_recursive(path, success)
+        call create_directory_recursive(trim(normalized_path), success)
         
         if (.not. success .and. debug_enabled) then
             call log_warning('Directory creation failed (check permissions and parent existence)')
@@ -105,7 +105,8 @@ contains
         character(len=*), intent(in) :: path
         logical, intent(out) :: success
         logical :: dir_exists, parent_exists
-        character(len=512) :: parent_path, test_file
+        character(len=:), allocatable :: parent_path
+        character(len=:), allocatable :: test_file
         integer :: i, last_sep, unit, iostat
         
         success = .false.
@@ -128,7 +129,7 @@ contains
         
         if (last_sep > 0) then
             parent_path = path(1:last_sep)
-            call check_directory_exists(parent_path, parent_exists)
+            call check_directory_exists(trim(parent_path), parent_exists)
             if (.not. parent_exists) then
                 ! Parent doesn't exist, can't create subdirectory
                 success = .false.
@@ -146,7 +147,7 @@ contains
             if (is_windows()) then
                 test_file = trim(test_file) // "\test_dir_creation.tmp"
             else
-                test_file = trim(test_file) // "/test_dir_creation.tmp"
+                test_file = trim(test_file) // '/test_dir_creation.tmp'
             end if
             
             ! Try to open a file to test if we can create in this directory
@@ -166,7 +167,7 @@ contains
         use, intrinsic :: iso_c_binding, only: c_null_char, c_char
         character(len=*), intent(in) :: path
         logical, intent(out) :: success
-        character(len=512) :: parent_path
+        character(len=:), allocatable :: parent_path
         integer :: i, last_sep
         logical :: parent_exists, dir_exists
         
@@ -192,9 +193,9 @@ contains
             parent_path = path(1:last_sep)
             
             ! Recursively create parent
-            call check_directory_exists(parent_path, parent_exists)
+            call check_directory_exists(trim(parent_path), parent_exists)
             if (.not. parent_exists) then
-                call create_directory_recursive(parent_path, parent_exists)
+                call create_directory_recursive(trim(parent_path), parent_exists)
                 if (.not. parent_exists) then
                     success = .false.
                     return
@@ -216,7 +217,7 @@ contains
             path_c(n+1) = c_null_char
             success = (create_directory_windows_c(path_c) == 1)
         end block
-        
+
         ! Final check
         call check_directory_exists(path, success)
     end subroutine create_directory_recursive
@@ -226,7 +227,7 @@ contains
         !! Issue #903: Intelligent path whitelist for user experience
         character(len=*), intent(in) :: path
         logical, intent(out) :: is_allowed
-        character(len=512) :: normalized_path
+        character(len=:), allocatable :: normalized_path
         
         normalized_path = trim(path)
         is_allowed = .false.
@@ -293,7 +294,7 @@ contains
         !! Issue #903: Support matplotlib-like directory auto-creation
         character(len=*), intent(in) :: path
         logical, intent(out) :: is_allowed
-        character(len=512) :: first_component
+        character(len=:), allocatable :: first_component
         integer :: first_slash
         
         is_allowed = .false.

--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -98,22 +98,24 @@ contains
         !! the runtime file operations with path validation.
         use fortplot_file_operations, only: create_directory_runtime, check_directory_exists
         character(len=*), intent(in) :: filepath
-        character(len=512) :: dir
-        integer :: i
+        character(len=:), allocatable :: dir
+        integer :: i, last_sep
         logical :: success, exists
 
-        dir = ''
+        last_sep = 0
 
         ! Find last path separator (both '/' and '\\' supported)
         do i = len_trim(filepath), 1, -1
             if (filepath(i:i) == '/' .or. filepath(i:i) == '\\') then
-                if (i > 1) dir = filepath(1:i-1)
+                if (i > 1) last_sep = i - 1
                 exit
             end if
         end do
 
         ! If no directory component, nothing to do
-        if (len_trim(dir) == 0) return
+        if (last_sep <= 0) return
+
+        dir = filepath(1:last_sep)
 
         ! If already exists, we're done
         call check_directory_exists(trim(dir), exists)

--- a/test/test_long_path_directory_creation.f90
+++ b/test/test_long_path_directory_creation.f90
@@ -5,45 +5,64 @@ program test_long_path_directory_creation
 
     character(len=:), allocatable :: base_dir
     character(len=:), allocatable :: segment
-    character(len=:), allocatable :: long_dir
+    character(len=:), allocatable :: long_dir_runtime
+    character(len=:), allocatable :: ensure_dir
     character(len=:), allocatable :: file_path
-    integer :: i, num_segments
+    character(len=64) :: suffix_buffer
+    integer :: i, num_segments, clock_count
     logical :: exists, success
 
-    base_dir = 'build/test/output/long_path_dir'
     segment = 'segblock'
     num_segments = 80
 
-    long_dir = base_dir
+    call system_clock(count=clock_count)
+    write(suffix_buffer, '(I0)') clock_count
+    base_dir = 'build/test/output/long_path_dir_' // trim(suffix_buffer)
+
+    long_dir_runtime = base_dir
     do i = 1, num_segments
-        long_dir = trim(long_dir) // '/' // segment
+        long_dir_runtime = trim(long_dir_runtime) // '/' // segment
     end do
-    long_dir = trim(long_dir) // '/final_destination'
+    long_dir_runtime = trim(long_dir_runtime) // '/runtime_destination'
 
-    file_path = trim(long_dir) // '/plot.png'
-
-    if (len_trim(long_dir) <= 512) then
-        print *, 'TEST SETUP ERROR: long_dir length', len_trim(long_dir), 'must exceed 512'
+    if (len_trim(long_dir_runtime) <= 512) then
+        print *, 'TEST SETUP ERROR: long_dir_runtime length', &
+                 len_trim(long_dir_runtime), 'must exceed 512'
         stop 1
     end if
 
-    call create_directory_runtime(trim(long_dir), success)
+    call create_directory_runtime(trim(long_dir_runtime), success)
     if (.not. success) then
         print *, 'FAIL: create_directory_runtime rejected long directory', &
-                 ' of length', len_trim(long_dir)
+                 ' of length', len_trim(long_dir_runtime)
+        stop 1
+    end if
+
+    ensure_dir = trim(long_dir_runtime) // '/ensure_target'
+    file_path = trim(ensure_dir) // '/plot.png'
+
+    if (len_trim(ensure_dir) <= 512) then
+        print *, 'TEST SETUP ERROR: ensure_dir length', &
+                 len_trim(ensure_dir), 'must exceed 512'
+        stop 1
+    end if
+
+    inquire(file=trim(ensure_dir)//'/.', exist=exists)
+    if (exists) then
+        print *, 'TEST SETUP ERROR: ensure_dir unexpectedly exists before test'
         stop 1
     end if
 
     call ensure_directory_exists(file_path)
 
-    inquire(file=trim(long_dir)//'/.' , exist=exists)
+    inquire(file=trim(ensure_dir)//'/.', exist=exists)
     if (.not. exists) then
         print *, 'FAIL: ensure_directory_exists did not create long directory', &
-                 ' of length', len_trim(long_dir)
+                 ' of length', len_trim(ensure_dir)
         stop 1
     else
         print *, 'PASS: ensure_directory_exists created long directory', &
-                 ' of length', len_trim(long_dir)
+                 ' of length', len_trim(ensure_dir)
     end if
 
 end program test_long_path_directory_creation

--- a/test/test_long_path_directory_creation.f90
+++ b/test/test_long_path_directory_creation.f90
@@ -1,0 +1,49 @@
+program test_long_path_directory_creation
+    use fortplot_utils, only: ensure_directory_exists
+    use fortplot_file_operations, only: create_directory_runtime
+    implicit none
+
+    character(len=:), allocatable :: base_dir
+    character(len=:), allocatable :: segment
+    character(len=:), allocatable :: long_dir
+    character(len=:), allocatable :: file_path
+    integer :: i, num_segments
+    logical :: exists, success
+
+    base_dir = 'build/test/output/long_path_dir'
+    segment = 'segblock'
+    num_segments = 80
+
+    long_dir = base_dir
+    do i = 1, num_segments
+        long_dir = trim(long_dir) // '/' // segment
+    end do
+    long_dir = trim(long_dir) // '/final_destination'
+
+    file_path = trim(long_dir) // '/plot.png'
+
+    if (len_trim(long_dir) <= 512) then
+        print *, 'TEST SETUP ERROR: long_dir length', len_trim(long_dir), 'must exceed 512'
+        stop 1
+    end if
+
+    call create_directory_runtime(trim(long_dir), success)
+    if (.not. success) then
+        print *, 'FAIL: create_directory_runtime rejected long directory', &
+                 ' of length', len_trim(long_dir)
+        stop 1
+    end if
+
+    call ensure_directory_exists(file_path)
+
+    inquire(file=trim(long_dir)//'/.' , exist=exists)
+    if (.not. exists) then
+        print *, 'FAIL: ensure_directory_exists did not create long directory', &
+                 ' of length', len_trim(long_dir)
+        stop 1
+    else
+        print *, 'PASS: ensure_directory_exists created long directory', &
+                 ' of length', len_trim(long_dir)
+    end if
+
+end program test_long_path_directory_creation


### PR DESCRIPTION
## Summary
- switch directory helpers to deferred-length strings so long paths are not truncated
- update `ensure_directory_exists` to slice once and reuse the full directory component
- add `test_long_path_directory_creation` to cover directories longer than 512 characters

## Verification
- fpm test --target test_long_path_directory_creation
- make test-ci
