### PR TITLE
fix: update stale comment to reference build/test/output (fixes #1449)

### DIFF
--- a/src/testing/fortplot_test_helpers.f90
+++ b/src/testing/fortplot_test_helpers.f90
@@ -97,7 +97,7 @@ contains
     
     subroutine ensure_test_directory(unique_suffix)
         !! Ensure test directory exists with proper error handling
-        !! Modified to use test/output/ directory structure per issue #774
+        !! Uses build/test/output/ directory structure per issue #820
         character(len=*), intent(in), optional :: unique_suffix
         character(len=512) :: base_temp
         character(len=:), allocatable :: suffix


### PR DESCRIPTION
## Summary
- Updates stale comment in `src/testing/fortplot_test_helpers.f90:100`
- Comment incorrectly referenced `test/output/` path from issue #774
- Implementation already correctly uses `build/test/output/` per issue #820
- Changed comment to match actual implementation and reference correct issue

## Verification
```bash
fpm build  # Success
fpm test   # All tests pass
grep -n "build/test/output" src/testing/fortplot_test_helpers.f90 | head -5
```

Output excerpt:
```
100:        !! Uses build/test/output/ directory structure per issue #820
116:        ! CRITICAL: Issue #820 - All test artifacts go to build/test/output/ directory
117:        ! Primary location: build/test/output/{test_name}/
118:        current_test_dir = "build/test/output/" // TEMP_DIR_PREFIX // trim(suffix)
```