### PR TITLE
fix: annotation styling parity (issue #1437)

### DIFF
--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -1,30 +1,43 @@
 module fortplot_raster
-    !! Main raster plotting context - reduced from 931 lines by extracting specialized modules
+    !! Main raster plotting context extracted into specialized modules
     use iso_c_binding
     use fortplot_context, only: plot_context, setup_canvas
     use fortplot_constants, only: EPSILON_COMPARE
-    use fortplot_text, only: render_text_to_image, calculate_text_width, calculate_text_height
+    use fortplot_text, only: render_text_to_image, render_text_with_size, &
+                             render_rotated_text_to_image, calculate_text_width, &
+                             calculate_text_width_with_size, calculate_text_height
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_unicode, only: escape_unicode_for_raster
     use fortplot_logging, only: log_error
     use fortplot_errors, only: fortplot_error_t, ERROR_INTERNAL
     use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, MARKER_DIAMOND, MARKER_CROSS
-    use fortplot_raster_drawing, only: draw_line_distance_aa, blend_pixel, distance_point_to_line_segment, &
+    use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, &
+                                MARKER_DIAMOND, MARKER_CROSS
+    use fortplot_raster_drawing, only: draw_line_distance_aa, blend_pixel, &
+                                       distance_point_to_line_segment, &
                                        ipart, fpart, rfpart, color_to_byte, &
-                                       draw_circle_antialiased, draw_circle_outline_antialiased, &
-                                       draw_circle_with_edge_face, draw_square_with_edge_face, &
+                                       draw_circle_antialiased, &
+                                       draw_circle_outline_antialiased, &
+                                       draw_circle_with_edge_face, &
+                                       draw_square_with_edge_face, &
                                        draw_diamond_with_edge_face, draw_x_marker
-    use fortplot_raster_line_styles, only: draw_styled_line, reset_pattern_distance, set_raster_line_style
-    use fortplot_raster_core, only: raster_image_t, create_raster_image, destroy_raster_image
+    use fortplot_raster_line_styles, only: draw_styled_line, reset_pattern_distance, &
+                                           set_raster_line_style
+    use fortplot_raster_core, only: raster_image_t, create_raster_image, &
+                                    destroy_raster_image
     use fortplot_raster_axes, only: raster_draw_axes_and_labels, raster_render_ylabel, &
-                                        raster_draw_axes_lines_and_ticks, raster_draw_axis_labels_only
+                                    raster_draw_axes_lines_and_ticks, &
+                                    raster_draw_axis_labels_only
     use fortplot_raster_labels, only: raster_draw_axis_labels
-    use fortplot_raster_rendering, only: raster_fill_heatmap, raster_fill_quad, fill_triangle, &
-                                        raster_render_legend_specialized, raster_calculate_legend_dimensions, &
-                                        raster_set_legend_border_width, raster_calculate_legend_position, &
-                                        raster_extract_rgb_data, raster_get_png_data, raster_prepare_3d_data
+    use fortplot_raster_rendering, only: raster_fill_heatmap, raster_fill_quad, &
+                                         fill_triangle, &
+                                         raster_render_legend_specialized, &
+                                         raster_calculate_legend_dimensions, &
+                                         raster_set_legend_border_width, &
+                                         raster_calculate_legend_position, &
+                                         raster_extract_rgb_data, raster_get_png_data, &
+                                         raster_prepare_3d_data
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -45,6 +58,7 @@ module fortplot_raster
         procedure :: line => raster_draw_line
         procedure :: color => raster_set_color_context
         procedure :: text => raster_draw_text
+        procedure :: draw_text_styled => raster_draw_text_styled
         procedure :: set_line_width => raster_set_line_width
         procedure :: set_line_style => raster_set_line_style_context
         procedure :: save => raster_save_dummy
@@ -58,16 +72,20 @@ module fortplot_raster
         procedure :: get_width_scale => raster_get_width_scale
         procedure :: get_height_scale => raster_get_height_scale
         procedure :: fill_heatmap => raster_fill_heatmap_context
-        procedure :: render_legend_specialized => raster_render_legend_specialized_context
-        procedure :: calculate_legend_dimensions => raster_calculate_legend_dimensions_context
+        procedure :: render_legend_specialized => &
+            raster_render_legend_specialized_context
+        procedure :: calculate_legend_dimensions => &
+            raster_calculate_legend_dimensions_context
         procedure :: set_legend_border_width => raster_set_legend_border_width_context
-        procedure :: calculate_legend_position_backend => raster_calculate_legend_position_context
+        procedure :: calculate_legend_position_backend => &
+            raster_calculate_legend_position_context
         procedure :: extract_rgb_data => raster_extract_rgb_data_context
         procedure :: get_png_data_backend => raster_get_png_data_context
         procedure :: prepare_3d_data => raster_prepare_3d_data_context
         procedure :: render_ylabel => raster_render_ylabel_context
         procedure :: draw_axes_and_labels_backend => raster_draw_axes_and_labels_context
-        procedure :: draw_axes_lines_and_ticks => raster_draw_axes_lines_and_ticks_context
+        procedure :: draw_axes_lines_and_ticks => &
+            raster_draw_axes_lines_and_ticks_context
         procedure :: draw_axis_labels_only => raster_draw_axis_labels_only_context
         procedure :: save_coordinates => raster_save_coordinates
         procedure :: set_coordinates => raster_set_coordinates
@@ -92,21 +110,26 @@ contains
         real(wp) :: px1, py1, px2, py2
         ! Transform coordinates to plot area (like matplotlib)
         ! Note: Raster Y=0 at top, so we need to flip Y coordinates
-        px1 = (x1 - this%x_min) / (this%x_max - this%x_min) * real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
+        px1 = (x1 - this%x_min)/(this%x_max - this%x_min)* &
+              real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
         py1 = real(this%plot_area%bottom + this%plot_area%height, wp) - &
-              (y1 - this%y_min) / (this%y_max - this%y_min) * real(this%plot_area%height, wp)
-        px2 = (x2 - this%x_min) / (this%x_max - this%x_min) * real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
+              (y1 - this%y_min)/(this%y_max - &
+                                 this%y_min)*real(this%plot_area%height, wp)
+        px2 = (x2 - this%x_min)/(this%x_max - this%x_min)* &
+              real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
         py2 = real(this%plot_area%bottom + this%plot_area%height, wp) - &
-              (y2 - this%y_min) / (this%y_max - this%y_min) * real(this%plot_area%height, wp)
+              (y2 - this%y_min)/(this%y_max - &
+                                 this%y_min)*real(this%plot_area%height, wp)
 
         ! Draw line with pattern support
         call draw_styled_line(this%raster%image_data, this%width, this%height, &
-                             px1, py1, px2, py2, &
-                             this%raster%current_r, this%raster%current_g, this%raster%current_b, &
-                             this%raster%current_line_width, &
-                             this%raster%line_style, this%raster%line_pattern, &
-                             this%raster%pattern_size, this%raster%pattern_length, &
-                             this%raster%pattern_distance)
+                              px1, py1, px2, py2, &
+                              this%raster%current_r, this%raster%current_g, &
+                              this%raster%current_b, &
+                              this%raster%current_line_width, &
+                              this%raster%line_style, this%raster%line_pattern, &
+                              this%raster%pattern_size, this%raster%pattern_length, &
+                              this%raster%pattern_distance)
     end subroutine raster_draw_line
 
     subroutine raster_set_color_context(this, r, g, b)
@@ -136,7 +159,7 @@ contains
         !! Set line style for raster context
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in) :: style
-        
+
         call this%raster%set_line_style(style)
     end subroutine raster_set_line_style_context
 
@@ -152,30 +175,123 @@ contains
         ! Process LaTeX commands
         call process_latex_in_text(text, processed_text, processed_len)
         ! Ensure mathtext gets parsed if superscripts/subscripts are present
-        call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+        call prepare_mathtext_if_needed(processed_text(1:processed_len), &
+                                        math_ready, math_len)
         ! Pass through Unicode (STB supports it)
         call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
 
         ! Transform coordinates to plot area (like matplotlib)
         ! Note: Raster Y=0 at top, so we need to flip Y coordinates
-        px = (x - this%x_min) / (this%x_max - this%x_min) * real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
+        px = (x - this%x_min)/(this%x_max - this%x_min)*real(this%plot_area%width, wp) &
+             + real(this%plot_area%left, wp)
         py = real(this%plot_area%bottom + this%plot_area%height, wp) - &
-             (y - this%y_min) / (this%y_max - this%y_min) * real(this%plot_area%height, wp)
+             (y - this%y_min)/(this%y_max - this%y_min)*real(this%plot_area%height, wp)
 
         call this%raster%get_color_bytes(r, g, b)
         call render_text_to_image(this%raster%image_data, this%width, this%height, &
-                                 int(px), int(py), trim(escaped_text), r, g, b)
+                                  int(px), int(py), trim(escaped_text), r, g, b)
     end subroutine raster_draw_text
