### PR TITLE
feat: expose color argument for add_plot overlays

### DIFF
--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -233,12 +233,13 @@ contains
         deallocate(wx, wy, wz)
     end subroutine add_scatter_3d_wrapper
 
-    subroutine add_plot(x, y, label, linestyle)
+    subroutine add_plot(x, y, label, linestyle, color)
         real(wp), intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
+        real(wp), intent(in), optional :: color(3)
 
         call ensure_fig_init()
-        call fig%add_plot(x, y, label=label, linestyle=linestyle)
+        call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color)
     end subroutine add_plot
 
     subroutine add_errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, &

--- a/test/test_pcolormesh_fast_negative.f90
+++ b/test/test_pcolormesh_fast_negative.f90
@@ -2,18 +2,27 @@ program test_pcolormesh_fast_negative
     !! Fast, minimal pcolormesh test covering negative coords/values
     !! Verifies ASCII output contains negative tick labels (no external tools)
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot, only: figure, pcolormesh, savefig, title
+    use fortplot, only: figure_t, figure, pcolormesh, savefig, title, &
+                        add_plot, ensure_global_figure_initialized, get_global_figure
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PCOLORMESH, &
+                                  PLOT_TYPE_LINE
     implicit none
 
     integer, parameter :: nx = 16, ny = 12
     real(wp) :: x(nx), y(ny)
     real(wp) :: c(nx-1, ny-1)
+    real(wp) :: xline(2), yline(2)
+    real(wp), parameter :: black(3) = [0.0_wp, 0.0_wp, 0.0_wp]
     integer :: i, j
     real(wp) :: xc, yc
     character(len=*), parameter :: out_txt = 'test/output/test_pcolormesh_fast_negative.txt'
     integer :: unit, ios
     character(len=8192) :: buf
     logical :: ok
+    class(*), pointer :: any_fig
+    class(figure_t), pointer :: fig
+    type(plot_data_t), pointer :: plots(:)
+    integer :: n
 
     ! Negative to positive coordinates (small grid for speed)
     do i = 1, nx
@@ -35,6 +44,46 @@ program test_pcolormesh_fast_negative
     call figure()
     call title('fast pcolormesh negative test')
     call pcolormesh(x, y, c, colormap='coolwarm')
+
+    ! Overlay a simple diagonal line in explicit black
+    xline = [x(1), x(nx)]
+    yline = [y(1), y(ny)]
+    call add_plot(xline, yline, color=black)
+
+    ! Introspect global figure state to verify overlay ordering and color
+    call ensure_global_figure_initialized()
+    any_fig => get_global_figure()
+    select type(any_fig)
+    type is (figure_t)
+        fig => any_fig
+    class default
+        print *, 'FAIL: get_global_figure did not return figure_t'
+        stop 1
+    end select
+
+    plots => fig%get_plots()
+    n = fig%get_plot_count()
+
+    if (n < 2) then
+        print *, 'FAIL: expected at least 2 plots, found', n
+        stop 1
+    end if
+
+    if (plots(1)%plot_type /= PLOT_TYPE_PCOLORMESH) then
+        print *, 'FAIL: first plot is not PLOT_TYPE_PCOLORMESH'
+        stop 1
+    end if
+
+    if (plots(2)%plot_type /= PLOT_TYPE_LINE) then
+        print *, 'FAIL: second plot is not PLOT_TYPE_LINE'
+        stop 1
+    end if
+
+    if (any(abs(plots(2)%color - black) > 1.0e-12_wp)) then
+        print *, 'FAIL: add_plot color was not propagated correctly'
+        stop 1
+    end if
+
     call savefig(out_txt)
 
     ! Read ASCII file and verify negative ticks appear


### PR DESCRIPTION
### **User description**
Expose an optional color(3) argument on the matplotlib-style add_plot wrapper so downstream codes can reliably draw black mesh overlays on top of pcolormesh fields using the simple, non-OO API.\n\nTests: \n- fpm test --target test_pcolormesh_fast_negative\n- make test-ci\n- make verify-artifacts


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Expose optional `color` argument to `add_plot` wrapper function

- Enable drawing colored overlays on pcolormesh visualizations

- Add comprehensive test verifying color propagation and plot ordering

- Validate overlay functionality through figure introspection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["add_plot wrapper"] -->|"add color parameter"| B["Enhanced API"]
  B -->|"pass to fig%add_plot"| C["Matplotlib backend"]
  D["Test: pcolormesh + overlay"] -->|"verify color & ordering"| E["Figure introspection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_matplotlib_plot_wrappers.f90</strong><dd><code>Add color parameter to add_plot wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/interfaces/fortplot_matplotlib_plot_wrappers.f90

<ul><li>Added optional <code>color(3)</code> parameter to <code>add_plot</code> subroutine signature<br> <li> Updated subroutine call to pass <code>color</code> argument to underlying <br><code>fig%add_plot</code><br> <li> Maintains backward compatibility with optional parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1423/files#diff-7c5493ac7947d49effe392895f87ec2ac77d0f0f8b4c79399d26f7bd329bbe88">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pcolormesh_fast_negative.f90</strong><dd><code>Add color overlay test with figure introspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_pcolormesh_fast_negative.f90

<ul><li>Added imports for <code>figure_t</code>, <code>add_plot</code>, figure introspection utilities, <br>and plot data types<br> <li> Created black color array and line coordinates for overlay test<br> <li> Added overlay line drawing using <code>add_plot</code> with explicit black color<br> <li> Implemented figure introspection to verify plot count, types, and <br>color propagation<br> <li> Added validation checks for plot ordering (pcolormesh first, line <br>second) and color correctness</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1423/files#diff-437eaf9a32756165c1b36514bfa082dd3a063305910c60aae34202d2a576fa80">+50/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

