### PR TITLE
feat: add stateful colorbar()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ coverage.*
 *.exe
 *.out
 test/test_*
+!test/test_*.f90
 
 # Binary executables (comprehensive patterns)
 fortplot_bridge

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -18,7 +18,7 @@ module fortplot
     !!
     !! = Key Types =
     !! - figure_t: Main plotting canvas for creating and managing plots
-    !! - animation_t: Animation framework for dynamic visualizations  
+    !! - animation_t: Animation framework for dynamic visualizations
     !! - color_t: Advanced color handling with matplotlib syntax support
     !! - validation_result_t: Testing utilities for plot output validation
     !!
@@ -52,48 +52,55 @@ module fortplot
     !! Author: fortplot contributors
 
     use iso_fortran_env, only: wp => real64
-    
+
     ! Core types and constants
     use fortplot_figure_core, only: figure_t
     use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY, &
                                   XLABEL_VERTICAL_OFFSET, YLABEL_HORIZONTAL_OFFSET, &
                                   TICK_MARK_LENGTH, TITLE_VERTICAL_OFFSET
-    
+
     ! Animation functionality
     use fortplot_animation, only: animation_t, FuncAnimation
-    
+
     ! Logging functionality
     use fortplot_logging, only: set_log_level, get_log_level, &
                                 LOG_LEVEL_SILENT, LOG_LEVEL_ERROR, &
                                 LOG_LEVEL_WARNING, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG
-    
+
     ! Validation functionality
-    use fortplot_validation, only: validation_result_t, validate_file_exists, validate_file_size, &
-                                   validate_png_format, validate_pdf_format, validate_ascii_format, &
+    use fortplot_validation, only: validation_result_t, validate_file_exists, &
+                                   validate_file_size, &
+                                   validate_png_format, validate_pdf_format, &
+                                   validate_ascii_format, &
                                    compare_with_baseline
-    
+
     ! Color functionality
     use fortplot_colors, only: color_t, parse_color, parse_color_rgba, is_valid_color, &
                                validate_color_for_backend, clear_color_cache
-    
+
     ! Contour extraction functionality
-    use fortplot_contour_regions, only: contour_region_t, contour_polygon_t, extract_contour_regions
-    
+    use fortplot_contour_regions, only: contour_region_t, contour_polygon_t, &
+                                        extract_contour_regions
+
     ! Annotation functionality with coordinate constants
     use fortplot_annotations, only: COORD_DATA, COORD_FIGURE, COORD_AXIS
-    
+
     ! Matplotlib-compatible API (all pyplot-style functions)
-    use fortplot_matplotlib, only: plot, contour, contour_filled, pcolormesh, streamplot, &
+    use fortplot_matplotlib, only: plot, contour, contour_filled, pcolormesh, &
+                                   streamplot, &
                                    hist, histogram, scatter, errorbar, boxplot, &
                                    bar, barh, text, annotate, &
                                    imshow, pie, polar, step, stem, &
-                                   fill, fill_between, twinx, twiny, &
+                                   fill, fill_between, twinx, twiny, colorbar, &
                                    xlabel, ylabel, title, legend, grid, &
-                                   savefig, savefig_with_status, figure, subplot, subplots, subplots_grid, &
-                                   add_plot, add_contour, add_contour_filled, add_pcolormesh, add_errorbar, &
+                                   savefig, savefig_with_status, figure, subplot, &
+                                   subplots, subplots_grid, &
+                                   add_plot, add_contour, add_contour_filled, &
+                                   add_pcolormesh, add_errorbar, &
                                    add_3d_plot, add_surface, add_scatter, &
                                    set_xscale, set_yscale, xlim, ylim, &
-                                   set_line_width, set_ydata, use_axis, get_active_axis, &
+                                   set_line_width, set_ydata, use_axis, &
+                                   get_active_axis, &
                                    show, show_viewer, &
                                    ensure_global_figure_initialized, get_global_figure
 
@@ -103,143 +110,144 @@ module fortplot
     ! =========================================================================
     ! PUBLIC INTERFACE RE-EXPORTS
     ! =========================================================================
-    
+
     ! Core types and constants
     public :: figure_t, wp
-    
+
     ! Numerical constants
     public :: EPSILON_COMPARE, EPSILON_GEOMETRY, &
               XLABEL_VERTICAL_OFFSET, YLABEL_HORIZONTAL_OFFSET, TICK_MARK_LENGTH, &
               TITLE_VERTICAL_OFFSET
-    
+
     ! Coordinate system constants for annotations
     public :: COORD_DATA, COORD_FIGURE, COORD_AXIS
-    
+
     ! Matplotlib-compatible plotting functions
     public :: plot, contour, contour_filled, pcolormesh, streamplot
     public :: hist, histogram, scatter, errorbar, boxplot
     public :: bar, barh
     public :: imshow, pie, polar, step, stem
     public :: fill, fill_between, twinx, twiny
+    public :: colorbar
     public :: text, annotate
-    
+
     ! Figure management and configuration
     public :: figure, subplot, subplots, subplots_grid
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: savefig, savefig_with_status
-    
+
     ! Extended plotting functions
     public :: add_plot, add_contour, add_contour_filled, add_pcolormesh
     public :: add_errorbar, add_3d_plot, add_surface, add_scatter
-    
+
     ! Display functions
     public :: show, show_viewer
-    
+
     ! Global figure access
     public :: ensure_global_figure_initialized, get_global_figure
-    
+
     ! Animation interface
     public :: animation_t, FuncAnimation
-    
+
     ! Logging interface
     public :: set_log_level, get_log_level
     public :: LOG_LEVEL_SILENT, LOG_LEVEL_ERROR
     public :: LOG_LEVEL_WARNING, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG
-    
+
     ! Validation interface
     public :: validation_result_t
     public :: validate_file_exists, validate_file_size
     public :: validate_png_format, validate_pdf_format, validate_ascii_format
     public :: compare_with_baseline
-    
+
     ! Color interface
     public :: color_t
     public :: parse_color, parse_color_rgba, is_valid_color
     public :: validate_color_for_backend, clear_color_cache
-    
+
     ! Contour region extraction interface
     public :: contour_region_t, contour_polygon_t, extract_contour_regions
 
     ! =========================================================================
     ! STYLE CONSTANTS (matplotlib-compatible)
     ! =========================================================================
-    
+
     ! Line style constants
-    
+
     !! Solid line style for continuous data visualization
     !! Usage: call plot(x, y, linestyle=LINESTYLE_SOLID)
     !! Visual: ————————————————————
     character(len=*), parameter, public :: LINESTYLE_SOLID = '-'
-    
+
     !! Dashed line style for highlighting trends or secondary data
     !! Usage: call plot(x, y, linestyle=LINESTYLE_DASHED)
     !! Visual: ---- ---- ---- ----
     character(len=*), parameter, public :: LINESTYLE_DASHED = '--'
-    
+
     !! Dotted line style for reference lines or uncertainty bounds
     !! Usage: call plot(x, y, linestyle=LINESTYLE_DOTTED)
     !! Visual: ••••••••••••••••••••
     character(len=*), parameter, public :: LINESTYLE_DOTTED = ':'
-    
+
     !! Dash-dot line style for mixed emphasis visualization
     !! Usage: call plot(x, y, linestyle=LINESTYLE_DASHDOT)
     !! Visual: ——•——•——•——•
     character(len=*), parameter, public :: LINESTYLE_DASHDOT = '-.'
-    
+
     !! No line style - displays only markers without connecting lines
     !! Usage: call plot(x, y, linestyle=LINESTYLE_NONE)
     !! Visual: • • • • (markers only)
     character(len=*), parameter, public :: LINESTYLE_NONE = 'None'
 
     ! Marker style constants
-    
+
     !! Circular markers for standard data point visualization
     !! Usage: call scatter(x, y, marker=MARKER_CIRCLE)
     !! Visual: ● (filled circle)
     character(len=*), parameter, public :: MARKER_CIRCLE = 'o'
-    
+
     !! Cross-shaped markers for outliers or special data points
-    !! Usage: call scatter(x, y, marker=MARKER_CROSS)  
+    !! Usage: call scatter(x, y, marker=MARKER_CROSS)
     !! Visual: ✕ (diagonal cross)
     character(len=*), parameter, public :: MARKER_CROSS = 'x'
-    
+
     !! Square markers for categorical or discrete data visualization
     !! Usage: call scatter(x, y, marker=MARKER_SQUARE)
     !! Visual: ■ (filled square)
     character(len=*), parameter, public :: MARKER_SQUARE = 's'
-    
+
     !! Diamond-shaped markers for highlighting key data points
     !! Usage: call scatter(x, y, marker=MARKER_DIAMOND)
     !! Visual: ♦ (filled diamond)
     character(len=*), parameter, public :: MARKER_DIAMOND = 'D'
-    
+
     !! Plus-sign markers for positive values or additive data
     !! Usage: call scatter(x, y, marker=MARKER_PLUS)
     !! Visual: ＋ (orthogonal plus)
     character(len=*), parameter, public :: MARKER_PLUS = '+'