+
+    subroutine raster_draw_text_styled(this, x_px, y_px, text, pixel_height, &
+                                       rotation, ha, va, bbox, color)
+        class(raster_context), intent(inout) :: this
+        real(wp), intent(in) :: x_px, y_px
+        character(len=*), intent(in) :: text
+        real(wp), intent(in) :: pixel_height
+        real(wp), intent(in) :: rotation
+        character(len=*), intent(in) :: ha, va
+        logical, intent(in) :: bbox
+        real(wp), intent(in) :: color(3)
+
+        integer :: x0, y0
+        integer :: text_w, text_h
+        integer(1) :: r, g, b
+        real(wp) :: w_px, h_px
+        real(wp) :: pad
+        real(wp) :: x1, y1, x2, y2, x3, y3, x4, y4
+        real(wp) :: cr, cg, cb
+
+        cr = max(0.0_wp, min(1.0_wp, color(1)))
+        cg = max(0.0_wp, min(1.0_wp, color(2)))
+        cb = max(0.0_wp, min(1.0_wp, color(3)))
+        r = int(nint(cr*255.0_wp), kind=1)
+        g = int(nint(cg*255.0_wp), kind=1)
+        b = int(nint(cb*255.0_wp), kind=1)
+
+        text_w = calculate_text_width_with_size(trim(text), pixel_height)
+        text_h = max(1, int(pixel_height))
+        w_px = real(text_w, wp)
+        h_px = real(text_h, wp)
+
+        x0 = int(nint(x_px))
+        y0 = int(nint(y_px))
+
+        select case (trim(ha))
+        case ('center')
+            x0 = x0 - int(nint(w_px/2.0_wp))
+        case ('right')
+            x0 = x0 - int(nint(w_px))
+        case default
+        end select
+
+        select case (trim(va))
+        case ('center')
+            y0 = y0 - int(nint(h_px/2.0_wp))
+        case ('bottom')
+            y0 = y0 - int(nint(h_px))
+        case default
+        end select
+
+        if (bbox) then
+            pad = max(2.0_wp, 0.2_wp*pixel_height)
+            x1 = real(x0, wp) - pad
+            y1 = real(y0, wp) - pad
+            x2 = real(x0, wp) + w_px + pad
+            y2 = y1
+            x3 = x2
+            y3 = real(y0, wp) + h_px + pad
+            x4 = x1
+            y4 = y3
+
+            call fill_triangle(this%raster%image_data, this%width, this%height, &
+                               x1, y1, x2, y2, x3, y3, -1_1, -1_1, -1_1)
+            call fill_triangle(this%raster%image_data, this%width, this%height, &
+                               x1, y1, x3, y3, x4, y4, -1_1, -1_1, -1_1)
+
+            call draw_line_distance_aa(this%raster%image_data, this%width, &
+                                       this%height, &
+                                       x1, y1, x2, y2, 0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp)
+            call draw_line_distance_aa(this%raster%image_data, this%width, &
+                                       this%height, x2, y2, x3, y3, 0.0_wp, &
+                                       0.0_wp, 0.0_wp, 1.0_wp)
+            call draw_line_distance_aa(this%raster%image_data, this%width, &
+                                       this%height, x3, y3, x4, y4, 0.0_wp, &
+                                       0.0_wp, 0.0_wp, 1.0_wp)
+            call draw_line_distance_aa(this%raster%image_data, this%width, &
+                                       this%height, &
+                                       x4, y4, x1, y1, 0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp)
+        end if
+
+        if (abs(rotation) > 1.0e-6_wp) then
+            call render_rotated_text_to_image(this%raster%image_data, this%width, &
+                                              this%height, x0, y0, trim(text), &
+                                              r, g, b, rotation, pixel_height)
+        else
+            call render_text_with_size(this%raster%image_data, this%width, &
+                                       this%height, x0, y0, trim(text), r, g, b, &
+                                       pixel_height)
+        end if
+    end subroutine raster_draw_text_styled
 
     subroutine raster_save_dummy(this, filename)
         !! Dummy save method - see issue #496 for implementation improvement roadmap
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in) :: filename
-        associate(dfl=>len_trim(filename)); end associate
-        
+        associate (dfl => len_trim(filename)); end associate
+
         ! This is a dummy implementation - concrete backends like PNG will override this
         ! Implementation improvement needed - see issue #496
-        call log_error("raster_context cannot save files directly. Use a concrete backend like PNG.")
+        call log_error("raster_context cannot save files directly. Use a PNG backend.")
         ! Return instead of stopping - this allows graceful error handling
         return
     end subroutine raster_save_dummy
@@ -186,12 +302,13 @@ contains
         character(len=*), intent(in) :: style
         real(wp) :: px, py
         integer(1) :: r, g, b
-        associate(dsl=>len_trim(style)); end associate
+        associate (dsl => len_trim(style)); end associate
 
         ! Transform coordinates to plot area
-        px = (x - this%x_min) / (this%x_max - this%x_min) * real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
+        px = (x - this%x_min)/(this%x_max - this%x_min)*real(this%plot_area%width, wp) &
+             + real(this%plot_area%left, wp)
         py = real(this%plot_area%bottom + this%plot_area%height, wp) - &
-             (y - this%y_min) / (this%y_max - this%y_min) * real(this%plot_area%height, wp)
+             (y - this%y_min)/(this%y_max - this%y_min)*real(this%plot_area%height, wp)
 
         call this%raster%get_color_bytes(r, g, b)
 
@@ -206,32 +323,53 @@ contains
         real(wp), intent(in) :: px, py
         character(len=*), intent(in) :: style
         real(wp) :: marker_size
-        
+
         marker_size = get_marker_size(style)
-        
+
         select case (trim(style))
         case (MARKER_CIRCLE)
-            call draw_circle_with_edge_face(this%raster%image_data, this%width, this%height, px, py, marker_size, &
-                                           this%raster%marker_edge_r, this%raster%marker_edge_g, this%raster%marker_edge_b, &
-                                           this%raster%marker_edge_alpha, this%raster%marker_face_r, this%raster%marker_face_g, &
-                                           this%raster%marker_face_b, this%raster%marker_face_alpha)
+            call draw_circle_with_edge_face(this%raster%image_data, this%width, &
+                                            this%height, px, py, marker_size, &
+                                            this%raster%marker_edge_r, &
+                                            this%raster%marker_edge_g, &
+                                            this%raster%marker_edge_b, &
+                                            this%raster%marker_edge_alpha, &
+                                            this%raster%marker_face_r, &
+                                            this%raster%marker_face_g, &
+                                            this%raster%marker_face_b, &
+                                            this%raster%marker_face_alpha)
         case (MARKER_SQUARE)
-            call draw_square_with_edge_face(this%raster%image_data, this%width, this%height, px, py, marker_size, &
-                                           this%raster%marker_edge_r, this%raster%marker_edge_g, this%raster%marker_edge_b, &
-                                           this%raster%marker_edge_alpha, this%raster%marker_face_r, this%raster%marker_face_g, &
-                                           this%raster%marker_face_b, this%raster%marker_face_alpha)
+            call draw_square_with_edge_face(this%raster%image_data, this%width, &
+                                            this%height, px, py, marker_size, &
+                                            this%raster%marker_edge_r, &
+                                            this%raster%marker_edge_g, &
+                                            this%raster%marker_edge_b, &
+                                            this%raster%marker_edge_alpha, &
+                                            this%raster%marker_face_r, &
+                                            this%raster%marker_face_g, &
+                                            this%raster%marker_face_b, &
+                                            this%raster%marker_face_alpha)
         case (MARKER_DIAMOND)
-            call draw_diamond_with_edge_face(this%raster%image_data, this%width, this%height, px, py, marker_size, &
-                                            this%raster%marker_edge_r, this%raster%marker_edge_g, this%raster%marker_edge_b, &
-                                            this%raster%marker_edge_alpha, this%raster%marker_face_r, this%raster%marker_face_g, &
-                                            this%raster%marker_face_b, this%raster%marker_face_alpha)
+            call draw_diamond_with_edge_face(this%raster%image_data, this%width, &
+                                             this%height, px, py, marker_size, &
+                                             this%raster%marker_edge_r, &
+                                             this%raster%marker_edge_g, &
+                                             this%raster%marker_edge_b, &
+                                             this%raster%marker_edge_alpha, &
+                                             this%raster%marker_face_r, &
+                                             this%raster%marker_face_g, &
+                                             this%raster%marker_face_b, &
+                                             this%raster%marker_face_alpha)
         case (MARKER_CROSS)
-            call draw_x_marker(this%raster%image_data, this%width, this%height, px, py, marker_size, &
-                               this%raster%marker_edge_r, this%raster%marker_edge_g, this%raster%marker_edge_b)
+            call draw_x_marker(this%raster%image_data, this%width, this%height, px, &
+                               py, marker_size, &
+                               this%raster%marker_edge_r, this%raster%marker_edge_g, &
+                               this%raster%marker_edge_b)
         end select
     end subroutine draw_raster_marker_by_style
 
-    subroutine raster_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, face_g, face_b)
+    subroutine raster_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, &
+                                        face_g, face_b)
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: edge_r, edge_g, edge_b
         real(wp), intent(in) :: face_r, face_g, face_b
@@ -246,7 +384,8 @@ contains
         this%raster%marker_face_alpha = 1.0_wp  ! Default to opaque
     end subroutine raster_set_marker_colors
 
-    subroutine raster_set_marker_colors_with_alpha(this, edge_r, edge_g, edge_b, edge_alpha, &
+    subroutine raster_set_marker_colors_with_alpha(this, edge_r, edge_g, edge_b, &
+                                                   edge_alpha, &
                                                    face_r, face_g, face_b, face_alpha)
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: edge_r, edge_g, edge_b, edge_alpha
@@ -266,9 +405,10 @@ contains
         !! Fill quadrilateral with current color - delegate to specialized module
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x_quad(4), y_quad(4)
-        
+
         call raster_fill_quad(this%raster, this%width, this%height, this%plot_area, &
-                              this%x_min, this%x_max, this%y_min, this%y_max, x_quad, y_quad)
+                              this%x_min, this%x_max, this%y_min, this%y_max, &
+                              x_quad, y_quad)
     end subroutine raster_fill_quad_context
 
     subroutine raster_draw_arrow(this, x, y, dx, dy, size, style)
@@ -276,7 +416,7 @@ contains
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x, y, dx, dy, size
         character(len=*), intent(in) :: style
-        
+
         real(wp) :: arrow_length, arrow_width, norm_dx, norm_dy
         real(wp) :: perp_x, perp_y  ! Perpendicular vector for arrow width
         real(wp) :: x1, y1, x2, y2, x3, y3  ! Triangle vertices
@@ -284,58 +424,60 @@ contains
         real(wp) :: magnitude
         integer(1) :: r, g, b
         real(wp) :: px, py, ddx, ddy
