### PR TITLE
fix: unblock GitHub Pages docs build (contour_filled_demo)

### DIFF
--- a/doc/subplots_function.md
+++ b/doc/subplots_function.md
@@ -1,3 +1,6 @@
+title: Subplots Function
+---
+
 # Subplots Function
 
 The `subplots()` function creates a grid of subplots on the current figure, similar to matplotlib's `plt.subplots()` function.

--- a/src/backends/memory/fortplot_contour_rendering.f90
+++ b/src/backends/memory/fortplot_contour_rendering.f90
@@ -103,8 +103,8 @@ contains
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
 
-        integer :: nx, ny
-        integer :: i, j, k, t
+        integer :: nx, ny, nx_z, ny_z, nx_cells, ny_cells
+        integer :: ix, iy, k, t
         integer :: nlev
         real(wp), allocatable :: levels(:)
         real(wp) :: lo, hi, mid
@@ -124,7 +124,12 @@ contains
 
         nx = size(plot_data%x_grid)
         ny = size(plot_data%y_grid)
-        if (nx < 2 .or. ny < 2) return
+        ny_z = size(plot_data%z_grid, 1)
+        nx_z = size(plot_data%z_grid, 2)
+
+        nx_cells = min(nx, nx_z) - 1
+        ny_cells = min(ny, ny_z) - 1
+        if (nx_cells <= 0 .or. ny_cells <= 0) return
 
         eps_z = 1.0e-12_wp*max(1.0_wp, abs(z_max - z_min))
 
@@ -142,23 +147,23 @@ contains
                                          color)
             call backend%color(color(1), color(2), color(3))
 
-            do i = 1, nx - 1
-                do j = 1, ny - 1
-                    x1 = plot_data%x_grid(i)
-                    y1 = plot_data%y_grid(j)
-                    z1 = plot_data%z_grid(i, j)
+            do iy = 1, ny_cells
+                do ix = 1, nx_cells
+                    x1 = plot_data%x_grid(ix)
+                    y1 = plot_data%y_grid(iy)
+                    z1 = plot_data%z_grid(iy, ix)
 
-                    x2 = plot_data%x_grid(i + 1)
-                    y2 = plot_data%y_grid(j)
-                    z2 = plot_data%z_grid(i + 1, j)
+                    x2 = plot_data%x_grid(ix + 1)
+                    y2 = plot_data%y_grid(iy)
+                    z2 = plot_data%z_grid(iy, ix + 1)
 
-                    x3 = plot_data%x_grid(i + 1)
-                    y3 = plot_data%y_grid(j + 1)
-                    z3 = plot_data%z_grid(i + 1, j + 1)
+                    x3 = plot_data%x_grid(ix + 1)
+                    y3 = plot_data%y_grid(iy + 1)
+                    z3 = plot_data%z_grid(iy + 1, ix + 1)
 
-                    x4 = plot_data%x_grid(i)
-                    y4 = plot_data%y_grid(j + 1)
-                    z4 = plot_data%z_grid(i, j + 1)
+                    x4 = plot_data%x_grid(ix)
+                    y4 = plot_data%y_grid(iy + 1)
+                    z4 = plot_data%z_grid(iy + 1, ix)
 
                     xin(1:4) = [x1, x2, x3, x4]
                     yin(1:4) = [y1, y2, y3, y4]


### PR DESCRIPTION
Fixes the GitHub Pages deployment failure introduced on main.

## Problem
The 'Deploy Documentation to GitHub Pages' workflow is failing on main because `make example` crashes when running `contour_filled_demo` (out-of-bounds access in contourf fill renderer).

## Fix
- Correct contourf cell indexing (z_grid is (ny,nx); iterate safely over cell extents)
- Add missing FORD title metadata for doc/subplots_function.md

## Evidence
- Failing upstream run: gh run view 20408602987 --log (contour_filled_demo exit code 2)
- Local repro before fix: /tmp/fortplot_contour_filled_demo_local.log
- Local pass after fix: /tmp/fortplot_contour_filled_demo_local_after_fix.log
- Local docs build: /tmp/fortplot_make_doc_pages_fix.log
- Local examples run: /tmp/fortplot_make_example_pages_fix.log
- Local test-ci + verify-artifacts: /tmp/fortplot_test-ci_pages_fix.log and /tmp/fortplot_verify-artifacts_pages_fix.log