-    
+
     !! Star-shaped markers for exceptional or peak values
     !! Usage: call scatter(x, y, marker=MARKER_STAR)
     !! Visual: ★ (filled star)
     character(len=*), parameter, public :: MARKER_STAR = '*'
-    
+
     !! Upward triangle markers for increasing trends or maxima
     !! Usage: call scatter(x, y, marker=MARKER_TRIANGLE_UP)
     !! Visual: ▲ (filled upward triangle)
     character(len=*), parameter, public :: MARKER_TRIANGLE_UP = '^'
-    
+
     !! Downward triangle markers for decreasing trends or minima
     !! Usage: call scatter(x, y, marker=MARKER_TRIANGLE_DOWN)
     !! Visual: ▼ (filled downward triangle)
     character(len=*), parameter, public :: MARKER_TRIANGLE_DOWN = 'v'
-    
+
     !! Pentagon-shaped markers for specialized scientific data
     !! Usage: call scatter(x, y, marker=MARKER_PENTAGON)
     !! Visual: ⬟ (filled pentagon)
     character(len=*), parameter, public :: MARKER_PENTAGON = 'p'
-    
+
     !! Hexagon-shaped markers for crystallographic or geometric data
     !! Usage: call scatter(x, y, marker=MARKER_HEXAGON)
     !! Visual: ⬢ (filled hexagon)

--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -4,7 +4,7 @@
 
 module fortplot_figure_core_ranges
     !! Figure data range management module
-    !! 
+    !!
     !! This module contains data range calculation methods
     !! extracted from fortplot_figure_core for architectural compliance
     !!
@@ -31,17 +31,17 @@ contains
         type(plot_data_t), intent(in) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         integer, intent(in) :: plot_count
-        
+
         call calculate_figure_data_ranges(plots, plot_count, &
-                                        state%xlim_set, state%ylim_set, &
-                                        state%x_min, state%x_max, &
-                                        state%y_min, state%y_max, &
-                                        state%x_min_transformed, &
-                                        state%x_max_transformed, &
-                                        state%y_min_transformed, &
-                                        state%y_max_transformed, &
-                                        state%xscale, state%yscale, &
-                                        state%symlog_threshold)
+                                          state%xlim_set, state%ylim_set, &
+                                          state%x_min, state%x_max, &
+                                          state%y_min, state%y_max, &
+                                          state%x_min_transformed, &
+                                          state%x_max_transformed, &
+                                          state%y_min_transformed, &
+                                          state%y_max_transformed, &
+                                          state%xscale, state%yscale, &
+                                          state%symlog_threshold)
     end subroutine update_data_ranges_figure
 
     subroutine update_data_ranges_pcolormesh_figure(plots, state, plot_count)
@@ -49,9 +49,9 @@ contains
         type(plot_data_t), intent(in) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         integer, intent(in) :: plot_count
-        
+
         real(wp) :: x_min_new, x_max_new, y_min_new, y_max_new
-        
+
         ! Safety check: ensure pcolormesh arrays are allocated before accessing
         if (.not. allocated(plots(plot_count)%pcolormesh_data%x_vertices) .or. &
             .not. allocated(plots(plot_count)%pcolormesh_data%y_vertices)) then
@@ -59,19 +59,19 @@ contains
             ! Skip data range update to prevent segfault
             return
         end if
-        
+
         ! Additional safety: check arrays have valid size
         if (size(plots(plot_count)%pcolormesh_data%x_vertices) == 0 .or. &
             size(plots(plot_count)%pcolormesh_data%y_vertices) == 0) then
             ! Zero-size arrays - skip data range update
             return
         end if
-        
+
         x_min_new = minval(plots(plot_count)%pcolormesh_data%x_vertices)
         x_max_new = maxval(plots(plot_count)%pcolormesh_data%x_vertices)
         y_min_new = minval(plots(plot_count)%pcolormesh_data%y_vertices)
         y_max_new = maxval(plots(plot_count)%pcolormesh_data%y_vertices)
-        
+
         if (.not. state%xlim_set) then
             if (plot_count == 1) then
                 state%x_min = x_min_new
@@ -81,7 +81,7 @@ contains
                 state%x_max = max(state%x_max, x_max_new)
             end if
         end if
-        
+
         if (.not. state%ylim_set) then
             if (plot_count == 1) then
                 state%y_min = y_min_new
@@ -98,7 +98,7 @@ contains
         real(wp), intent(in) :: data(:)
         real(wp), intent(in), optional :: position
         type(figure_state_t), intent(inout) :: state
-        
+
         ! Delegate to module implementation
         call update_boxplot_ranges(data, position, &
                                    state%x_min, state%x_max, &
@@ -113,13 +113,13 @@ end module fortplot_figure_core_ranges
 
 module fortplot_figure_core_operations
     !! Core operations implementations extracted from fortplot_figure_core
-    !! 
+    !!
     !! This module contains the actual implementations of core figure operations
     !! that were previously inline procedures in the main core module.
-    !! 
+    !!
     !! EXTRACTED OPERATIONS:
     !! - initialize: Figure initialization with backend setup
-    !! - add_plot: Basic line plotting functionality  
+    !! - add_plot: Basic line plotting functionality
     !! - add_contour: Contour plot creation
     !! - add_contour_filled: Filled contour plots
     !! - add_pcolormesh: Pseudocolor mesh plotting
@@ -134,7 +134,8 @@ module fortplot_figure_core_operations
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_figure_operations
     use fortplot_figure_management
-    use fortplot_figure_core_ranges, only: update_data_ranges_figure, update_data_ranges_pcolormesh_figure
+    use fortplot_figure_core_ranges, only: update_data_ranges_figure, &
+                                           update_data_ranges_pcolormesh_figure
     implicit none
 
     private
@@ -145,22 +146,25 @@ module fortplot_figure_core_operations
 
 contains
 
-    subroutine core_initialize(state, plots, streamlines, subplots_array, subplot_rows, &
+    subroutine core_initialize(state, plots, streamlines, subplots_array, &
+                               subplot_rows, &
                                subplot_cols, current_subplot, title, xlabel, ylabel, &
                                plot_count, width, height, backend, dpi)
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(plot_data_t), allocatable, intent(inout) :: streamlines(:)
-        type(subplot_data_t), allocatable, intent(inout) :: subplots_array(:,:)
-        integer, intent(inout) :: subplot_rows, subplot_cols, current_subplot, plot_count
+        type(subplot_data_t), allocatable, intent(inout) :: subplots_array(:, :)
+        integer, intent(inout) :: subplot_rows, subplot_cols, &
+                                  current_subplot, plot_count
         character(len=:), allocatable, intent(inout) :: title, xlabel, ylabel
         integer, intent(in), optional :: width, height
         character(len=*), intent(in), optional :: backend
         real(wp), intent(in), optional :: dpi
 
-        call figure_initialize(state, plots, streamlines, subplots_array, subplot_rows, &
-                              subplot_cols, current_subplot, title, xlabel, ylabel, &
-                              plot_count, width, height, backend, dpi)
+        call figure_initialize(state, plots, streamlines, subplots_array, &
+                               subplot_rows, &
+                               subplot_cols, current_subplot, title, xlabel, ylabel, &
+                               plot_count, width, height, backend, dpi)
     end subroutine core_initialize
 
     subroutine core_add_plot(plots, state, x, y, label, linestyle, color, plot_count)
@@ -170,21 +174,23 @@ contains
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
         integer, intent(inout) :: plot_count
-        
+
         call figure_add_plot_operation(plots, state, x, y, label, linestyle, color)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_plot
 
-    subroutine core_add_contour(plots, state, x_grid, y_grid, z_grid, levels, label, plot_count)
+    subroutine core_add_contour(plots, state, x_grid, y_grid, z_grid, levels, label, &
+                                plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:,:)
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in), optional :: levels(:)
         character(len=*), intent(in), optional :: label
         integer, intent(inout) :: plot_count
-        
-        call figure_add_contour_operation(plots, state, x_grid, y_grid, z_grid, levels, label)
+
+        call figure_add_contour_operation(plots, state, x_grid, y_grid, z_grid, &
+                                          levels, label)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_contour
@@ -193,7 +199,7 @@ contains
                                        colormap, show_colorbar, label, plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:,:)
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in), optional :: levels(:)
         character(len=*), intent(in), optional :: colormap, label
         logical, intent(in), optional :: show_colorbar
@@ -209,7 +215,7 @@ contains
                                 show_colorbar, alpha, edgecolor, linewidth, plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:,:)
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         character(len=*), intent(in), optional :: label, colormap
         logical, intent(in), optional :: show_colorbar
         real(wp), intent(in), optional :: alpha, linewidth
@@ -217,7 +223,8 @@ contains
         integer, intent(inout) :: plot_count
 
         call figure_add_surface_operation(plots, state, x_grid, y_grid, z_grid, label, &
-                                          colormap, show_colorbar, alpha, edgecolor, linewidth)
+                                          colormap, show_colorbar, alpha, &
+                                          edgecolor, linewidth)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_surface
@@ -226,20 +233,21 @@ contains
                                    edgecolors, linewidths, plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