-        associate(dsl=>len_trim(style)); end associate
-        
+        associate (dsl => len_trim(style)); end associate
+
         ! Transform data coordinates to pixel coordinates
-        px = (x - this%x_min) / (this%x_max - this%x_min) * real(this%plot_area%width, wp) + real(this%plot_area%left, wp)
+        px = (x - this%x_min)/(this%x_max - this%x_min)*real(this%plot_area%width, wp) &
+             + real(this%plot_area%left, wp)
         py = real(this%plot_area%bottom + this%plot_area%height, wp) - &
-             (y - this%y_min) / (this%y_max - this%y_min) * real(this%plot_area%height, wp)
-        
+             (y - this%y_min)/(this%y_max - this%y_min)*real(this%plot_area%height, wp)
+
         ! Scale direction components to pixel units (account for inverted Y)
-        ddx = dx * ( real(this%plot_area%width, wp) / max(1.0_wp, (this%x_max - this%x_min)) )
-        ddy = -dy * ( real(this%plot_area%height, wp) / max(1.0_wp, (this%y_max - this%y_min)) )
-        
+        ddx = dx*(real(this%plot_area%width, wp)/max(1.0_wp, (this%x_max - this%x_min)))
+        ddy = -dy*(real(this%plot_area%height, wp)/max(1.0_wp, (this%y_max - &
+                                                                this%y_min)))
+
         ! Normalize direction vector
         magnitude = sqrt(ddx*ddx + ddy*ddy)
         if (magnitude < 1e-10_wp) return  ! Avoid division by zero
-        
-        norm_dx = ddx / magnitude
-        norm_dy = ddy / magnitude
-        
+
+        norm_dx = ddx/magnitude
+        norm_dy = ddy/magnitude
+
         ! Calculate arrow dimensions based on size
-        arrow_length = size * 8.0_wp  ! Scale factor for reasonable arrow size
-        arrow_width = arrow_length * 0.5_wp
-        
+        arrow_length = size*8.0_wp  ! Scale factor for reasonable arrow size
+        arrow_width = arrow_length*0.5_wp
+
         ! Calculate perpendicular vector for arrow width
         perp_x = -norm_dy
         perp_y = norm_dx
-        
+
         ! Calculate triangle vertices for arrow head (tip at pixel coords)
         x1 = px
         y1 = py
-        
+
         ! Base vertices of arrow head
-        x2 = px - arrow_length * norm_dx + arrow_width * perp_x
-        y2 = py - arrow_length * norm_dy + arrow_width * perp_y
+        x2 = px - arrow_length*norm_dx + arrow_width*perp_x
+        y2 = py - arrow_length*norm_dy + arrow_width*perp_y
 
-        x3 = px - arrow_length * norm_dx - arrow_width * perp_x
-        y3 = py - arrow_length * norm_dy - arrow_width * perp_y
+        x3 = px - arrow_length*norm_dx - arrow_width*perp_x
+        y3 = py - arrow_length*norm_dy - arrow_width*perp_y
 
-        shaft_base_x = px - arrow_length * norm_dx
-        shaft_base_y = py - arrow_length * norm_dy
+        shaft_base_x = px - arrow_length*norm_dx
+        shaft_base_y = py - arrow_length*norm_dy
 
         ! Get current color for filling
         call this%raster%get_color_bytes(r, g, b)
 
         call draw_line_distance_aa(this%raster%image_data, this%width, this%height, &
                                    shaft_base_x, shaft_base_y, px, py, &
-                                   real(r, wp) / 255.0_wp, real(g, wp) / 255.0_wp, &
-                                   real(b, wp) / 255.0_wp, 1.0_wp)
+                                   real(r, wp)/255.0_wp, real(g, wp)/255.0_wp, &
+                                   real(b, wp)/255.0_wp, 1.0_wp)
 
         ! Draw filled triangle arrow head
         call fill_triangle(this%raster%image_data, this%width, this%height, &
-                          x1, y1, x2, y2, x3, y3, r, g, b)
-        
+                           x1, y1, x2, y2, x3, y3, r, g, b)
+
         ! Mark that arrows have been rendered
         this%has_rendered_arrows = .true.
         this%uses_vector_arrows = .false.
@@ -346,7 +488,7 @@ contains
         !! Get ASCII output (not applicable for raster backend)
         class(raster_context), intent(in) :: this
         character(len=:), allocatable :: output
-        
+
         output = ""  ! Raster backend doesn't produce ASCII output
     end function raster_get_ascii_output
 
@@ -354,23 +496,23 @@ contains
         !! Get width scaling factor for coordinate transformation
         class(raster_context), intent(in) :: this
         real(wp) :: scale
-        
+
         ! Calculate scaling from logical to pixel coordinates
         if (this%width > 0 .and. this%x_max > this%x_min) then
-            scale = real(this%width, wp) / (this%x_max - this%x_min)
+            scale = real(this%width, wp)/(this%x_max - this%x_min)
         else
             scale = 1.0_wp
         end if
     end function raster_get_width_scale
 
     function raster_get_height_scale(this) result(scale)
-        !! Get height scaling factor for coordinate transformation  
+        !! Get height scaling factor for coordinate transformation
         class(raster_context), intent(in) :: this
         real(wp) :: scale
-        
+
         ! Calculate scaling from logical to pixel coordinates
         if (this%height > 0 .and. this%y_max > this%y_min) then
-            scale = real(this%height, wp) / (this%y_max - this%y_min)
+            scale = real(this%height, wp)/(this%y_max - this%y_min)
         else
             scale = 1.0_wp
         end if
@@ -379,35 +521,37 @@ contains
     subroutine raster_fill_heatmap_context(this, x_grid, y_grid, z_grid, z_min, z_max)
         !! Fill contour plot - delegate to specialized rendering module
         class(raster_context), intent(inout) :: this
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:,:)
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
-        
+
         call raster_fill_heatmap(this%raster, this%width, this%height, this%plot_area, &
-                                this%x_min, this%x_max, this%y_min, this%y_max, &
-                                x_grid, y_grid, z_grid, z_min, z_max)
+                                 this%x_min, this%x_max, this%y_min, this%y_max, &
+                                 x_grid, y_grid, z_grid, z_min, z_max)
     end subroutine raster_fill_heatmap_context
 
-    subroutine raster_render_legend_specialized_context(this, legend, legend_x, legend_y)
+    subroutine raster_render_legend_specialized_context(this, legend, &
+                                                        legend_x, legend_y)
         use fortplot_legend, only: legend_t
         class(raster_context), intent(inout) :: this
         type(legend_t), intent(in) :: legend
         real(wp), intent(in) :: legend_x, legend_y
-        
+
         call raster_render_legend_specialized(legend, legend_x, legend_y)
     end subroutine raster_render_legend_specialized_context
 
-    subroutine raster_calculate_legend_dimensions_context(this, legend, legend_width, legend_height)
+    subroutine raster_calculate_legend_dimensions_context(this, legend, legend_width, &
+                                                          legend_height)
         use fortplot_legend, only: legend_t
         class(raster_context), intent(in) :: this
         type(legend_t), intent(in) :: legend
         real(wp), intent(out) :: legend_width, legend_height
-        
+
         call raster_calculate_legend_dimensions(legend, legend_width, legend_height)
     end subroutine raster_calculate_legend_dimensions_context
 
     subroutine raster_set_legend_border_width_context(this)
         class(raster_context), intent(inout) :: this
-        
+
         call this%set_line_width(0.1_wp)  ! Thin border for PNG like axes
     end subroutine raster_set_legend_border_width_context
 
@@ -416,7 +560,7 @@ contains
         class(raster_context), intent(in) :: this
         type(legend_t), intent(in) :: legend
         real(wp), intent(out) :: x, y
-        
+
         call raster_calculate_legend_position(legend, x, y)
     end subroutine raster_calculate_legend_position_context
 
@@ -424,7 +568,7 @@ contains
         class(raster_context), intent(in) :: this
         integer, intent(in) :: width, height
         real(wp), intent(out) :: rgb_data(width, height, 3)
-        
+
         call raster_extract_rgb_data(this%raster, width, height, rgb_data)
     end subroutine raster_extract_rgb_data_context
 
@@ -433,7 +577,7 @@ contains
         integer, intent(in) :: width, height
         integer(1), allocatable, intent(out) :: png_data(:)
         integer, intent(out) :: status
-        
+
         call raster_get_png_data(width, height, png_data, status)
     end subroutine raster_get_png_data_context
 
@@ -441,7 +585,7 @@ contains
         use fortplot_plot_data, only: plot_data_t
         class(raster_context), intent(inout) :: this
         type(plot_data_t), intent(in) :: plots(:)
-        
+
         call raster_prepare_3d_data(plots)
     end subroutine raster_prepare_3d_data_context
 
@@ -449,11 +593,13 @@ contains
         !! Render rotated Y-axis label - delegate to axes module
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in) :: ylabel
-        
-        call raster_render_ylabel(this%raster, this%width, this%height, this%plot_area, ylabel)
+
+        call raster_render_ylabel(this%raster, this%width, this%height, &
+                                  this%plot_area, ylabel)
     end subroutine raster_render_ylabel_context
 
-    subroutine raster_draw_axes_and_labels_context(this, xscale, yscale, symlog_threshold, &
+    subroutine raster_draw_axes_and_labels_context(this, xscale, yscale, &
+                                                   symlog_threshold, &
                                                    x_min, x_max, y_min, y_max, &
                                                    title, xlabel, ylabel, &
                                                    z_min, z_max, has_3d_plots)
@@ -492,15 +638,17 @@ contains
                     if (allocated(ylabel)) ylabel_str = ylabel
                 end if
 
-                call raster_draw_axis_labels(this%raster, this%width, this%height, this%plot_area, &
+                call raster_draw_axis_labels(this%raster, this%width, this%height, &
+                                             this%plot_area, &
                                              title_str, xlabel_str, ylabel_str)
             end if
         else
             ! Delegate to standard 2D axes module
-            call raster_draw_axes_and_labels(this%raster, this%width, this%height, this%plot_area, &
-                                            xscale, yscale, symlog_threshold, &
-                                            x_min, x_max, y_min, y_max, &
-                                            title, xlabel, ylabel)
+            call raster_draw_axes_and_labels(this%raster, this%width, this%height, &
+                                             this%plot_area, &
+                                             xscale, yscale, symlog_threshold, &
+                                             x_min, x_max, y_min, y_max, &
+                                             title, xlabel, ylabel)
         end if
     end subroutine raster_draw_axes_and_labels_context
 
@@ -508,7 +656,7 @@ contains
         !! Save current coordinate system
         class(raster_context), intent(in) :: this
         real(wp), intent(out) :: x_min, x_max, y_min, y_max
-        
+
         x_min = this%x_min
         x_max = this%x_max
         y_min = this%y_min
@@ -519,7 +667,7 @@ contains
         !! Set coordinate system
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
-        
+
         this%x_min = x_min
         this%x_max = x_max
         this%y_min = y_min
@@ -530,49 +678,53 @@ contains
         !! Render axes for raster context - see issue #495 for implementation roadmap
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
-        if (present(title_text)) then; associate(dt=>len_trim(title_text)); end associate; end if
-        if (present(xlabel_text)) then; associate(dx=>len_trim(xlabel_text)); end associate; end if
-        if (present(ylabel_text)) then; associate(dy=>len_trim(ylabel_text)); end associate; end if
-        
+        if (present(title_text)) then; associate (dt => len_trim(title_text)); end associate; end if
+        if (present(xlabel_text)) then; associate (dx => len_trim(xlabel_text)); end associate; end if
+        if (present(ylabel_text)) then; associate (dy => len_trim(ylabel_text)); end associate; end if
+
         ! Raster axes are rendered as part of draw_axes_and_labels_backend
         ! Implementation needed - see issue #495
     end subroutine raster_render_axes
 
-    subroutine raster_draw_axes_lines_and_ticks_context(this, xscale, yscale, symlog_threshold, &
-                                                       x_min, x_max, y_min, y_max)
+    subroutine raster_draw_axes_lines_and_ticks_context(this, xscale, yscale, &
+                                                        symlog_threshold, &
+                                                        x_min, x_max, y_min, y_max)
         !! Draw axes lines and tick marks WITHOUT labels (for proper drawing order)
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
-        
+
         ! Set color to black for axes and ticks
         call this%color(0.0_wp, 0.0_wp, 0.0_wp)
-        
+
         ! Delegate to axes module
-        call raster_draw_axes_lines_and_ticks(this%raster, this%width, this%height, this%plot_area, &
-                                            xscale, yscale, symlog_threshold, &
-                                            x_min, x_max, y_min, y_max)
+        call raster_draw_axes_lines_and_ticks(this%raster, this%width, this%height, &
+                                              this%plot_area, &
+                                              xscale, yscale, symlog_threshold, &
+                                              x_min, x_max, y_min, y_max)
     end subroutine raster_draw_axes_lines_and_ticks_context
 
-    subroutine raster_draw_axis_labels_only_context(this, xscale, yscale, symlog_threshold, &
-                                                   x_min, x_max, y_min, y_max, &
-                                                   title, xlabel, ylabel)
+    subroutine raster_draw_axis_labels_only_context(this, xscale, yscale, &
+                                                    symlog_threshold, &
+                                                    x_min, x_max, y_min, y_max, &
+                                                    title, xlabel, ylabel)
         !! Draw ONLY axis labels and tick labels (for proper drawing order)
         class(raster_context), intent(inout) :: this
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         character(len=:), allocatable, intent(in), optional :: title, xlabel, ylabel
-        
+
         ! Set color to black for text
         call this%color(0.0_wp, 0.0_wp, 0.0_wp)
-        
+
         ! Delegate to axes module
-        call raster_draw_axis_labels_only(this%raster, this%width, this%height, this%plot_area, &
-                                        xscale, yscale, symlog_threshold, &
-                                        x_min, x_max, y_min, y_max, &
-                                        title, xlabel, ylabel)
+        call raster_draw_axis_labels_only(this%raster, this%width, this%height, &
+                                          this%plot_area, &
+                                          xscale, yscale, symlog_threshold, &
+                                          x_min, x_max, y_min, y_max, &
+                                          title, xlabel, ylabel)
     end subroutine raster_draw_axis_labels_only_context
 
 end module fortplot_raster

--- a/src/backends/raster/fortplot_raster_text_rendering.f90
+++ b/src/backends/raster/fortplot_raster_text_rendering.f90
@@ -1,15 +1,16 @@
 module fortplot_raster_text_rendering
     !! Raster-specific text rendering primitives (glyph rasterization, mathtext drawing)
     use iso_c_binding, only: c_ptr, c_f_pointer, c_int8_t, &
-                                 c_associated
+                             c_associated
     use fortplot_stb_truetype
     use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
     use fortplot_text_fonts, only: init_text_system, get_global_font, get_font_scale, &
-                                  is_font_initialized, get_font_scale_for_size, &
-                                  get_font_metrics
+                                   is_font_initialized, get_font_scale_for_size, &
+                                   get_font_metrics
     use fortplot_mathtext, only: parse_mathtext, mathtext_element_t
     use fortplot_raster_primitives, only: draw_line_distance_aa
-    use fortplot_text_layout, only: has_mathtext, preprocess_math_text, calculate_mathtext_width_internal, &
+    use fortplot_text_layout, only: has_mathtext, preprocess_math_text, &
+                                    calculate_mathtext_width_internal, &
                                     calculate_text_width_with_size_internal, &
                                     calculate_text_height_with_size_internal, &
                                     DEFAULT_FONT_SIZE
@@ -52,7 +53,8 @@ contains
             call preprocess_math_text(text, processed, plen)
             elements = parse_mathtext(processed(1:plen))
             call render_mathtext_elements_internal(image_data, width, height, x, y, &
-                elements, r, g, b, real(DEFAULT_FONT_SIZE, wp))
+                                                   elements, r, g, b, &
+                                                   real(DEFAULT_FONT_SIZE, wp))
             return
         end if
 
@@ -74,23 +76,24 @@ contains
             end if
 
             bitmap_ptr = stb_get_codepoint_bitmap(font, scale, scale, char_code, &
-                                                 bmp_width, bmp_height, xoff, yoff)
+                                                  bmp_width, bmp_height, xoff, yoff)
 
             if (c_associated(bitmap_ptr)) then
                 call render_stb_glyph(image_data, width, height, pen_x, pen_y, &
-                    bitmap_ptr, bmp_width, bmp_height, xoff, yoff, r, g, &
-                                     b)
+                                      bitmap_ptr, bmp_width, bmp_height, xoff, &
+                                      yoff, r, g, &
+                                      b)
                 call stb_free_bitmap(bitmap_ptr)
             end if
 
             call stb_get_codepoint_hmetrics(font, char_code, advance_width, &
-                left_side_bearing)
-            pen_x = pen_x + int(real(advance_width) * scale)
+                                            left_side_bearing)
+            pen_x = pen_x + int(real(advance_width)*scale)
         end do
     end subroutine render_text_to_image
 
     subroutine render_text_with_size(image_data, width, height, x, y, text, &
-            r, g, b, pixel_height)
+                                     r, g, b, pixel_height)
         !! Render text with specific font size
         !! Supports mathematical notation with superscripts and subscripts
         integer(1), intent(inout) :: image_data(:)
@@ -119,7 +122,7 @@ contains
             call preprocess_math_text(text, processed, plen)
             elements = parse_mathtext(processed(1:plen))
             call render_mathtext_elements_internal(image_data, width, height, x, y, &
-                elements, r, g, b, pixel_height)
+                                                   elements, r, g, b, pixel_height)
             return
         end if
 
@@ -141,29 +144,31 @@ contains
             end if
 
             bitmap_ptr = stb_get_codepoint_bitmap(font, scale, scale, char_code, &
-                                                 bmp_width, bmp_height, xoff, yoff)
+                                                  bmp_width, bmp_height, xoff, yoff)
 
             if (c_associated(bitmap_ptr)) then
                 call render_stb_glyph(image_data, width, height, pen_x, pen_y, &
-                    bitmap_ptr, bmp_width, bmp_height, xoff, yoff, r, g, &
-                    b)
+                                      bitmap_ptr, bmp_width, bmp_height, xoff, &
+                                      yoff, r, g, &
+                                      b)
                 call stb_free_bitmap(bitmap_ptr)
             end if
 
             call stb_get_codepoint_hmetrics(font, char_code, advance_width, &
-                left_side_bearing)
-            pen_x = pen_x + int(real(advance_width) * scale)
+                                            left_side_bearing)
+            pen_x = pen_x + int(real(advance_width)*scale)
         end do
     end subroutine render_text_with_size
 
     subroutine render_rotated_text_to_image(image_data, width, height, x, y, text, &
-            r, g, b, angle)
+                                            r, g, b, angle, pixel_height)
         !! Render rotated text to PNG image using STB TrueType with UTF-8 support
         integer(1), intent(inout) :: image_data(:)
         integer, intent(in) :: width, height, x, y
         character(len=*), intent(in) :: text
         integer(1), intent(in) :: r, g, b
         real(wp), intent(in) :: angle  ! Rotation angle in degrees
+        real(wp), intent(in), optional :: pixel_height
 
         integer :: i, char_code, pen_x, pen_y
         integer :: advance_width, left_side_bearing
@@ -182,11 +187,14 @@ contains
 
         font = get_global_font()
         scale = get_font_scale()
+        if (present(pixel_height)) then
+            scale = get_font_scale_for_size(pixel_height)
+        end if
 
         pen_x = x
         pen_y = y