-        real(wp), intent(in) :: x(:), y(:), c(:,:)
+        real(wp), intent(in) :: x(:), y(:), c(:, :)
         character(len=*), intent(in), optional :: colormap
         real(wp), intent(in), optional :: vmin, vmax
         real(wp), intent(in), optional :: edgecolors(3)
         real(wp), intent(in), optional :: linewidths
         integer, intent(inout) :: plot_count
-        
+
         call figure_add_pcolormesh_operation(plots, state, x, y, c, colormap, &
-                                            vmin, vmax, edgecolors, linewidths)
+                                             vmin, vmax, edgecolors, linewidths)
         plot_count = state%plot_count
         call update_data_ranges_pcolormesh_figure(plots, state, state%plot_count)
     end subroutine core_add_pcolormesh
 
-    subroutine core_add_fill_between(plots, state, x, upper, lower, mask, color_string, alpha, &
+    subroutine core_add_fill_between(plots, state, x, upper, lower, mask, &
+                                     color_string, alpha, &
                                      plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
@@ -251,12 +259,14 @@ contains
         real(wp), intent(in), optional :: alpha
         integer, intent(inout) :: plot_count
 
-        call figure_add_fill_between_operation(plots, state, x, upper, lower, mask, color_string, alpha)
+        call figure_add_fill_between_operation(plots, state, x, upper, lower, mask, &
+                                               color_string, alpha)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_fill_between
 
-    subroutine core_add_pie(plots, state, values, labels, autopct, startangle, colors, explode, plot_count)
+    subroutine core_add_pie(plots, state, values, labels, autopct, startangle, colors, &
+                            explode, plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         real(wp), intent(in) :: values(:)
@@ -267,7 +277,8 @@ contains
         real(wp), intent(in), optional :: explode(:)
         integer, intent(inout) :: plot_count
 
-        call figure_add_pie_operation(plots, state, values, labels, startangle, colors, explode, autopct)
+        call figure_add_pie_operation(plots, state, values, labels, startangle, &
+                                      colors, explode, autopct)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_pie
@@ -276,16 +287,17 @@ contains
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         integer, intent(inout) :: plot_count
-        real(wp), intent(in) :: x(:), y(:), u(:,:), v(:,:)
+        real(wp), intent(in) :: x(:), y(:), u(:, :), v(:, :)
         real(wp), intent(in), optional :: density
         real(wp), intent(in), optional :: color(3)
-        
+
         call figure_streamplot_operation(plots, state, plot_count, x, y, u, v, &
                                          density, color)
     end subroutine core_streamplot
 
     subroutine core_savefig(state, plots, plot_count, filename, blocking, &
-                            annotations, annotation_count, subplots_array, subplot_rows, subplot_cols)
+                            annotations, annotation_count, subplots_array, &
+                            subplot_rows, subplot_cols)
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(in) :: plot_count
@@ -293,15 +305,18 @@ contains
         logical, intent(in), optional :: blocking
         type(text_annotation_t), allocatable, intent(inout) :: annotations(:)
         integer, intent(in) :: annotation_count
-        type(subplot_data_t), intent(in), optional :: subplots_array(:,:)
+        type(subplot_data_t), intent(in), optional :: subplots_array(:, :)
         integer, intent(in), optional :: subplot_rows, subplot_cols
-        
+
         call figure_savefig(state, plots, plot_count, filename, blocking, &
-                            annotations, annotation_count, subplots_array, subplot_rows, subplot_cols)
+                            annotations, annotation_count, subplots_array, &
+                            subplot_rows, subplot_cols)
     end subroutine core_savefig
-    
-    subroutine core_savefig_with_status(state, plots, plot_count, filename, status, blocking, &
-                                        annotations, annotation_count, subplots_array, subplot_rows, subplot_cols)
+
+    subroutine core_savefig_with_status(state, plots, plot_count, filename, status, &
+                                        blocking, &
+                                        annotations, annotation_count, subplots_array, &
+                                        subplot_rows, subplot_cols)
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(in) :: plot_count
@@ -310,14 +325,17 @@ contains
         logical, intent(in), optional :: blocking
         type(text_annotation_t), allocatable, intent(inout) :: annotations(:)
         integer, intent(in) :: annotation_count
-        type(subplot_data_t), intent(in), optional :: subplots_array(:,:)
+        type(subplot_data_t), intent(in), optional :: subplots_array(:, :)
         integer, intent(in), optional :: subplot_rows, subplot_cols
-        
-        call figure_savefig_with_status(state, plots, plot_count, filename, status, blocking, &
-                                        annotations, annotation_count, subplots_array, subplot_rows, subplot_cols)
+
+        call figure_savefig_with_status(state, plots, plot_count, filename, status, &
+                                        blocking, &
+                                        annotations, annotation_count, subplots_array, &
+                                        subplot_rows, subplot_cols)
     end subroutine core_savefig_with_status
 
-    subroutine core_show(state, plots, plot_count, blocking, annotations, annotation_count, &
+    subroutine core_show(state, plots, plot_count, blocking, annotations, &
+                         annotation_count, &
                          subplots_array, subplot_rows, subplot_cols)
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
@@ -325,10 +343,11 @@ contains
         logical, intent(in), optional :: blocking
         type(text_annotation_t), allocatable, intent(inout) :: annotations(:)
         integer, intent(in) :: annotation_count
-        type(subplot_data_t), intent(in), optional :: subplots_array(:,:)
+        type(subplot_data_t), intent(in), optional :: subplots_array(:, :)
         integer, intent(in), optional :: subplot_rows, subplot_cols
-        
-        call figure_show(state, plots, plot_count, blocking, annotations, annotation_count, &
+
+        call figure_show(state, plots, plot_count, blocking, annotations, &
+                         annotation_count, &
                          subplots_array, subplot_rows, subplot_cols)
     end subroutine core_show
 
@@ -339,10 +358,10 @@ end module fortplot_figure_core_operations
 
 module fortplot_figure_core_accessors
     !! Property accessor methods extracted from fortplot_figure_core
-    !! 
+    !!
     !! This module contains property accessor methods for the core figure
     !! to maintain architectural compliance with size limits.
-    
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_annotations, only: text_annotation_t
     use fortplot_plot_data, only: plot_data_t, arrow_data_t
@@ -355,8 +374,10 @@ module fortplot_figure_core_accessors
     private
     public :: core_get_width, core_get_height, core_get_rendered, core_set_rendered
     public :: core_get_plot_count, core_get_plots, core_get_x_min, core_get_x_max
-    public :: core_get_y_min, core_get_y_max, core_backend_color, core_backend_associated
-    public :: core_backend_line, core_setup_png_backend_for_animation, core_backend_arrow
+    public :: core_get_y_min, core_get_y_max, core_backend_color, &
+              core_backend_associated
+    public :: core_backend_line, core_setup_png_backend_for_animation, &
+              core_backend_arrow
     public :: core_extract_rgb_data_for_animation, core_extract_png_data_for_animation
 
 contains
@@ -458,11 +479,11 @@ contains
         end if
 
         if (.not. allocated(state%stream_arrows)) then
-            allocate(state%stream_arrows(1))
+            allocate (state%stream_arrows(1))
             new_index = 1
         else
             new_index = size(state%stream_arrows) + 1
-            allocate(tmp(new_index))
+            allocate (tmp(new_index))
             if (new_index > 1) tmp(1:new_index - 1) = state%stream_arrows
             call move_alloc(tmp, state%stream_arrows)
         end if
@@ -484,21 +505,24 @@ contains
     end subroutine core_setup_png_backend_for_animation
 
     subroutine core_extract_rgb_data_for_animation(state, rgb_data, plots, plot_count, &
-                                                   annotations, annotation_count, rendered)
+                                                   annotations, &
+                                                   annotation_count, rendered)
         type(figure_state_t), intent(inout) :: state
-        real(wp), intent(out) :: rgb_data(:,:,:)
+        real(wp), intent(out) :: rgb_data(:, :, :)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(in) :: plot_count, annotation_count
         type(text_annotation_t), allocatable, intent(inout) :: annotations(:)
         logical, intent(in) :: rendered
-        
+
         if (.not. rendered) call figure_render(state, plots, plot_count, &
-            annotations, annotation_count)
+                                               annotations, annotation_count)
         call figure_extract_rgb_data_for_animation(state, rgb_data, rendered)
     end subroutine core_extract_rgb_data_for_animation
 
-    subroutine core_extract_png_data_for_animation(state, png_data, status, plots, plot_count, &
-                                                   annotations, annotation_count, rendered)
+    subroutine core_extract_png_data_for_animation(state, png_data, status, plots, &
+                                                   plot_count, &
+                                                   annotations, &
+                                                   annotation_count, rendered)
         type(figure_state_t), intent(inout) :: state
         integer(1), allocatable, intent(out) :: png_data(:)
         integer, intent(out) :: status
@@ -506,9 +530,9 @@ contains
         integer, intent(in) :: plot_count, annotation_count
         type(text_annotation_t), allocatable, intent(inout) :: annotations(:)
         logical, intent(in) :: rendered
-        
+
         if (.not. rendered) call figure_render(state, plots, plot_count, &
-            annotations, annotation_count)
+                                               annotations, annotation_count)
         call figure_extract_png_data_for_animation(state, png_data, status, rendered)
     end subroutine core_extract_png_data_for_animation
 