-        cos_a = cos(angle * PI / 180.0_wp)
-        sin_a = sin(angle * PI / 180.0_wp)
+        cos_a = cos(angle*PI/180.0_wp)
+        sin_a = sin(angle*PI/180.0_wp)
 
         i = 1
         do while (i <= len_trim(text))
@@ -200,24 +208,26 @@ contains
             end if
 
             bitmap_ptr = stb_get_codepoint_bitmap(font, scale, scale, char_code, &
-                                                 bmp_width, bmp_height, xoff, yoff)
+                                                  bmp_width, bmp_height, xoff, yoff)
 
             if (c_associated(bitmap_ptr)) then
                 call render_stb_glyph(image_data, width, height, pen_x, pen_y, &
-                    bitmap_ptr, bmp_width, bmp_height, xoff, yoff, r, g, &
-                                     b)
+                                      bitmap_ptr, bmp_width, bmp_height, xoff, &
+                                      yoff, r, g, &
+                                      b)
                 call stb_free_bitmap(bitmap_ptr)
             end if
 
             call stb_get_codepoint_hmetrics(font, char_code, advance_width, &
-                left_side_bearing)
-            pen_x = pen_x + int(real(advance_width) * scale * cos_a)
-            pen_y = pen_y + int(real(advance_width) * scale * sin_a)
+                                            left_side_bearing)
+            pen_x = pen_x + int(real(advance_width)*scale*cos_a)
+            pen_y = pen_y + int(real(advance_width)*scale*sin_a)
         end do
     end subroutine render_rotated_text_to_image
 
     recursive subroutine render_mathtext_elements_internal(image_data, width, &
-            height, x, y, elements, r, g, b, base_font_size)
+                                                           height, x, y, elements, r, &
+                                                           g, b, base_font_size)
         !! Render mathematical text elements to image for the raster backend
         integer(1), intent(inout) :: image_data(:)
         integer, intent(in) :: width, height, x, y
@@ -230,6 +240,7 @@ contains
         integer :: rad_width, sym_w, rad_height, top_y
         real(wp) :: ascent, descent, line_gap
         logical :: success
+        type(mathtext_element_t), allocatable :: rad_elements(:)
 
         pen_x = x
         pen_y = y
@@ -238,45 +249,58 @@ contains
         if (.not. success) return
 
         do i = 1, size(elements)
-            element_font_size = base_font_size * elements(i)%font_size_ratio
+            element_font_size = base_font_size*elements(i)%font_size_ratio
 
             if (elements(i)%element_type == 3) then
                 pen_y = y
 
-                rad_width = calculate_mathtext_width_internal(&
-                    parse_mathtext(elements(i)%text), element_font_size)
+                rad_elements = parse_mathtext(elements(i)%text)
+                rad_width = calculate_mathtext_width_internal(rad_elements, &
+                                                              element_font_size)
                 rad_height = calculate_text_height_with_size_internal(element_font_size)
-                sym_w = int(0.6_wp * element_font_size)
+                sym_w = int(0.6_wp*element_font_size)
                 top_y = pen_y - rad_height
                 call draw_line_distance_aa(image_data, width, height, &
-                    real(pen_x, wp), real(pen_y, wp), real(pen_x + sym_w/2, wp), &
-                    real(pen_y + sym_w/2, wp), real(r, wp)/255.0_wp, &
-                    real(g, wp)/255.0_wp, real(b, wp)/255.0_wp, 0.1_wp)
+                                           real(pen_x, wp), real(pen_y, wp), &
+                                           real(pen_x + sym_w/2, wp), &
+                                           real(pen_y + sym_w/2, wp), &
+                                           real(r, wp)/255.0_wp, &
+                                           real(g, wp)/255.0_wp, &
+                                           real(b, wp)/255.0_wp, 0.1_wp)
                 call draw_line_distance_aa(image_data, width, height, &
-                    real(pen_x + sym_w/2, wp), real(pen_y + sym_w/2, wp), &
-                    real(pen_x + sym_w, wp), real(top_y, wp), real(r, wp)/255.0_wp, &
-                    real(g, wp)/255.0_wp, real(b, wp)/255.0_wp, 0.1_wp)
+                                           real(pen_x + sym_w/2, wp), &
+                                           real(pen_y + sym_w/2, wp), &
+                                           real(pen_x + sym_w, wp), &
+                                           real(top_y, wp), &
+                                           real(r, wp)/255.0_wp, &
+                                           real(g, wp)/255.0_wp, &
+                                           real(b, wp)/255.0_wp, 0.1_wp)
                 call draw_line_distance_aa(image_data, width, height, &
-                    real(pen_x + sym_w, wp), real(top_y, wp), &
-                    real(pen_x + sym_w + rad_width, wp), real(top_y, wp), &
-                    real(r, wp)/255.0_wp, real(g, wp)/255.0_wp, real(b, wp)/255.0_wp, &
-                    0.1_wp)
+                                           real(pen_x + sym_w, wp), &
+                                           real(top_y, wp), &
+                                           real(pen_x + sym_w + rad_width, wp), &
+                                           real(top_y, wp), &
+                                           real(r, wp)/255.0_wp, &
+                                           real(g, wp)/255.0_wp, &
+                                           real(b, wp)/255.0_wp, 0.1_wp)
                 call render_mathtext_elements_internal(image_data, width, height, &
-                    pen_x + sym_w, pen_y, parse_mathtext(elements(i)%text), r, g, &
-                    b, element_font_size)
+                                                       pen_x + sym_w, pen_y, &
+                                                       rad_elements, r, g, b, &
+                                                       element_font_size)
                 pen_x = pen_x + sym_w + rad_width
             else
-                pen_y = y - int(elements(i)%vertical_offset * base_font_size)
+                pen_y = y - int(elements(i)%vertical_offset*base_font_size)
                 call render_text_with_size_internal(image_data, width, height, &
-                    pen_x, pen_y, elements(i)%text, r, g, b, element_font_size)
-                pen_x = pen_x + calculate_text_width_with_size_internal(&
-                    elements(i)%text, element_font_size)
+                                                    pen_x, pen_y, elements(i)%text, r, &
+                                                    g, b, element_font_size)
+                pen_x = pen_x + calculate_text_width_with_size_internal( &
+                        elements(i)%text, element_font_size)
             end if
         end do
     end subroutine render_mathtext_elements_internal
 
     subroutine render_text_with_size_internal(image_data, width, height, x, y, text, &
-            r, g, b, pixel_height)
+                                              r, g, b, pixel_height)
         !! Internal text rendering helper to avoid circular dependencies
         integer(1), intent(inout) :: image_data(:)
         integer, intent(in) :: width, height, x, y
@@ -315,18 +339,19 @@ contains
             end if
 
             bitmap_ptr = stb_get_codepoint_bitmap(font, scale, scale, char_code, &
-                                                 bmp_width, bmp_height, xoff, yoff)
+                                                  bmp_width, bmp_height, xoff, yoff)
 
             if (c_associated(bitmap_ptr)) then
                 call render_stb_glyph(image_data, width, height, pen_x, pen_y, &
-                    bitmap_ptr, bmp_width, bmp_height, xoff, yoff, r, g, &
-                    b)
+                                      bitmap_ptr, bmp_width, bmp_height, xoff, &
+                                      yoff, r, g, &
+                                      b)
                 call stb_free_bitmap(bitmap_ptr)
             end if
 
             call stb_get_codepoint_hmetrics(font, char_code, advance_width, &
-                left_side_bearing)
-            pen_x = pen_x + int(real(advance_width) * scale)
+                                            left_side_bearing)
+            pen_x = pen_x + int(real(advance_width)*scale)
         end do
     end subroutine render_text_with_size_internal
 
@@ -347,7 +372,7 @@ contains
             return
         end if
 
-        call c_f_pointer(bitmap_ptr, bitmap_buffer, [bmp_width * bmp_height])
+        call c_f_pointer(bitmap_ptr, bitmap_buffer, [bmp_width*bmp_height])
 
         glyph_x = pen_x + xoff
         glyph_y = pen_y + yoff
@@ -359,33 +384,38 @@ contains
 
                 if (img_x >= 0 .and. img_x < width .and. img_y >= 0 .and. &
                     img_y < height) then
-                    alpha_int = int(bitmap_buffer(row * bmp_width + col + 1))
+                    alpha_int = int(bitmap_buffer(row*bmp_width + col + 1))
                     if (alpha_int < 0) alpha_int = alpha_int + 256
 
                     if (alpha_int > 0) then
-                        pixel_idx = (img_y * width + img_x) * 3 + 1
+                        pixel_idx = (img_y*width + img_x)*3 + 1
 
-                        if (pixel_idx < 1 .or. pixel_idx + 2 > width * height * 3) then
+                        if (pixel_idx < 1 .or. pixel_idx + 2 > width*height*3) then
                             cycle
                         end if
 
-                        alpha_f = real(alpha_int) / 255.0
+                        alpha_f = real(alpha_int)/255.0
                         bg_r = real(int(image_data(pixel_idx), &
-                            kind=selected_int_kind(2)) + &
-                            merge(256, 0, image_data(pixel_idx) < 0))
+                                        kind=selected_int_kind(2)) + &
+                                    merge(256, 0, image_data(pixel_idx) < 0))
                         bg_g = real(int(image_data(pixel_idx + 1), &
-                            kind=selected_int_kind(2)) + &
-                            merge(256, 0, image_data(pixel_idx + 1) < 0))
+                                        kind=selected_int_kind(2)) + &
+                                    merge(256, 0, image_data(pixel_idx + 1) < 0))
                         bg_b = real(int(image_data(pixel_idx + 2), &
-                            kind=selected_int_kind(2)) + &
-                            merge(256, 0, image_data(pixel_idx + 2) < 0))
+                                        kind=selected_int_kind(2)) + &
+                                    merge(256, 0, image_data(pixel_idx + 2) < 0))
 