@@ -519,11 +543,11 @@ end module fortplot_figure_core_accessors
 
 module fortplot_figure_core_advanced
     !! Advanced plotting operations extracted from fortplot_figure_core
-    !! 
+    !!
     !! This module contains advanced plotting functionality like scatter plots,
     !! histograms, and statistical plots that were moved from the core module
     !! to maintain architectural compliance with size limits.
-    
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: plot_data_t
     use fortplot_figure_initialization, only: figure_state_t
@@ -532,12 +556,13 @@ module fortplot_figure_core_advanced
     implicit none
 
     private
-    public :: core_scatter, core_hist, core_boxplot
+    public :: core_scatter, core_hist, core_boxplot, core_colorbar
 
 contains
 
     subroutine core_scatter(plots, state, plot_count, x, y, s, c, marker, markersize, &
-                           color, colormap, vmin, vmax, label, show_colorbar, default_color)
+                            color, colormap, vmin, vmax, label, show_colorbar, &
+                            default_color)
         !! Add an efficient scatter plot using a single plot object
         !! Properly handles thousands of points without O(n) overhead
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
@@ -550,16 +575,16 @@ contains
         real(wp), intent(in), optional :: color(3)
         logical, intent(in), optional :: show_colorbar
         real(wp), intent(in) :: default_color(3)
-        
+
         ! Delegate to efficient scatter implementation
         call figure_scatter_operation(state, plots, state%plot_count, &
-                                     x, y, s, c, marker, markersize, color, &
-                                     colormap, vmin, vmax, label, show_colorbar, &
-                                     default_color)
-        
+                                      x, y, s, c, marker, markersize, color, &
+                                      colormap, vmin, vmax, label, show_colorbar, &
+                                      default_color)
+
         ! Update figure state
         plot_count = state%plot_count
-        
+
         ! Update data ranges
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_scatter
@@ -574,12 +599,13 @@ contains
         logical, intent(in), optional :: density
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
-        
-        call figure_hist_operation(plots, state, plot_count, data, bins, density, label, color)
+
+        call figure_hist_operation(plots, state, plot_count, data, bins, density, &
+                                   label, color)
     end subroutine core_hist
 
     subroutine core_boxplot(plots, state, plot_count, data, position, width, label, &
-                           show_outliers, horizontal, color, max_plots)
+                            show_outliers, horizontal, color, max_plots)
         !! Create a box plot
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(in) :: state
@@ -592,10 +618,74 @@ contains
         logical, intent(in), optional :: horizontal
         character(len=*), intent(in), optional :: color
         integer, intent(in) :: max_plots
-        
-        call figure_boxplot_operation(state, plots, plot_count, data, position, width, label, &
-                                     show_outliers, horizontal, color, max_plots)
+
+        call figure_boxplot_operation(state, plots, plot_count, data, position, &
+                                      width, label, &
+                                      show_outliers, horizontal, color, max_plots)
     end subroutine core_boxplot
+
+    subroutine core_colorbar(state, plots, plot_count, plot_index, label, location, &
+                             fraction, pad, shrink)
+        !! Enable a stateful colorbar for the current figure.
+        !!
+        !! This mirrors matplotlib's pyplot behavior: the colorbar is configured
+        !! independently from plot creation and is rendered during save/show.
+        type(figure_state_t), intent(inout) :: state
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer, intent(in), optional :: plot_index
+        character(len=*), intent(in), optional :: label, location
+        real(wp), intent(in), optional :: fraction, pad, shrink
+
+        integer :: idx
+
+        associate (dummy => size(plots)); end associate
+
+        if (plot_count <= 0) then
+            state%colorbar_enabled = .false.
+            state%colorbar_plot_index = 0
+            return
+        end if
+
+        idx = 0
+        if (present(plot_index)) then
+            if (plot_index >= 1 .and. plot_index <= plot_count) then
+                idx = plot_index
+            end if
+        end if
+
+        if (idx == 0) then
+            idx = plot_count
+        end if
+
+        state%colorbar_enabled = .true.
+        state%colorbar_plot_index = idx
+
+        if (present(location)) then
+            if (len_trim(location) > 0) state%colorbar_location = trim(location)
+        end if
+
+        if (present(fraction)) then
+            state%colorbar_fraction = max(0.01_wp, min(0.45_wp, fraction))
+        end if
+
+        if (present(pad)) then
+            state%colorbar_pad = max(0.0_wp, min(0.30_wp, pad))
+        end if
+
+        if (present(shrink)) then
+            state%colorbar_shrink = max(0.05_wp, min(1.0_wp, shrink))
+        end if
+
+        state%colorbar_label_set = .false.
+        if (allocated(state%colorbar_label)) deallocate (state%colorbar_label)
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                state%colorbar_label = trim(label)
+                state%colorbar_label_set = .true.
+            end if
+        end if
+    end subroutine core_colorbar
 
 end module fortplot_figure_core_advanced
 ! ==== End: src/figures/core/fortplot_figure_core_advanced.f90 ====
@@ -604,10 +694,10 @@ end module fortplot_figure_core_advanced
 
 module fortplot_figure_core_utils
     !! Utility operations extracted from fortplot_figure_core
-    !! 
+    !!
     !! This module contains utility operations like set_ydata and legend
     !! to maintain architectural compliance with size limits.
-    
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: plot_data_t
     use fortplot_figure_initialization, only: figure_state_t
@@ -632,7 +722,7 @@ contains
         integer, intent(in) :: plot_count
         character(len=*), intent(in), optional :: location
         call figure_legend_operation(state%legend_data, state%show_legend, &
-                                    plots, plot_count, location, state%backend_name)
+                                     plots, plot_count, location, state%backend_name)
     end subroutine core_figure_legend
 
 end module fortplot_figure_core_utils

--- a/src/figures/fortplot_figure_comprehensive_operations.f90
+++ b/src/figures/fortplot_figure_comprehensive_operations.f90
@@ -1,6 +1,6 @@
 module fortplot_figure_comprehensive_operations
     !! Comprehensive operations interface for fortplot figure core
-    !! 
+    !!
     !! This module provides a single comprehensive interface that aggregates
     !! ALL figure operations needed by the core module. This reduces coupling
     !! from 19 direct dependencies to 1 comprehensive interface.
@@ -15,12 +15,13 @@ module fortplot_figure_comprehensive_operations
     use fortplot_context
     use fortplot_plot_data, only: plot_data_t
     use fortplot_figure_initialization, only: figure_state_t
-    
+
     ! Import ALL necessary modules (facade pattern allows more dependencies)
     use fortplot_figure_operations
     use fortplot_figure_management
     use fortplot_figure_properties_new
-    use fortplot_figure_core_ranges, only: update_data_ranges_figure, update_data_ranges_pcolormesh_figure
+    use fortplot_figure_core_ranges, only: update_data_ranges_figure, &
+                                           update_data_ranges_pcolormesh_figure
     use fortplot_figure_core_operations
     use fortplot_figure_core_config
     use fortplot_figure_core_advanced
@@ -32,56 +33,71 @@ module fortplot_figure_comprehensive_operations
 
     ! Re-export ALL operations needed by core module
     ! Operations module functions (exact names used by core)
-    public :: figure_add_plot_operation, figure_add_contour_operation, figure_add_contour_filled_operation
-    public :: figure_add_surface_operation, figure_add_pcolormesh_operation, figure_add_fill_between_operation
+    public :: figure_add_plot_operation, figure_add_contour_operation, &
+              figure_add_contour_filled_operation
+    public :: figure_add_surface_operation, figure_add_pcolormesh_operation, &
+              figure_add_fill_between_operation
     public :: figure_add_pie_operation
     public :: figure_streamplot_operation, figure_hist_operation
-    public :: figure_boxplot_operation, figure_scatter_operation, figure_set_xlabel_operation
-    public :: figure_set_ylabel_operation, figure_set_title_operation, figure_set_xscale_operation
-    public :: figure_set_yscale_operation, figure_set_xlim_operation, figure_set_ylim_operation
-    public :: figure_set_line_width_operation, figure_set_ydata_operation, figure_legend_operation
+    public :: figure_boxplot_operation, figure_scatter_operation, &
+              figure_set_xlabel_operation
+    public :: figure_set_ylabel_operation, figure_set_title_operation, &
+              figure_set_xscale_operation
+    public :: figure_set_yscale_operation, figure_set_xlim_operation, &
+              figure_set_ylim_operation
+    public :: figure_set_line_width_operation, figure_set_ydata_operation, &
+              figure_legend_operation
     public :: figure_grid_operation, figure_render
-    
+
     ! Management module functions
-    public :: figure_initialize, figure_destroy, figure_clear, figure_savefig, figure_savefig_with_status
+    public :: figure_initialize, figure_destroy, figure_clear, figure_savefig, &
+              figure_savefig_with_status
     public :: figure_show, figure_clear_streamlines
     public :: figure_subplots, figure_subplot_plot, figure_subplot_plot_count
-    public :: figure_subplot_set_title, figure_subplot_set_xlabel, figure_subplot_set_ylabel
+    public :: figure_subplot_set_title, figure_subplot_set_xlabel, &
+              figure_subplot_set_ylabel
     public :: figure_subplot_title
     public :: figure_setup_png_backend_for_animation
-    public :: figure_extract_rgb_data_for_animation, figure_extract_png_data_for_animation
+    public :: figure_extract_rgb_data_for_animation, &
+              figure_extract_png_data_for_animation
     public :: core_clear, core_clear_streamlines, core_destroy
-    
-    ! Properties module functions  
-    public :: figure_get_width, figure_get_height, figure_get_rendered, figure_set_rendered
+
+    ! Properties module functions
+    public :: figure_get_width, figure_get_height, figure_get_rendered, &
+              figure_set_rendered
     public :: figure_get_plot_count, figure_get_plots
     public :: figure_get_x_min, figure_get_x_max, figure_get_y_min, figure_get_y_max
-    public :: figure_backend_color, figure_backend_associated, figure_backend_line, figure_backend_arrow
-    
+    public :: figure_backend_color, figure_backend_associated, figure_backend_line, &
+              figure_backend_arrow
+
     ! Additional operations needed by core
     public :: update_data_ranges_figure, update_data_ranges_pcolormesh_figure
-    
+
     ! Core operations extracted from main module
-    public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled, core_add_surface
+    public :: core_initialize, core_add_plot, core_add_contour, &
+              core_add_contour_filled, core_add_surface
     public :: core_add_pcolormesh, core_add_fill_between, core_add_pie
     public :: core_streamplot, core_savefig, core_savefig_with_status
     public :: core_show
-    
+    public :: core_colorbar
+
     ! Configuration operations from core_config module
     public :: core_set_xlabel, core_set_ylabel, core_set_title
     public :: core_set_xscale, core_set_yscale, core_set_xlim, core_set_ylim
     public :: core_set_line_width, core_grid
-    
+
     ! Advanced plotting operations from core_advanced module
     public :: core_scatter, core_hist, core_boxplot
-    
+
     ! Property accessor operations from core_accessors module
     public :: core_get_width, core_get_height, core_get_rendered, core_set_rendered
     public :: core_get_plot_count, core_get_plots, core_get_x_min, core_get_x_max
-    public :: core_get_y_min, core_get_y_max, core_backend_color, core_backend_associated
-    public :: core_backend_line, core_setup_png_backend_for_animation, core_backend_arrow
+    public :: core_get_y_min, core_get_y_max, core_backend_color, &
+              core_backend_associated
+    public :: core_backend_line, core_setup_png_backend_for_animation, &
+              core_backend_arrow
     public :: core_extract_rgb_data_for_animation, core_extract_png_data_for_animation
-    
+
     ! Utility operations from core_utils module
     public :: core_set_ydata, core_figure_legend
 