-                        image_data(pixel_idx) = int(bg_r * (1.0 - alpha_f) + &
-                            real(int(r) + merge(256, 0, r < 0)) * alpha_f, 1)
-                        image_data(pixel_idx + 1) = int(bg_g * (1.0 - alpha_f) + &
-                            real(int(g) + merge(256, 0, g < 0)) * alpha_f, 1)
-                        image_data(pixel_idx + 2) = int(bg_b * (1.0 - alpha_f) + &
-                            real(int(b) + merge(256, 0, b < 0)) * alpha_f, 1)
+                        image_data(pixel_idx) = int(bg_r*(1.0 - alpha_f) + &
+                                                    real(int(r) + merge(256, 0, r < &
+                                                                        0))*alpha_f, 1)
+                        image_data(pixel_idx + 1) = int(bg_g*(1.0_wp - alpha_f) + &
+                                                        real(int(g) + &
+                                                             merge(256, 0, g < 0))* &
+                                                        alpha_f, 1)
+                        image_data(pixel_idx + 2) = int(bg_b*(1.0_wp - alpha_f) + &
+                                                        real(int(b) + &
+                                                             merge(256, 0, b < 0))* &
+                                                        alpha_f, 1)
                     end if
                 end if
             end do
@@ -398,12 +428,12 @@ contains
         integer(1), intent(in) :: r, g, b
         integer :: pixel_idx, img_x, img_y, max_idx
 
-        max_idx = width * height * 3
+        max_idx = width*height*3
 
         do img_y = y, min(y + 6, height - 1)
             do img_x = x, min(x + 4, width - 1)
                 if (img_x >= 0 .and. img_y >= 0) then
-                    pixel_idx = (img_y * width + img_x) * 3 + 1
+                    pixel_idx = (img_y*width + img_x)*3 + 1
                     if (pixel_idx > 0 .and. pixel_idx <= max_idx - 2) then
                         image_data(pixel_idx) = r
                         image_data(pixel_idx + 1) = g

--- a/src/backends/vector/fortplot_pdf_text_render.f90
+++ b/src/backends/vector/fortplot_pdf_text_render.f90
@@ -3,10 +3,11 @@ module fortplot_pdf_text_render
 
     use iso_fortran_env, only: wp => real64
     use fortplot_pdf_core, only: pdf_context_core, PDF_FONT_SIZE, &
-        PDF_LABEL_SIZE, PDF_TITLE_SIZE
+                                 PDF_LABEL_SIZE, PDF_TITLE_SIZE
     use fortplot_pdf_text_escape, only: escape_pdf_string
     use fortplot_pdf_text_segments, only: process_text_segments, &
-        process_rotated_text_segments, render_mixed_font_at_position
+                                          process_rotated_text_segments, &
+                                          render_mixed_font_at_position
     implicit none
     private
 
@@ -26,23 +27,23 @@ contains
         character(len=1024) :: text_cmd
         integer :: escaped_len
 
-        allocate(character(len=len(text) * 6) :: escaped_text)
+        allocate (character(len=len(text)*6) :: escaped_text)
         call escape_pdf_string(text, escaped_text, escaped_len)
 
-        this%stream_data = this%stream_data // 'BT' // new_line('a')
+        this%stream_data = this%stream_data//'BT'//new_line('a')
 