--- a/src/figures/management/fortplot_figure_colorbar.f90
+++ b/src/figures/management/fortplot_figure_colorbar.f90
@@ -1,0 +1,346 @@
+module fortplot_figure_colorbar
+    !! Stateful colorbar rendering (matplotlib-style).
+    !!
+    !! Implements:
+    !! - Plot-area splitting for right/left/top/bottom colorbar placement
+    !! - Scalar-mappable detection (pcolormesh/scatter/filled contour)
+    !! - Gradient rendering + ticks/labels using existing primitives
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PCOLORMESH, &
+                                  PLOT_TYPE_SCATTER, &
+                                  PLOT_TYPE_CONTOUR
+    use fortplot_margins, only: plot_area_t
+    use fortplot_png, only: png_context
+    use fortplot_pdf, only: pdf_context
+    use fortplot_colormap, only: get_colormap_color
+    use fortplot_ticks, only: find_nice_tick_locations, format_tick_value_smart
+    use fortplot_string_utils, only: to_lowercase
+    implicit none
+
+    private
+    public :: prepare_colorbar_layout
+    public :: resolve_colorbar_mappable
+    public :: render_colorbar
+
+contains
+
+    subroutine prepare_colorbar_layout(backend, location, fraction, pad, shrink, &
+                                       saved_area, main_area, colorbar_area, supported)
+        class(plot_context), intent(inout) :: backend
+        character(len=*), intent(in) :: location
+        real(wp), intent(in) :: fraction, pad, shrink
+        type(plot_area_t), intent(out) :: saved_area, main_area, colorbar_area
+        logical, intent(out) :: supported
+
+        supported = .false.
+
+        call get_backend_plot_area(backend, saved_area, supported)
+        if (.not. supported) then
+            main_area = saved_area
+            colorbar_area = saved_area
+            return
+        end if
+
+        call compute_colorbar_plot_areas(saved_area, location, fraction, pad, shrink, &
+                                         main_area, colorbar_area)
+        call set_backend_plot_area(backend, main_area)
+    end subroutine prepare_colorbar_layout
+
+    subroutine resolve_colorbar_mappable(plots, plot_count, preferred_index, &
+                                         plot_index, vmin, vmax, colormap, ok)
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer, intent(in) :: preferred_index
+        integer, intent(out) :: plot_index
+        real(wp), intent(out) :: vmin, vmax
+        character(len=20), intent(out) :: colormap
+        logical, intent(out) :: ok
+
+        integer :: i, start_idx
+        logical :: found
+
+        ok = .false.
+        plot_index = 0
+        vmin = 0.0_wp
+        vmax = 1.0_wp
+        colormap = 'viridis'
+
+        if (plot_count <= 0) return
+
+        start_idx = preferred_index
+        if (start_idx < 1 .or. start_idx > plot_count) start_idx = plot_count
+
+        found = .false.
+        do i = start_idx, 1, -1
+            if (plots(i)%plot_type == PLOT_TYPE_PCOLORMESH) then
+                if (allocated(plots(i)%pcolormesh_data%c_values)) then
+                    vmin = plots(i)%pcolormesh_data%vmin
+                    vmax = plots(i)%pcolormesh_data%vmax
+                    if (.not. plots(i)%pcolormesh_data%vmin_set) vmin = &
+                        minval(plots(i)%pcolormesh_data%c_values)
+                    if (.not. plots(i)%pcolormesh_data%vmax_set) vmax = &
+                        maxval(plots(i)%pcolormesh_data%c_values)
+                    colormap = plots(i)%pcolormesh_data%colormap_name
+                    plot_index = i
+                    found = .true.
+                    exit
+                end if
+            end if
+
+            if (plots(i)%plot_type == PLOT_TYPE_SCATTER) then
+                if (allocated(plots(i)%scatter_colors)) then
+                    if (size(plots(i)%scatter_colors) > 0) then
+                        if (plots(i)%scatter_vrange_set) then
+                            vmin = plots(i)%scatter_vmin
+                            vmax = plots(i)%scatter_vmax
+                        else
+                            vmin = minval(plots(i)%scatter_colors)
+                            vmax = maxval(plots(i)%scatter_colors)
+                        end if
+                        colormap = plots(i)%scatter_colormap
+                        plot_index = i
+                        found = .true.
+                        exit
+                    end if
+                end if
+            end if
+
+            if (plots(i)%plot_type == PLOT_TYPE_CONTOUR) then
+                if (plots(i)%fill_contours .and. allocated(plots(i)%z_grid)) then
+                    if (size(plots(i)%z_grid) > 0) then
+                        vmin = minval(plots(i)%z_grid)
+                        vmax = maxval(plots(i)%z_grid)
+                        colormap = plots(i)%colormap
+                        plot_index = i
+                        found = .true.
+                        exit
+                    end if
+                end if
+            end if
+        end do
+
+        if (.not. found) return
+        if (vmax <= vmin) vmax = vmin + 1.0_wp
+        ok = .true.
+    end subroutine resolve_colorbar_mappable
+
+    subroutine render_colorbar(backend, plot_area, vmin, vmax, colormap, &
+                               location, label)
+        class(plot_context), intent(inout) :: backend
+        type(plot_area_t), intent(in) :: plot_area
+        real(wp), intent(in) :: vmin, vmax
+        character(len=*), intent(in) :: colormap
+        character(len=*), intent(in) :: location
+        character(len=*), intent(in), optional :: label
+
+        type(plot_area_t) :: saved_area
+        logical :: supported
+        real(wp) :: x_min_saved, x_max_saved, y_min_saved, y_max_saved
+        character(len=32) :: loc
+        logical :: vertical
+        integer :: n_slices, i
+        real(wp) :: t, c(3)
+        real(wp) :: x0, x1, y0, y1
+        real(wp) :: quad_x(4), quad_y(4)
+        real(wp) :: tick_locations(20), nice_min, nice_max, nice_step
+        integer :: n_ticks
+        real(wp) :: tick, tick_len
+        character(len=20) :: tick_label
+        real(wp) :: mid_val
+        real(wp) :: range_val
+
+        supported = .false.
+        call get_backend_plot_area(backend, saved_area, supported)
+        if (.not. supported) return
+
+        call backend%save_coordinates(x_min_saved, x_max_saved, y_min_saved, &
+                                      y_max_saved)
+        call set_backend_plot_area(backend, plot_area)
+
+        loc = to_lowercase(trim(location))
+        vertical = .true.
+        if (loc == 'top' .or. loc == 'bottom') vertical = .false.
+
+        range_val = max(1.0e-12_wp, vmax - vmin)
+        mid_val = 0.5_wp*(vmin + vmax)
+
+        if (vertical) then
+            call backend%set_coordinates(0.0_wp, 1.0_wp, vmin, vmax)
+            n_slices = min(128, max(32, plot_area%height/4))
+        else
+            call backend%set_coordinates(vmin, vmax, 0.0_wp, 1.0_wp)
+            n_slices = min(128, max(32, plot_area%width/4))
+        end if
+
+        do i = 1, n_slices
+            if (n_slices == 1) then
+                t = 0.5_wp
+            else
+                t = real(i - 1, wp)/real(n_slices - 1, wp)
+            end if
+            call get_colormap_color(t, colormap, c)
+            call backend%color(c(1), c(2), c(3))
+
+            if (vertical) then
+                x0 = 0.0_wp
+                x1 = 1.0_wp
+                y0 = vmin + (real(i - 1, wp)/real(n_slices, wp))*range_val
+                y1 = vmin + (real(i, wp)/real(n_slices, wp))*range_val
+                quad_x = [x0, x1, x1, x0]
+                quad_y = [y0, y0, y1, y1]
+            else
+                y0 = 0.0_wp
+                y1 = 1.0_wp
+                x0 = vmin + (real(i - 1, wp)/real(n_slices, wp))*range_val
+                x1 = vmin + (real(i, wp)/real(n_slices, wp))*range_val
+                quad_x = [x0, x1, x1, x0]
+                quad_y = [y0, y0, y1, y1]
+            end if
+
+            call backend%fill_quad(quad_x, quad_y)
+        end do
+
+        call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
+        if (vertical) then
+            call backend%line(0.0_wp, vmin, 1.0_wp, vmin)
+            call backend%line(0.0_wp, vmax, 1.0_wp, vmax)
+            call backend%line(0.0_wp, vmin, 0.0_wp, vmax)
+            call backend%line(1.0_wp, vmin, 1.0_wp, vmax)
+        else
+            call backend%line(vmin, 0.0_wp, vmax, 0.0_wp)
+            call backend%line(vmin, 1.0_wp, vmax, 1.0_wp)
+            call backend%line(vmin, 0.0_wp, vmin, 1.0_wp)
+            call backend%line(vmax, 0.0_wp, vmax, 1.0_wp)
+        end if
+
+        call find_nice_tick_locations(vmin, vmax, 5, nice_min, nice_max, nice_step, &
+                                      tick_locations, n_ticks)
+        tick_len = 0.08_wp
+        do i = 1, n_ticks
+            tick = tick_locations(i)
+            tick_label = format_tick_value_smart(tick, 10)
+            if (vertical) then
+                call backend%line(1.0_wp, tick, 1.0_wp + tick_len, tick)
+                call backend%text(1.0_wp + 0.12_wp, tick, trim(tick_label))
+            else
+                call backend%line(tick, 0.0_wp, tick, -tick_len)
+                call backend%text(tick, -0.18_wp, trim(tick_label))
+            end if
+        end do
+
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                if (vertical) then
+                    call backend%text(1.35_wp, mid_val, trim(label))
+                else
+                    call backend%text(mid_val, -0.40_wp, trim(label))
+                end if
+            end if
+        end if
+
+        call backend%set_coordinates(x_min_saved, x_max_saved, y_min_saved, y_max_saved)
+        call set_backend_plot_area(backend, saved_area)
+    end subroutine render_colorbar
+
+    subroutine compute_colorbar_plot_areas(orig, location, fraction, pad, &
+                                           shrink, main, cb)
+        type(plot_area_t), intent(in) :: orig
+        character(len=*), intent(in) :: location
+        real(wp), intent(in) :: fraction, pad, shrink
+        type(plot_area_t), intent(out) :: main, cb
+
+        character(len=32) :: loc
+        logical :: vertical
+        integer :: bar_px, pad_px
+        integer :: long_px, shrink_px, delta_px
+
+        main = orig
+        cb = orig
+
+        loc = to_lowercase(trim(location))
+        vertical = .true.
+        if (loc == 'top' .or. loc == 'bottom') vertical = .false.
+
+        if (vertical) then
+            bar_px = max(1, int(max(0.01_wp, fraction)*real(orig%width, wp)))
+            pad_px = max(0, int(max(0.0_wp, pad)*real(orig%width, wp)))
+
+            main%width = max(1, orig%width - bar_px - pad_px)
+            cb%width = bar_px
+
+            long_px = max(1, orig%height)
+            shrink_px = max(1, int(max(0.05_wp, min(1.0_wp, shrink))*real(long_px, wp)))
+            delta_px = (long_px - shrink_px)/2
+            cb%height = shrink_px
+            cb%bottom = orig%bottom + delta_px
+
+            if (loc == 'left') then
+                cb%left = orig%left
+                main%left = orig%left + bar_px + pad_px
+            else
+                main%left = orig%left
+                cb%left = orig%left + main%width + pad_px
+            end if
+        else
+            bar_px = max(1, int(max(0.01_wp, fraction)*real(orig%height, wp)))
+            pad_px = max(0, int(max(0.0_wp, pad)*real(orig%height, wp)))
+
+            main%height = max(1, orig%height - bar_px - pad_px)
+            cb%height = bar_px
+
+            long_px = max(1, orig%width)
+            shrink_px = max(1, int(max(0.05_wp, min(1.0_wp, shrink))*real(long_px, wp)))
+            delta_px = (long_px - shrink_px)/2
+            cb%width = shrink_px
+            cb%left = orig%left + delta_px
+
+            if (loc == 'bottom') then
+                cb%bottom = orig%bottom
+                main%bottom = orig%bottom + bar_px + pad_px
+            else
+                main%bottom = orig%bottom
+                cb%bottom = orig%bottom + main%height + pad_px
+            end if
+        end if
+    end subroutine compute_colorbar_plot_areas
+
+    subroutine get_backend_plot_area(backend, plot_area, supported)
+        class(plot_context), intent(in) :: backend
+        type(plot_area_t), intent(out) :: plot_area
+        logical, intent(out) :: supported
+
+        supported = .false.
+        plot_area%left = 0
+        plot_area%bottom = 0
+        plot_area%width = 0
+        plot_area%height = 0
+
+        select type (bk => backend)
+        type is (png_context)
+            plot_area = bk%plot_area
+            supported = .true.
+        type is (pdf_context)
+            plot_area = bk%plot_area
+            supported = .true.
+        class default
+            supported = .false.
+        end select
+    end subroutine get_backend_plot_area
+
+    subroutine set_backend_plot_area(backend, plot_area)
+        class(plot_context), intent(inout) :: backend
+        type(plot_area_t), intent(in) :: plot_area
+
+        select type (bk => backend)
+        type is (png_context)
+            bk%plot_area = plot_area
+        type is (pdf_context)
+            bk%plot_area = plot_area
+        class default
+            continue
+        end select
+    end subroutine set_backend_plot_area
+
+end module fortplot_figure_colorbar

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -1,21 +1,22 @@
 module fortplot_figure_initialization
     !! Figure initialization and configuration module
-    !! 
+    !!
     !! Single Responsibility: Initialize figures and manage basic configuration
     !! Extracted from fortplot_figure_core to reduce file size and improve modularity
-    
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_utils, only: initialize_backend
     use fortplot_legend, only: legend_t
-    use fortplot_plot_data, only: plot_data_t, arrow_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, arrow_data_t, AXIS_PRIMARY, &
+                                  AXIS_TWINX, AXIS_TWINY
     implicit none
-    
+
     private
     public :: figure_state_t, initialize_figure_state, reset_figure_state
     public :: setup_figure_backend, configure_figure_dimensions
     public :: set_figure_labels, set_figure_scales, set_figure_limits
-    
+
     type :: figure_state_t
         !! Figure state and configuration data
         !! Encapsulates all configuration and state management
@@ -23,23 +24,24 @@ module fortplot_figure_initialization
         character(len=10) :: backend_name = 'png'
         integer :: plot_count = 0
         logical :: rendered = .false.
-        
+
         ! Figure dimensions
         integer :: width = 640
         integer :: height = 480
-        real(wp) :: dpi = 100.0_wp  ! Default DPI for consistency with matplotlib interface
-        
+        real(wp) :: dpi = 100.0_wp
+        ! Default DPI for consistency with matplotlib interface
+
         ! Plot area settings
         real(wp) :: margin_left = 0.15_wp
         real(wp) :: margin_right = 0.05_wp
         real(wp) :: margin_bottom = 0.15_wp
         real(wp) :: margin_top = 0.05_wp
-        
+
         ! Scale settings
         character(len=10) :: xscale = 'linear'
         character(len=10) :: yscale = 'linear'
         real(wp) :: symlog_threshold = 1.0_wp
-        
+
         ! Axis limits
         real(wp) :: x_min, x_max, y_min, y_max
         real(wp) :: x_min_transformed, x_max_transformed
@@ -64,31 +66,37 @@ module fortplot_figure_initialization
         real(wp) :: twinx_y_max_transformed = 1.0_wp
         real(wp) :: twiny_x_min_transformed = 0.0_wp
         real(wp) :: twiny_x_max_transformed = 1.0_wp