-        write(text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+        write (text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
             this%fonts%get_helvetica_obj(), PDF_FONT_SIZE
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
-        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
+        write (text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
             x, y
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
-        this%stream_data = this%stream_data // '(' // escaped_text(1:escaped_len) // &
-            ') Tj' // new_line('a')
+        this%stream_data = this%stream_data//'('//escaped_text(1:escaped_len)// &
+                           ') Tj'//new_line('a')
 
-        this%stream_data = this%stream_data // 'ET' // new_line('a')
+        this%stream_data = this%stream_data//'ET'//new_line('a')
     end subroutine draw_pdf_text
 
     subroutine draw_mixed_font_text(this, x, y, text, font_size)
@@ -58,43 +59,47 @@ contains
         fs = PDF_LABEL_SIZE
         if (present(font_size)) fs = font_size
 
-        this%stream_data = this%stream_data // 'BT' // new_line('a')
+        this%stream_data = this%stream_data//'BT'//new_line('a')
 
-        write(text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+        write (text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
             this%fonts%get_helvetica_obj(), fs
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
-        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
+        write (text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
             x, y
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
         call process_text_segments(this, text, in_symbol_font, fs)
 
-        this%stream_data = this%stream_data // 'ET' // new_line('a')
+        this%stream_data = this%stream_data//'ET'//new_line('a')
     end subroutine draw_mixed_font_text
 
-    subroutine draw_rotated_mixed_font_text(this, x, y, text, font_size)
+    subroutine draw_rotated_mixed_font_text(this, x, y, text, font_size, angle_deg)
         class(pdf_context_core), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
         real(wp), intent(in), optional :: font_size
+        real(wp), intent(in), optional :: angle_deg
         character(len=1024) :: font_cmd
         real(wp) :: fs
+        real(wp) :: angle
 
         fs = PDF_LABEL_SIZE
         if (present(font_size)) fs = font_size
+        angle = 90.0_wp
+        if (present(angle_deg)) angle = angle_deg
 
-        this%stream_data = this%stream_data // 'BT' // new_line('a')
+        this%stream_data = this%stream_data//'BT'//new_line('a')
 
-        write(font_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+        write (font_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
             this%fonts%get_helvetica_obj(), fs
-        this%stream_data = this%stream_data // trim(adjustl(font_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(font_cmd))//new_line('a')
 
-        call setup_rotated_text_matrix(this, x, y)
+        call setup_rotated_text_matrix(this, x, y, angle)
 
         call process_rotated_text_segments(this, text, fs)
 
-        this%stream_data = this%stream_data // 'ET' // new_line('a')
+        this%stream_data = this%stream_data//'ET'//new_line('a')
     end subroutine draw_rotated_mixed_font_text
 
     subroutine draw_pdf_text_direct(this, x, y, text)
@@ -103,18 +108,18 @@ contains
         character(len=*), intent(in) :: text
         character(len=1024) :: text_cmd
 
-        this%stream_data = this%stream_data // 'BT' // new_line('a')
+        this%stream_data = this%stream_data//'BT'//new_line('a')
 
-        write(text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+        write (text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
             this%fonts%get_helvetica_obj(), PDF_FONT_SIZE
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
-        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
+        write (text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
             x, y
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
-        this%stream_data = this%stream_data // '(' // text // ') Tj' // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
+        this%stream_data = this%stream_data//'('//text//') Tj'//new_line('a')
 
-        this%stream_data = this%stream_data // 'ET' // new_line('a')
+        this%stream_data = this%stream_data//'ET'//new_line('a')
     end subroutine draw_pdf_text_direct
 
     subroutine draw_pdf_text_bold(this, x, y, text)
@@ -125,37 +130,45 @@ contains
         character(len=:), allocatable :: escaped_text
         integer :: escaped_len
 
-        this%stream_data = this%stream_data // 'BT' // new_line('a')
-        this%stream_data = this%stream_data // '2 Tr' // new_line('a')
-        this%stream_data = this%stream_data // '0.3 w' // new_line('a')
+        this%stream_data = this%stream_data//'BT'//new_line('a')
+        this%stream_data = this%stream_data//'2 Tr'//new_line('a')
+        this%stream_data = this%stream_data//'0.3 w'//new_line('a')
 
-        write(text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+        write (text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
             this%fonts%get_helvetica_obj(), PDF_TITLE_SIZE
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))//new_line('a')
 
-        allocate(character(len=len(text) * 6) :: escaped_text)
+        allocate (character(len=len(text)*6) :: escaped_text)
         call escape_pdf_string(text, escaped_text, escaped_len)
 
-        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
+        write (text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') &
             x, y
-        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // &
-            new_line('a')
-        this%stream_data = this%stream_data // '(' // &
-            escaped_text(1:escaped_len) // ') Tj' // new_line('a')
+        this%stream_data = this%stream_data//trim(adjustl(text_cmd))// &
+                           new_line('a')
+        this%stream_data = this%stream_data//'('// &
+                           escaped_text(1:escaped_len)//') Tj'//new_line('a')
 
-        this%stream_data = this%stream_data // '0 Tr' // new_line('a')
-        this%stream_data = this%stream_data // 'ET' // new_line('a')
+        this%stream_data = this%stream_data//'0 Tr'//new_line('a')
+        this%stream_data = this%stream_data//'ET'//new_line('a')
     end subroutine draw_pdf_text_bold
 
-    subroutine setup_rotated_text_matrix(this, x, y)
+    subroutine setup_rotated_text_matrix(this, x, y, angle_deg)
         class(pdf_context_core), intent(inout) :: this
         real(wp), intent(in) :: x, y
+        real(wp), intent(in) :: angle_deg
         character(len=256) :: matrix_cmd
+        real(wp) :: a, b, c, d, theta
 
-        write(matrix_cmd, '("0 1 -1 0 ", F0.3, 1X, F0.3, " Tm")') &
-            x, y
-        this%stream_data = this%stream_data // trim(adjustl(matrix_cmd)) // &
-            new_line('a')
+        theta = angle_deg*acos(-1.0_wp)/180.0_wp
+        a = cos(theta)
+        b = sin(theta)
+        c = -sin(theta)
+        d = cos(theta)
+
+        write (matrix_cmd, '(4(F0.6,1X),F0.3,1X,F0.3," Tm")') &
+            a, b, c, d, x, y
+        this%stream_data = this%stream_data//trim(adjustl(matrix_cmd))// &
+                           new_line('a')
     end subroutine setup_rotated_text_matrix
 
 end module fortplot_pdf_text_render

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -314,10 +314,17 @@ contains
         character(len=*), intent(in) :: filename
         logical, intent(in), optional :: blocking
 
-        call core_savefig(self%state, self%plots, self%plot_count, filename, &
-                          blocking, self%annotations, self%annotation_count, &
-                          self%subplots_array, self%subplot_rows, &
-                          self%subplot_cols)
+        if (allocated(self%subplots_array) .and. self%subplot_rows > 0 .and. &
+            self%subplot_cols > 0) then
+            call core_savefig(self%state, self%plots, self%plot_count, filename, &
+                              blocking, self%annotations, self%annotation_count, &
+                              subplots_array=self%subplots_array, &
+                              subplot_rows=self%subplot_rows, &
+                              subplot_cols=self%subplot_cols)
+        else
+            call core_savefig(self%state, self%plots, self%plot_count, filename, &
+                              blocking, self%annotations, self%annotation_count)
+        end if
     end subroutine savefig
 
     subroutine savefig_with_status(self, filename, status, blocking)
@@ -327,11 +334,19 @@ contains
         integer, intent(out) :: status
         logical, intent(in), optional :: blocking
 
-        call core_savefig_with_status(self%state, self%plots, self%plot_count, &
-                                      filename, status, blocking, &
-                                      self%annotations, self%annotation_count, &
-                                      self%subplots_array, self%subplot_rows, &
-                                      self%subplot_cols)
+        if (allocated(self%subplots_array) .and. self%subplot_rows > 0 .and. &
+            self%subplot_cols > 0) then
+            call core_savefig_with_status(self%state, self%plots, self%plot_count, &
+                                          filename, status, blocking, &
+                                          self%annotations, self%annotation_count, &
+                                          subplots_array=self%subplots_array, &
+                                          subplot_rows=self%subplot_rows, &
+                                          subplot_cols=self%subplot_cols)
+        else
+            call core_savefig_with_status(self%state, self%plots, self%plot_count, &
+                                          filename, status, blocking, &
+                                          self%annotations, self%annotation_count)
+        end if
     end subroutine savefig_with_status
 
     subroutine show(self, blocking)
@@ -339,10 +354,17 @@ contains
         class(figure_t), intent(inout) :: self
         logical, intent(in), optional :: blocking
 
-        call core_show(self%state, self%plots, self%plot_count, blocking, &
-                       self%annotations, self%annotation_count, &
-                       self%subplots_array, self%subplot_rows, &
-                       self%subplot_cols)
+        if (allocated(self%subplots_array) .and. self%subplot_rows > 0 .and. &
+            self%subplot_cols > 0) then
+            call core_show(self%state, self%plots, self%plot_count, blocking, &
+                           self%annotations, self%annotation_count, &
+                           subplots_array=self%subplots_array, &
+                           subplot_rows=self%subplot_rows, &
+                           subplot_cols=self%subplot_cols)
+        else
+            call core_show(self%state, self%plots, self%plot_count, blocking, &
+                           self%annotations, self%annotation_count)
+        end if
     end subroutine show
 
     !! CONFIGURATION METHODS - Delegated to core config module

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -327,7 +327,7 @@ contains
                                                annotation_count, &
                                                state%x_min, state%x_max, &
                                                state%y_min, state%y_max, &
-                                               state%width, state%height, &
+                                               state%width, state%height, state%dpi, &
                                                state%margin_left, state%margin_right, &
                                                state%margin_bottom, state%margin_top)
             end if

--- a/src/plotting/fortplot_plot_annotations.f90
+++ b/src/plotting/fortplot_plot_annotations.f90
@@ -1,13 +1,14 @@
 module fortplot_plot_annotations
     !! Plot annotation operations module
-    !! 
+    !!
     !! This module handles text and arrow annotations for plots including
     !! coordinate system specification and styling options.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t
-    use fortplot_annotations, only: text_annotation_t, COORD_DATA, COORD_FIGURE, COORD_AXIS, &
-        validate_annotation
+    use fortplot_annotations, only: text_annotation_t, COORD_DATA, COORD_FIGURE, &
+                                    COORD_AXIS, &
+                                    validate_annotation
     use fortplot_logging, only: log_warning
 
     implicit none
@@ -19,7 +20,7 @@ module fortplot_plot_annotations
 contains
 
     subroutine add_text_annotation(self, x, y, text, coord_type, font_size, rotation, &
-                                  ha, va, bbox, color, alpha, weight, style)
+                                   ha, va, bbox, color, alpha, weight, style)
         !! Add text annotation to figure
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x, y
@@ -32,16 +33,16 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: alpha
         character(len=*), intent(in), optional :: weight, style
-        
+
         type(text_annotation_t) :: annotation
         logical :: valid_annotation
         character(len=256) :: error_message
-        
+
         ! Set annotation properties
         annotation%x = x
         annotation%y = y
         annotation%text = text
-        
+
         if (present(coord_type)) then
             select case (coord_type)
             case ('data')
@@ -56,10 +57,15 @@ contains
         else
             annotation%coord_type = COORD_DATA
         end if
-        
+
         if (present(font_size)) annotation%font_size = font_size
         if (present(rotation)) annotation%rotation = rotation
-        if (present(ha)) annotation%ha = ha
+        if (present(ha)) then
+            if (len_trim(ha) > 0) then
+                annotation%ha = ha
+                annotation%alignment = ha
+            end if
+        end if
         if (present(va)) annotation%va = va
         if (present(bbox)) then
             annotation%bbox = bbox
@@ -69,29 +75,31 @@ contains
         if (present(alpha)) annotation%alpha = alpha
         if (present(weight)) annotation%weight = weight
         if (present(style)) annotation%style = style
-        
+
         ! Validate annotation at creation time (Issue #870: prevent duplicate warnings)
         call validate_annotation(annotation, valid_annotation, error_message)
         annotation%validated = .true.
         annotation%valid = valid_annotation
-        
+
         ! Only add valid annotations to prevent rendering issues
         if (valid_annotation) then
             ! Add annotation to figure
             if (.not. allocated(self%annotations)) then
-                allocate(self%annotations(self%max_annotations))
+                allocate (self%annotations(self%max_annotations))
             end if
-            
+
             self%annotation_count = self%annotation_count + 1
             self%annotations(self%annotation_count) = annotation
         else
             ! Issue warning once at creation time, not during rendering
-            call log_warning("Skipping invalid annotation: " // trim(error_message))
+            call log_warning("Skipping invalid annotation: "//trim(error_message))
         end if
     end subroutine add_text_annotation
 
-    subroutine add_arrow_annotation(self, text, xy, xytext, xy_coord_type, xytext_coord_type, &
-                                   arrowprops, font_size, color, alpha)
+    subroutine add_arrow_annotation(self, text, xy, xytext, xy_coord_type, &
+                                    xytext_coord_type, &
+                                    arrowprops, font_size, color, alpha, ha, va, &
+                                    rotation, bbox)
         !! Add arrow annotation to figure
         class(figure_t), intent(inout) :: self
         character(len=*), intent(in) :: text
@@ -103,11 +111,14 @@ contains
         real(wp), intent(in), optional :: font_size
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: alpha
-        
+        character(len=*), intent(in), optional :: ha, va
+        real(wp), intent(in), optional :: rotation
+        logical, intent(in), optional :: bbox
+
         type(text_annotation_t) :: annotation
         logical :: valid_annotation
         character(len=256) :: error_message
-        
+
         ! Set annotation properties
         annotation%x = xytext(1)
         annotation%y = xytext(2)
@@ -115,7 +126,7 @@ contains
         annotation%arrow_x = xy(1)
         annotation%arrow_y = xy(2)
         annotation%has_arrow = .true.
-        
+
         if (present(xytext_coord_type)) then
             select case (xytext_coord_type)
             case ('data')
@@ -130,7 +141,7 @@ contains
         else
             annotation%coord_type = COORD_DATA
         end if
-        
+
         if (present(xy_coord_type)) then
             select case (xy_coord_type)
             case ('data')
@@ -145,29 +156,41 @@ contains
         else
             annotation%arrow_coord_type = COORD_DATA
         end if
-        
+
         if (present(arrowprops)) annotation%arrowstyle = arrowprops
         if (present(font_size)) annotation%font_size = font_size
         if (present(color)) annotation%color = color
         if (present(alpha)) annotation%alpha = alpha
-        
+        if (present(ha)) then
+            if (len_trim(ha) > 0) then
+                annotation%ha = ha
+                annotation%alignment = ha
+            end if
+        end if
+        if (present(va)) annotation%va = va
+        if (present(rotation)) annotation%rotation = rotation
+        if (present(bbox)) then
+            annotation%bbox = bbox
+            annotation%has_bbox = bbox
+        end if
+
         ! Validate annotation at creation time (Issue #870: prevent duplicate warnings)
         call validate_annotation(annotation, valid_annotation, error_message)
         annotation%validated = .true.
         annotation%valid = valid_annotation
-        
+
         ! Only add valid annotations to prevent rendering issues
         if (valid_annotation) then
             ! Add annotation to figure
             if (.not. allocated(self%annotations)) then
-                allocate(self%annotations(self%max_annotations))
+                allocate (self%annotations(self%max_annotations))
             end if
-            
+
             self%annotation_count = self%annotation_count + 1
             self%annotations(self%annotation_count) = annotation
         else
             ! Issue warning once at creation time, not during rendering
-            call log_warning("Skipping invalid annotation: " // trim(error_message))
+            call log_warning("Skipping invalid annotation: "//trim(error_message))
         end if
     end subroutine add_arrow_annotation
 

--- a/src/text/fortplot_text_stub.f90
+++ b/src/text/fortplot_text_stub.f90
@@ -2,23 +2,24 @@ module fortplot_text_stub
     !! Text and annotation functions implementation
     !! Provides pyplot-style text() and annotate() functions that integrate
     !! with the global figure and annotation system
-    
+
     use iso_fortran_env, only: wp => real64
     use fortplot_global, only: global_figure
     use fortplot_plot_annotations, only: add_text_annotation, add_arrow_annotation
     use fortplot_annotations, only: COORD_DATA, COORD_FIGURE, COORD_AXIS
     use fortplot_logging, only: log_error
-    
+
     implicit none
     private
-    
+
     public :: text, annotate
-    
+
 contains
 
-    subroutine text(x, y, text_content, coord_type, font_size, rotation, alignment, has_bbox, ha)
+    subroutine text(x, y, text_content, coord_type, font_size, rotation, alignment, &
+                    has_bbox, ha)
         !! Add text annotation to the current figure
-        !! 
+        !!
         !! Parameters:
         !!   x, y: Position coordinates
         !!   text_content: Text to display
@@ -34,15 +35,15 @@ contains
         character(len=*), intent(in), optional :: alignment, ha
         real(wp), intent(in), optional :: font_size, rotation
         logical, intent(in), optional :: has_bbox
-        
+
         character(len=16) :: coord_type_str
-        
+
         ! Check if global figure is allocated
         if (.not. allocated(global_figure)) then
             call log_error("text: No current figure - call figure() first")
             return
         end if
-        
+
         ! Convert coordinate type to string
         coord_type_str = 'data'
         if (present(coord_type)) then
@@ -55,7 +56,7 @@ contains
                 coord_type_str = 'axes'
             end select
         end if
-        
+
         ! Determine horizontal alignment
         block
             character(len=:), allocatable :: ha_str
@@ -66,19 +67,26 @@ contains
             else
                 ha_str = ''
             end if
-            
-            ! Add text annotation to current figure
-            call add_text_annotation(global_figure, x, y, text_content, &
-                                    coord_type=coord_type_str, &
-                                    font_size=font_size, &
-                                    rotation=rotation, &
-                                    ha=ha_str, &
-                                    bbox=has_bbox)
+
+            if (len_trim(ha_str) > 0) then
+                call add_text_annotation(global_figure, x, y, text_content, &
+                                         coord_type=coord_type_str, &
+                                         font_size=font_size, &
+                                         rotation=rotation, &
+                                         ha=ha_str, &
+                                         bbox=has_bbox)
+            else
+                call add_text_annotation(global_figure, x, y, text_content, &
+                                         coord_type=coord_type_str, &
+                                         font_size=font_size, &
+                                         rotation=rotation, &
+                                         bbox=has_bbox)
+            end if
         end block
     end subroutine text
 
     subroutine annotate(text_content, xy, xytext, xy_coord_type, xytext_coord_type, &
-                       arrow_style, arrow_color, font_size, has_bbox, alignment, ha)
+                        arrow_style, arrow_color, font_size, has_bbox, alignment, ha)
         !! Add arrow annotation to the current figure
         !!
         !! Parameters:
@@ -97,30 +105,33 @@ contains
         real(wp), dimension(2), intent(in) :: xy
         real(wp), dimension(2), intent(in), optional :: xytext
         integer, intent(in), optional :: xy_coord_type, xytext_coord_type
-        character(len=*), intent(in), optional :: arrow_style, arrow_color, alignment, ha
+        character(len=*), intent(in), optional :: arrow_style, arrow_color, &
+                                                  alignment, ha
         real(wp), intent(in), optional :: font_size
         logical, intent(in), optional :: has_bbox
-        
+
         character(len=16) :: xy_coord_str, xytext_coord_str
-        character(len=1) :: dummy_c
-        logical :: dummy_l
+        character(len=:), allocatable :: ha_str
         real(wp), dimension(2) :: text_pos
-        ! Quiet unused optionals to keep stub warning-free
-        if (present(arrow_color)) dummy_c = arrow_color(1:1)
-        if (present(alignment)) dummy_c = alignment(1:1)
-        if (present(ha)) dummy_c = ha(1:1)
-        if (present(has_bbox)) dummy_l = has_bbox
-        
+        ! Determine horizontal alignment (Matplotlib-compatible alias handling)
+        if (present(ha)) then
+            ha_str = ha
+        else if (present(alignment)) then
+            ha_str = alignment
+        else
+            ha_str = ''
+        end if
+
         ! Check if global figure is allocated
         if (.not. allocated(global_figure)) then
             call log_error("annotate: No current figure - call figure() first")
             return
         end if
-        
+
         ! Set text position (default to xy if not specified)
         text_pos = xy
         if (present(xytext)) text_pos = xytext
-        
+
         ! Convert coordinate types to strings
         xy_coord_str = 'data'
         if (present(xy_coord_type)) then
@@ -133,7 +144,7 @@ contains
                 xy_coord_str = 'axes'
             end select
         end if
-        
+
         xytext_coord_str = xy_coord_str  ! Default to same as xy
         if (present(xytext_coord_type)) then
             select case (xytext_coord_type)
@@ -145,13 +156,24 @@ contains
                 xytext_coord_str = 'axes'
             end select
         end if
-        
+
         ! Add arrow annotation to current figure
-        call add_arrow_annotation(global_figure, text_content, xy, text_pos, &
-                                 xy_coord_type=xy_coord_str, &
-                                 xytext_coord_type=xytext_coord_str, &
-                                 arrowprops=arrow_style, &
-                                 font_size=font_size)
+        if (len_trim(ha_str) > 0) then
+            call add_arrow_annotation(global_figure, text_content, xy, text_pos, &
+                                      xy_coord_type=xy_coord_str, &
+                                      xytext_coord_type=xytext_coord_str, &
+                                      arrowprops=arrow_style, &
+                                      font_size=font_size, &
+                                      ha=ha_str, &
+                                      bbox=has_bbox)
+        else
+            call add_arrow_annotation(global_figure, text_content, xy, text_pos, &
+                                      xy_coord_type=xy_coord_str, &
+                                      xytext_coord_type=xytext_coord_str, &
+                                      arrowprops=arrow_style, &
+                                      font_size=font_size, &
+                                      bbox=has_bbox)
+        end if
     end subroutine annotate
 
 end module fortplot_text_stub

--- a/test/test_annotation_styling_1437.f90
+++ b/test/test_annotation_styling_1437.f90
@@ -1,0 +1,83 @@
+program test_annotation_styling_1437
+    !! Regression guard for Issue #1437:
+    !! - rotated text uses rotation matrix in PDF
+    !! - bbox draws a filled/stroked rectangle in PDF
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use test_pdf_utils, only: extract_pdf_stream_text
+    implicit none
+
+    character(len=*), parameter :: out_pdf = &
+                                   'test/output/test_annotation_styling_1437.pdf'
+    character(len=:), allocatable :: stream_text
+    integer :: status
+    class(figure_t), pointer :: fig_ptr
+
+    call figure(figsize=[6.4_wp, 4.8_wp])
+    call plot([0.0_wp, 1.0_wp], [0.0_wp, 1.0_wp])
+
+    call text(0.5_wp, 0.5_wp, "Rotated", coord_type=COORD_DATA, &
+              font_size=12.0_wp, rotation=90.0_wp, alignment="center", &
+              has_bbox=.true.)
+
+    fig_ptr => get_global_figure()
+    if (.not. associated(fig_ptr)) then
+        print *, 'FAIL: global figure pointer not associated'
+        stop 1
+    end if
+    if (fig_ptr%annotation_count < 1) then
+        print *, 'FAIL: expected at least one annotation after text()'
+        stop 1
+    end if
+
+    call savefig(out_pdf)
+
+    call extract_pdf_stream_text(out_pdf, stream_text, status)
+    if (status /= 0) then
+        print *, 'FAIL: could not extract PDF stream text'
+        stop 1
+    end if
+
+    call assert_contains_any(stream_text, &
+                             [character(len=36) :: &
+                              '0.000000 1.000000 -1.000000 0.000000', &
+                              '.000000 1.000000 -1.000000 .000000', &
+                              '-.000000 1.000000 -1.000000 -.000000'], &
+                             'Rotation matrix present')
+    call assert_contains(stream_text, '1 1 1 rg', 'BBox fill color set')
+    call assert_contains(stream_text, ' re B', 'BBox rectangle drawn and filled')
+
+    print *, 'PASS: annotation styling PDF guards present (Issue #1437)'
+
+contains
+
+    subroutine assert_contains(text, pattern, message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: message
+
+        if (index(text, pattern) <= 0) then
+            print *, 'FAIL: ', trim(message), ' (missing: ', trim(pattern), ')'
+            stop 1
+        end if
+    end subroutine assert_contains
+
+    subroutine assert_contains_any(text, patterns, message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: patterns(:)
+        character(len=*), intent(in) :: message
+
+        integer :: i
+
+        do i = 1, size(patterns)
+            if (index(text, trim(patterns(i))) > 0) return
+        end do
+
+        print *, 'FAIL: ', trim(message)
+        do i = 1, size(patterns)
+            print *, '  missing: ', trim(patterns(i))
+        end do
+        stop 1
+    end subroutine assert_contains_any
+
+end program test_annotation_styling_1437


### PR DESCRIPTION
Fixes #1437.

What changed
- Render `text()`/`annotate()` consistently across raster and PDF backends: rotation, bbox, alignment, and arrowheads.
- Fix undefined behaviour in `figure_t%savefig`/`show` where an unallocated `subplots_array` was always passed into optional arguments (could prevent annotations from rendering in PDF).
- Remove an over-broad pie-annotation heuristic that accidentally skipped normal short annotations (e.g. Rotated) for PDF.
- Add regression test `test_annotation_styling_1437` that asserts PDF output contains a bbox draw (`re B`) and a 90° rotation matrix.

Evidence
- `make test-ci 2>&1 | tee /tmp/fortplot_test-ci_issue1437.log`
- `make verify-artifacts 2>&1 | tee /tmp/fortplot_verify-artifacts_issue1437.log`
- Visual comparison (local):
  - `file:///tmp/fortplot_issue1437_annotation_compare/compare_fortplot_vs_mpl.png`
  - `file:///tmp/fortplot_issue1437_annotation_compare/diff_fortplot_vs_mpl_heat.png`

Repro
- `make example ARGS="annotation_demo"`
  - Fortplot output: `output/example/fortran/annotation_demo/annotation_demo.png`