-        
+
         ! Labels
         character(len=:), allocatable :: title
         character(len=:), allocatable :: xlabel
         character(len=:), allocatable :: ylabel
-        
+
         ! Color palette: seaborn colorblind palette
-        real(wp), dimension(3,6) :: colors = reshape([ &
-            0.0_wp,   0.447_wp, 0.698_wp,  & ! #0072B2 (blue)
-            0.0_wp,   0.619_wp, 0.451_wp,  & ! #009E73 (green)
-            0.835_wp, 0.369_wp, 0.0_wp,    & ! #D55E00 (orange)
-            0.8_wp,   0.475_wp, 0.655_wp,  & ! #CC79A7 (purple)
-            0.941_wp, 0.894_wp, 0.259_wp,  & ! #F0E442 (yellow)
-            0.337_wp, 0.702_wp, 0.914_wp], & ! #56B4E9 (cyan)
-            [3,6])
-        
+        real(wp), dimension(3, 6) :: colors = reshape([ &
+                                                      0.0_wp, 0.447_wp, 0.698_wp, &
+                                                      ! #0072B2 (blue)
+                                                      0.0_wp, 0.619_wp, 0.451_wp, &
+                                                      ! #009E73 (green)
+                                                      0.835_wp, 0.369_wp, 0.0_wp, &
+                                                      ! #D55E00 (orange)
+                                                      0.8_wp, 0.475_wp, 0.655_wp, &
+                                                      ! #CC79A7 (purple)
+                                                      0.941_wp, 0.894_wp, 0.259_wp, &
+                                                      ! #F0E442 (yellow)
+                                                      0.337_wp, 0.702_wp, 0.914_wp], &
+                                                      ! #56B4E9 (cyan)
+                                                      [3, 6])
+
         ! Legend support
         type(legend_t) :: legend_data
         logical :: show_legend = .false.
         integer :: max_plots = 500
-        
+
         ! Drawing properties
         real(wp) :: current_line_width = 1.0_wp
         logical :: has_error = .false.
-        
+
         ! Grid settings
         logical :: grid_enabled = .false.
         character(len=10) :: grid_which = 'both'
@@ -96,30 +104,43 @@ module fortplot_figure_initialization
         real(wp) :: grid_alpha = 0.3_wp
         character(len=10) :: grid_linestyle = '-'
 
+        ! Stateful colorbar (matplotlib-style)
+        logical :: colorbar_enabled = .false.
+        integer :: colorbar_plot_index = 0
+        character(len=10) :: colorbar_location = 'right'
+        real(wp) :: colorbar_fraction = 0.15_wp
+        real(wp) :: colorbar_pad = 0.05_wp
+        real(wp) :: colorbar_shrink = 1.0_wp
+        logical :: colorbar_label_set = .false.
+        character(len=:), allocatable :: colorbar_label
+
         ! Streamplot arrow storage (rendered after plots)
         type(arrow_data_t), allocatable :: stream_arrows(:)
     end type figure_state_t
-    
+
 contains
-    
+
     subroutine initialize_figure_state(state, width, height, backend, dpi)
         !! Initialize figure state with specified parameters
         !! Added Issue #854: Parameter validation for user input safety
         !! Added DPI support for OO interface consistency with matplotlib interface
-        use fortplot_parameter_validation, only: validate_plot_dimensions, validate_file_path, &
-                                               parameter_validation_result_t, validation_warning
+        use fortplot_parameter_validation, only: validate_plot_dimensions, &
+                                                 validate_file_path, &
+                                                 parameter_validation_result_t, &
+                                                 validation_warning
         type(figure_state_t), intent(inout) :: state
         integer, intent(in), optional :: width, height
         character(len=*), intent(in), optional :: backend
         real(wp), intent(in), optional :: dpi
-        
+
         type(parameter_validation_result_t) :: validation
         real(wp) :: width_real, height_real
 
         ! Set DPI with validation
         if (present(dpi)) then
             if (dpi <= 0.0_wp) then
-                call validation_warning("Invalid DPI value, using default 100.0", "figure_initialization")
+                call validation_warning("Invalid DPI value, using default 100.0", &
+                                        "figure_initialization")
                 state%dpi = 100.0_wp
             else
                 state%dpi = dpi
@@ -133,8 +154,9 @@ contains
             width_real = real(width, wp)
             height_real = real(state%height, wp)
             if (present(height)) height_real = real(height, wp)
-            
-            validation = validate_plot_dimensions(width_real, height_real, "figure_initialization")
+
+            validation = validate_plot_dimensions(width_real, height_real, &
+                                                  "figure_initialization")
             if (validation%is_valid) then
                 state%width = width
             else
@@ -142,12 +164,13 @@ contains
                 state%width = 640
             end if
         end if
-        
+
         if (present(height)) then
             width_real = real(state%width, wp)
             height_real = real(height, wp)
-            
-            validation = validate_plot_dimensions(width_real, height_real, "figure_initialization")
+
+            validation = validate_plot_dimensions(width_real, height_real, &
+                                                  "figure_initialization")
             if (validation%is_valid) then
                 state%height = height
             else
@@ -155,23 +178,27 @@ contains
                 state%height = 480
             end if
         end if
-        
+
         ! Initialize backend - default to PNG if not specified
         if (present(backend)) then
             ! Validate backend name (basic check for supported backends)
             if (len_trim(backend) == 0) then
-                call validation_warning("Empty backend name provided, using default 'png'", &
-                                      "figure_initialization")
+                call validation_warning( &
+                    "Empty backend name provided, using default 'png'", &
+                    "figure_initialization")
                 state%backend_name = 'png'
                 call initialize_backend(state%backend, 'png', state%width, state%height)
-            else if (backend /= 'png' .and. backend /= 'pdf' .and. backend /= 'ascii') then
-                call validation_warning("Unknown backend '" // trim(backend) // &
-                                      "', using default 'png'", "figure_initialization")
+            else if (backend /= 'png' .and. backend /= 'pdf' .and. backend /= &
+                     'ascii') then
+                call validation_warning( &
+                    "Unknown backend '"//trim(backend)//"', using default 'png'", &
+                    "figure_initialization")
                 state%backend_name = 'png'
                 call initialize_backend(state%backend, 'png', state%width, state%height)
             else
                 state%backend_name = backend
-                call initialize_backend(state%backend, backend, state%width, state%height)
+                call initialize_backend(state%backend, backend, state%width, &
+                                        state%height)
             end if
         else
             ! Default to PNG backend to prevent uninitialized backend
@@ -180,7 +207,7 @@ contains
                 call initialize_backend(state%backend, 'png', state%width, state%height)
             end if
         end if
-        
+
         ! Reset state
         ! Reset state manually to avoid legend issues
         state%plot_count = 0
@@ -189,13 +216,13 @@ contains
         state%xlim_set = .false.
         state%ylim_set = .false.
         state%has_error = .false.
-        
+
         ! Proper legend initialization without manual deallocate
         state%legend_data%num_entries = 0
         block
             use fortplot_legend, only: legend_entry_t
             type(legend_entry_t), allocatable :: new_entries(:)
-            allocate(new_entries(0))
+            allocate (new_entries(0))
             call move_alloc(new_entries, state%legend_data%entries)
         end block
 
@@ -214,27 +241,36 @@ contains
         state%twinx_y_max_transformed = 1.0_wp
         state%twiny_x_min_transformed = 0.0_wp
         state%twiny_x_max_transformed = 1.0_wp
-        if (allocated(state%twinx_ylabel)) deallocate(state%twinx_ylabel)
-        if (allocated(state%twiny_xlabel)) deallocate(state%twiny_xlabel)
+        if (allocated(state%twinx_ylabel)) deallocate (state%twinx_ylabel)
+        if (allocated(state%twiny_xlabel)) deallocate (state%twiny_xlabel)
+
+        state%colorbar_enabled = .false.
+        state%colorbar_plot_index = 0
+        state%colorbar_location = 'right'
+        state%colorbar_fraction = 0.15_wp
+        state%colorbar_pad = 0.05_wp
+        state%colorbar_shrink = 1.0_wp
+        state%colorbar_label_set = .false.
+        if (allocated(state%colorbar_label)) deallocate (state%colorbar_label)
     end subroutine initialize_figure_state
-    
+
     subroutine reset_figure_state(state)
         !! Reset figure state to initial values
         type(figure_state_t), intent(inout) :: state
-        
+
         state%plot_count = 0
         state%rendered = .false.
         state%show_legend = .false.
-        
+
         ! Initialize legend data (safe initialization without manual deallocate)
         state%legend_data%num_entries = 0
         block
             use fortplot_legend, only: legend_entry_t
             type(legend_entry_t), allocatable :: new_entries(:)
-            allocate(new_entries(0))
+            allocate (new_entries(0))
             call move_alloc(new_entries, state%legend_data%entries)
         end block
-        
+
         ! Reset axis limits and labels
         state%xlim_set = .false.
         state%ylim_set = .false.
@@ -257,21 +293,32 @@ contains
         state%twinx_y_max_transformed = 1.0_wp
         state%twiny_x_min_transformed = 0.0_wp
         state%twiny_x_max_transformed = 1.0_wp
-        if (allocated(state%twinx_ylabel)) deallocate(state%twinx_ylabel)
-        if (allocated(state%twiny_xlabel)) deallocate(state%twiny_xlabel)
-        
+        if (allocated(state%twinx_ylabel)) deallocate (state%twinx_ylabel)
+        if (allocated(state%twiny_xlabel)) deallocate (state%twiny_xlabel)
+
+        state%colorbar_enabled = .false.
+        state%colorbar_plot_index = 0
+        state%colorbar_location = 'right'
+        state%colorbar_fraction = 0.15_wp
+        state%colorbar_pad = 0.05_wp
+        state%colorbar_shrink = 1.0_wp
+        state%colorbar_label_set = .false.
+        if (allocated(state%colorbar_label)) deallocate (state%colorbar_label)
+
         state%has_error = .false.
 
-        if (allocated(state%stream_arrows)) deallocate(state%stream_arrows)
+        if (allocated(state%stream_arrows)) deallocate (state%stream_arrows)
     end subroutine reset_figure_state
-    
+
     subroutine setup_figure_backend(state, backend_name)
         !! Setup or change the figure backend
         type(figure_state_t), intent(inout) :: state
         character(len=*), intent(in) :: backend_name
 
-        ! Reinitialize backend; initialize_backend has intent(out) and will handle deallocation
-        call initialize_backend(state%backend, backend_name, state%width, state%height)
+        ! Reinitialize backend; initialize_backend has intent(out) and will handle
+        ! deallocation.
+        call initialize_backend(state%backend, backend_name, state%width, &
+                                state%height)
 
         ! Update the backend_name field to match the current backend
         state%backend_name = backend_name
@@ -279,22 +326,22 @@ contains
         ! Force re-rendering with new backend
         state%rendered = .false.
     end subroutine setup_figure_backend
-    
+
     subroutine configure_figure_dimensions(state, width, height)
         !! Configure figure dimensions
         type(figure_state_t), intent(inout) :: state
         integer, intent(in), optional :: width, height
-        
+
         if (present(width)) state%width = width
         if (present(height)) state%height = height
-        
+
         ! If backend exists, reinitialize with new dimensions
         if (allocated(state%backend)) then
             ! Get current backend type and reinitialize
             state%rendered = .false.
         end if
     end subroutine configure_figure_dimensions
-    
+
     subroutine set_figure_labels(state, title, xlabel, ylabel)
         !! Set figure labels
         type(figure_state_t), intent(inout) :: state
@@ -322,13 +369,13 @@ contains
             end select
         end if
     end subroutine set_figure_labels
-    
+
     subroutine set_figure_scales(state, xscale, yscale, threshold)
         !! Set axis scale types
         type(figure_state_t), intent(inout) :: state
         character(len=*), intent(in), optional :: xscale, yscale
         real(wp), intent(in), optional :: threshold
-        
+
         if (present(xscale)) then
             if (state%active_axis == AXIS_TWINY) then
                 state%twiny_xscale = xscale

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -6,7 +6,7 @@ module fortplot_matplotlib
     !! by re-exporting the consolidated implementation from
     !! `fortplot_matplotlib_advanced`. Public API remains stable while
     !! internal modules are simplified.
-    
+
     use fortplot_matplotlib_advanced, only: &
         plot, scatter, errorbar, boxplot, &
         bar, barh, hist, histogram, &
@@ -15,18 +15,19 @@ module fortplot_matplotlib
         fill, fill_between, twinx, twiny, &
         contour, contour_filled, pcolormesh, streamplot, &
         add_contour, add_contour_filled, add_pcolormesh, add_surface, &
+        colorbar, &
         xlabel, ylabel, title, legend, grid, &
         xlim, ylim, set_xscale, set_yscale, &
         set_line_width, set_ydata, use_axis, get_active_axis, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
         show, show_viewer, get_global_figure, ensure_global_figure_initialized
-    
+
     use fortplot_text_stub, only: &
         text, annotate
-    
+
     implicit none
     private
-    
+
     ! Re-export all matplotlib-style functions from submodules
     ! Plotting functions
     public :: plot, scatter, errorbar, boxplot
@@ -34,23 +35,24 @@ module fortplot_matplotlib
     public :: add_plot, add_errorbar, add_scatter, add_3d_plot
     public :: imshow, pie, polar, step, stem
     public :: fill, fill_between, twinx, twiny
-    
+
     ! Contour and field functions
     public :: contour, contour_filled, pcolormesh, streamplot
     public :: add_contour, add_contour_filled, add_pcolormesh, add_surface
-    
+    public :: colorbar
+
     ! Axis and annotation functions
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: text, annotate
-    
+
     ! Figure management functions
     public :: figure, subplot, subplots, subplots_grid
     public :: savefig, savefig_with_status
     public :: show, show_viewer
-    
+
     ! Testing support
     public :: get_global_figure, ensure_global_figure_initialized
-    
+
 end module fortplot_matplotlib

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -14,6 +14,7 @@ module fortplot_matplotlib_advanced
         ensure_global_figure_initialized, get_global_figure, figure, subplot, &
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
         show_figure, show_viewer
+    use fortplot_matplotlib_colorbar, only: colorbar
     use fortplot_matplotlib_plots_new, only: &
         imshow, pie, polar, step, stem, fill, fill_between, twinx, twiny
 
@@ -32,6 +33,7 @@ module fortplot_matplotlib_advanced
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis
+    public :: colorbar
 
     public :: figure, subplot, subplots, subplots_grid
     public :: savefig, savefig_with_status

--- a/src/interfaces/fortplot_matplotlib_colorbar.f90
+++ b/src/interfaces/fortplot_matplotlib_colorbar.f90
@@ -1,0 +1,26 @@
+module fortplot_matplotlib_colorbar
+    !! Matplotlib-style stateful colorbar wrapper.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_global, only: fig => global_figure
+    use fortplot_matplotlib_session, only: ensure_fig_init
+    implicit none
+
+    private
+    public :: colorbar
+
+contains
+
+    subroutine colorbar(label, location, fraction, pad, shrink, plot_index)
+        character(len=*), intent(in), optional :: label, location
+        real(wp), intent(in), optional :: fraction, pad, shrink
+        integer, intent(in), optional :: plot_index
+
+        call ensure_fig_init()
+
+        call fig%colorbar(plot_index=plot_index, label=label, location=location, &
+                          fraction=fraction, pad=pad, shrink=shrink)
+    end subroutine colorbar
+
+end module fortplot_matplotlib_colorbar
+

--- a/test/test_colorbar_stateful.f90
+++ b/test/test_colorbar_stateful.f90
@@ -1,0 +1,47 @@
+program test_colorbar_stateful
+    use fortplot, only: pcolormesh, colorbar, savefig
+    use fortplot_security, only: safe_create_directory
+    use fortplot_validation, only: validate_file_exists, validate_file_size, &
+                                   validate_png_format, &
+                                   validation_result_t
+    use, intrinsic :: iso_fortran_env, only: wp => real64, error_unit
+    implicit none
+
+    type(validation_result_t) :: v
+    logical :: dir_ok
+    real(wp) :: x(3), y(3)
+    real(wp) :: z(2, 2)
+    character(len=*), parameter :: out_file = 'test/output/test_colorbar_stateful.png'
+
+    call safe_create_directory('test/output', dir_ok)
+    if (.not. dir_ok) then
+        write (error_unit, '(A)') 'Failed to create test/output directory'
+        stop 1
+    end if
+
+    x = [0.0_wp, 1.0_wp, 2.0_wp]
+    y = [0.0_wp, 1.0_wp, 2.0_wp]
+    z(:, :) = reshape([0.0_wp, 0.5_wp, 0.75_wp, 1.0_wp], [2, 2])
+
+    call pcolormesh(x, y, z, colormap='viridis')
+    call colorbar(label='Value', location='right', fraction=0.15_wp, pad=0.05_wp)
+    call savefig(out_file)
+
+    v = validate_file_exists(out_file)
+    if (.not. v%passed) then
+        write (error_unit, '(A)') trim(v%message)
+        stop 1
+    end if
+
+    v = validate_file_size(out_file, 200)
+    if (.not. v%passed) then
+        write (error_unit, '(A)') trim(v%message)
+        stop 1
+    end if
+
+    v = validate_png_format(out_file)
+    if (.not. v%passed) then
+        write (error_unit, '(A)') trim(v%message)
+        stop 1
+    end if
+end program test_colorbar_stateful


### PR DESCRIPTION
Closes #1428.

## Summary
- Adds a stateful `colorbar()` API (pyplot + OO) that can be called after `pcolormesh`, `scatter`, or `contour_filled`.
- Implements matplotlib-style placement by splitting the current plot area and rendering a gradient + ticks in the reserved strip.

## API
- `call colorbar(label=..., location=..., fraction=..., pad=..., shrink=..., plot_index=...)`
  - `location`: `right|left|top|bottom` (default: `right`)

## Tests
- `make test-ci 2>&1 | tee /tmp/fortplot-test-ci-1428.log`

Excerpt:
```
PASS: src/* subfolder item limits respected (≤20 soft, ≤50 hard)
CI essential test suite completed successfully
```
