### PR TITLE
feat: Add quiver() for discrete vector field arrows (fixes #1456)

### DIFF
--- a/example/fortran/quiver_demo/quiver_demo.f90
+++ b/example/fortran/quiver_demo/quiver_demo.f90
@@ -1,0 +1,51 @@
+program quiver_demo
+    !! Demonstrate quiver plot for discrete vector field arrows
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, quiver, xlabel, ylabel, title, savefig
+    implicit none
+
+    integer, parameter :: nx = 10, ny = 10
+    real(wp), dimension(nx*ny) :: x, y, u, v
+    integer :: i, j, k
+    real(wp) :: xi, yj
+
+    ! Create grid of points for vector field
+    k = 0
+    do j = 1, ny
+        do i = 1, nx
+            k = k + 1
+            xi = -2.0_wp + 4.0_wp * real(i-1, wp) / real(nx-1, wp)
+            yj = -2.0_wp + 4.0_wp * real(j-1, wp) / real(ny-1, wp)
+            x(k) = xi
+            y(k) = yj
+            ! Circular flow field (same as streamplot demo)
+            u(k) = -yj
+            v(k) = xi
+        end do
+    end do
+
+    ! Basic quiver plot
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call quiver(x, y, u, v)
+    call xlabel('X')
+    call ylabel('Y')
+    call title('Quiver Plot Demo - Circular Flow')
+
+    call savefig('output/example/fortran/quiver_demo/quiver_demo.png')
+    call savefig('output/example/fortran/quiver_demo/quiver_demo.pdf')
+    call savefig('output/example/fortran/quiver_demo/quiver_demo.txt')
+
+    ! Scaled quiver plot
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call quiver(x, y, u, v, scale=0.5_wp)
+    call xlabel('X')
+    call ylabel('Y')
+    call title('Quiver Plot Demo - Smaller Arrows')
+
+    call savefig('output/example/fortran/quiver_demo/quiver_scaled.png')
+    call savefig('output/example/fortran/quiver_demo/quiver_scaled.pdf')
+    call savefig('output/example/fortran/quiver_demo/quiver_scaled.txt')
+
+    print *, 'Quiver demo completed!'
+
+end program quiver_demo

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -87,7 +87,7 @@ module fortplot
 
     ! Matplotlib-compatible API (all pyplot-style functions)
     use fortplot_matplotlib, only: plot, contour, contour_filled, pcolormesh, &
-                                   streamplot, &
+                                   streamplot, quiver, add_quiver, &
                                    hist, histogram, scatter, errorbar, boxplot, &
                                    bar, barh, text, annotate, &
                                    imshow, pie, polar, step, stem, &
@@ -123,7 +123,8 @@ module fortplot
     public :: COORD_DATA, COORD_FIGURE, COORD_AXIS
 
     ! Matplotlib-compatible plotting functions
-    public :: plot, contour, contour_filled, pcolormesh, streamplot
+    public :: plot, contour, contour_filled, pcolormesh, streamplot, quiver
+    public :: add_quiver
     public :: hist, histogram, scatter, errorbar, boxplot
     public :: bar, barh
     public :: imshow, pie, polar, step, stem

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -60,6 +60,7 @@ module fortplot_figure_core
         procedure :: add_surface
         procedure :: add_pcolormesh
         procedure :: streamplot
+        procedure :: quiver
         procedure :: savefig
         procedure :: save => savefig
         procedure :: savefig_with_status
@@ -311,6 +312,20 @@ contains
         call core_streamplot(self%plots, self%state, self%plot_count, x, y, u, v, &
                              density, color)
     end subroutine streamplot
+
+    subroutine quiver(self, x, y, u, v, scale, color, width, headwidth, &
+                      headlength, units)
+        !! Add quiver plot (discrete vector arrows) to figure
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        real(wp), intent(in), optional :: scale
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: width, headwidth, headlength
+        character(len=*), intent(in), optional :: units
+
+        call core_quiver(self%plots, self%state, self%plot_count, x, y, u, v, &
+                         scale, color, width, headwidth, headlength, units)
+    end subroutine quiver
 
     !! I/O OPERATIONS - Delegated to core I/O module
 

--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -136,12 +136,13 @@ module fortplot_figure_core_operations
     use fortplot_figure_management
     use fortplot_figure_core_ranges, only: update_data_ranges_figure, &
                                            update_data_ranges_pcolormesh_figure
+    use fortplot_figure_quiver, only: quiver_figure
     implicit none
 
     private
     public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled
     public :: core_add_surface, core_add_pcolormesh, core_add_fill_between, core_add_pie
-    public :: core_streamplot, core_savefig, core_savefig_with_status
+    public :: core_streamplot, core_quiver, core_savefig, core_savefig_with_status
     public :: core_show
 
 contains
@@ -294,6 +295,23 @@ contains
         call figure_streamplot_operation(plots, state, plot_count, x, y, u, v, &
                                          density, color)
     end subroutine core_streamplot
+
+    subroutine core_quiver(plots, state, plot_count, x, y, u, v, scale, color, &
+                           width, headwidth, headlength, units)
+        !! Add quiver plot (discrete vector arrows) to figure
+        type(plot_data_t), allocatable, intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        integer, intent(inout) :: plot_count
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        real(wp), intent(in), optional :: scale
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: width, headwidth, headlength
+        character(len=*), intent(in), optional :: units
+
+        call quiver_figure(plots, state, plot_count, x, y, u, v, scale, color, &
+                           width, headwidth, headlength, units)
+        call update_data_ranges_figure(plots, state, plot_count)
+    end subroutine core_quiver
 
     subroutine core_savefig(state, plots, plot_count, filename, blocking, &
                             annotations, annotation_count, subplots_array, &

--- a/src/figures/fortplot_figure_comprehensive_operations.f90
+++ b/src/figures/fortplot_figure_comprehensive_operations.f90
@@ -77,7 +77,7 @@ module fortplot_figure_comprehensive_operations
     public :: core_initialize, core_add_plot, core_add_contour, &
               core_add_contour_filled, core_add_surface
     public :: core_add_pcolormesh, core_add_fill_between, core_add_pie
-    public :: core_streamplot, core_savefig, core_savefig_with_status
+    public :: core_streamplot, core_quiver, core_savefig, core_savefig_with_status
     public :: core_show
     public :: core_colorbar
 

--- a/src/figures/plot_types/fortplot_figure_quiver.f90
+++ b/src/figures/plot_types/fortplot_figure_quiver.f90
@@ -1,0 +1,123 @@
+module fortplot_figure_quiver
+    !! Quiver plot (discrete vector arrows) functionality module
+    !!
+    !! Single Responsibility: Handle quiver plot creation for discrete vector fields
+    !! Provides arrow visualization at grid points showing direction and magnitude
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_QUIVER
+    use fortplot_figure_initialization, only: figure_state_t
+    implicit none
+
+    private
+    public :: quiver_basic_validation, quiver_figure
+
+contains
+
+    function quiver_basic_validation(x, y, u, v) result(is_valid)
+        !! Validate quiver input arrays have matching dimensions
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        logical :: is_valid
+
+        is_valid = .true.
+
+        if (size(x) /= size(y)) then
+            is_valid = .false.
+            return
+        end if
+
+        if (size(x) /= size(u)) then
+            is_valid = .false.
+            return
+        end if
+
+        if (size(x) /= size(v)) then
+            is_valid = .false.
+            return
+        end if
+
+        if (size(x) == 0) then
+            is_valid = .false.
+            return
+        end if
+    end function quiver_basic_validation
+
+    subroutine quiver_figure(plots, state, plot_count, x, y, u, v, &
+                             scale, color, width, headwidth, headlength, units)
+        !! Add quiver plot to figure
+        !! Creates discrete vector arrows at (x,y) positions with (u,v) directions
+        type(plot_data_t), intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        integer, intent(inout) :: plot_count
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        real(wp), intent(in), optional :: scale
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: width, headwidth, headlength
+        character(len=*), intent(in), optional :: units
+
+        integer :: n, plot_idx
+        real(wp) :: arrow_color(3)
+
+        if (.not. quiver_basic_validation(x, y, u, v)) then
+            state%has_error = .true.
+            return
+        end if
+
+        n = size(x)
+        plot_count = plot_count + 1
+        plot_idx = plot_count
+
+        if (plot_idx > size(plots)) then
+            state%has_error = .true.
+            return
+        end if
+
+        plots(plot_idx)%plot_type = PLOT_TYPE_QUIVER
+
+        allocate(plots(plot_idx)%x(n))
+        allocate(plots(plot_idx)%y(n))
+        allocate(plots(plot_idx)%quiver_u(n))
+        allocate(plots(plot_idx)%quiver_v(n))
+
+        plots(plot_idx)%x = x
+        plots(plot_idx)%y = y
+        plots(plot_idx)%quiver_u = u
+        plots(plot_idx)%quiver_v = v
+
+        if (present(scale)) then
+            plots(plot_idx)%quiver_scale = scale
+        else
+            plots(plot_idx)%quiver_scale = 1.0_wp
+        end if
+
+        if (present(width)) then
+            plots(plot_idx)%quiver_width = width
+        end if
+
+        if (present(headwidth)) then
+            plots(plot_idx)%quiver_headwidth = headwidth
+        end if
+
+        if (present(headlength)) then
+            plots(plot_idx)%quiver_headlength = headlength
+        end if
+
+        if (present(units)) then
+            plots(plot_idx)%quiver_units = trim(adjustl(units))
+        end if
+
+        arrow_color = [0.0_wp, 0.0_wp, 0.0_wp]
+        if (present(color)) arrow_color = color
+        plots(plot_idx)%color = arrow_color
+
+        if (.not. state%xlim_set) then
+            if (state%x_min > minval(x)) state%x_min = minval(x)
+            if (state%x_max < maxval(x)) state%x_max = maxval(x)
+        end if
+        if (.not. state%ylim_set) then
+            if (state%y_min > minval(y)) state%y_min = minval(y)
+            if (state%y_max < maxval(y)) state%y_max = maxval(y)
+        end if
+    end subroutine quiver_figure
+
+end module fortplot_figure_quiver

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -13,9 +13,9 @@ module fortplot_matplotlib
         add_plot, add_errorbar, add_scatter, add_3d_plot, &
         imshow, pie, polar, step, stem, &
         fill, fill_between, twinx, twiny, &
-        contour, contour_filled, pcolormesh, streamplot, &
+        contour, contour_filled, pcolormesh, streamplot, quiver, &
         add_contour, add_contour_filled, add_pcolormesh, add_surface, &
-        colorbar, &
+        add_quiver, colorbar, &
         xlabel, ylabel, title, legend, grid, &
         xlim, ylim, set_xscale, set_yscale, &
         set_line_width, set_ydata, use_axis, get_active_axis, &
@@ -37,9 +37,9 @@ module fortplot_matplotlib
     public :: fill, fill_between, twinx, twiny
 
     ! Contour and field functions
-    public :: contour, contour_filled, pcolormesh, streamplot
+    public :: contour, contour_filled, pcolormesh, streamplot, quiver
     public :: add_contour, add_contour_filled, add_pcolormesh, add_surface
-    public :: colorbar
+    public :: add_quiver, colorbar
 
     ! Axis and annotation functions
     public :: xlabel, ylabel, title, legend, grid

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -5,8 +5,8 @@ module fortplot_matplotlib_advanced
         plot, scatter, errorbar, boxplot, bar, barh, hist, histogram, add_plot, &
         add_errorbar, add_scatter, add_3d_plot
     use fortplot_matplotlib_field_wrappers, only: &
-        contour, contour_filled, pcolormesh, streamplot, add_contour, &
-        add_contour_filled, add_pcolormesh, add_surface
+        contour, contour_filled, pcolormesh, streamplot, quiver, add_quiver, &
+        add_contour, add_contour_filled, add_pcolormesh, add_surface
     use fortplot_matplotlib_axes, only: &
         xlabel, ylabel, title, legend, grid, xlim, ylim, set_xscale, set_yscale, &
         set_line_width, set_ydata, use_axis, get_active_axis
@@ -27,8 +27,9 @@ module fortplot_matplotlib_advanced
     public :: imshow, pie, polar, step, stem
     public :: fill, fill_between, twinx, twiny
 
-    public :: contour, contour_filled, pcolormesh, streamplot
+    public :: contour, contour_filled, pcolormesh, streamplot, quiver
     public :: add_contour, add_contour_filled, add_pcolormesh, add_surface
+    public :: add_quiver
 
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale

--- a/src/interfaces/fortplot_matplotlib_field_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_field_wrappers.f90
@@ -14,6 +14,7 @@ module fortplot_matplotlib_field_wrappers
     public :: contour_filled
     public :: pcolormesh
     public :: streamplot
+    public :: quiver, add_quiver
     public :: add_contour
     public :: add_contour_filled
     public :: add_pcolormesh
@@ -201,6 +202,32 @@ contains
         if (allocated(trajectories)) deallocate(trajectories)
         if (allocated(traj_lengths)) deallocate(traj_lengths)
     end subroutine streamplot
+
+    subroutine quiver(x, y, u, v, scale, color, width, headwidth, headlength, units)
+        !! Create quiver plot showing discrete vector arrows at grid points
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        real(wp), intent(in), optional :: scale
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: width, headwidth, headlength
+        character(len=*), intent(in), optional :: units
+
+        call ensure_fig_init()
+        call fig%quiver(x, y, u, v, scale=scale, color=color, width=width, &
+                        headwidth=headwidth, headlength=headlength, units=units)
+    end subroutine quiver
+
+    subroutine add_quiver(x, y, u, v, scale, color, width, headwidth, &
+                          headlength, units)
+        !! Add quiver plot showing discrete vector arrows at grid points
+        real(wp), intent(in) :: x(:), y(:), u(:), v(:)
+        real(wp), intent(in), optional :: scale
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: width, headwidth, headlength
+        character(len=*), intent(in), optional :: units
+
+        call quiver(x, y, u, v, scale=scale, color=color, width=width, &
+                    headwidth=headwidth, headlength=headlength, units=units)
+    end subroutine add_quiver
 
     subroutine add_contour(x, y, z, levels, label)
         real(wp), intent(in) :: x(:), y(:)

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -17,7 +17,8 @@ module fortplot_plot_data
     public :: PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
               PLOT_TYPE_ERRORBAR, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
               PLOT_TYPE_BOXPLOT, PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
-              PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, PLOT_TYPE_REFLINE
+              PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, PLOT_TYPE_REFLINE, &
+              PLOT_TYPE_QUIVER
     public :: HALF_WIDTH, IQR_WHISKER_MULTIPLIER
 
     ! Plot type constants
@@ -33,6 +34,7 @@ module fortplot_plot_data
     integer, parameter :: PLOT_TYPE_SURFACE = 10
     integer, parameter :: PLOT_TYPE_PIE = 11
     integer, parameter :: PLOT_TYPE_REFLINE = 12
+    integer, parameter :: PLOT_TYPE_QUIVER = 13
 
     ! Constants for calculations
     real(wp), parameter :: HALF_WIDTH = 0.5_wp
@@ -143,6 +145,13 @@ module fortplot_plot_data
         character(len=:), allocatable :: pie_autopct
         real(wp) :: pie_radius = 1.0_wp
         real(wp) :: pie_center(2) = [0.0_wp, 0.0_wp]
+        ! Quiver plot data
+        real(wp), allocatable :: quiver_u(:), quiver_v(:)
+        real(wp) :: quiver_scale = 1.0_wp
+        real(wp) :: quiver_width = 0.005_wp
+        real(wp) :: quiver_headwidth = 3.0_wp
+        real(wp) :: quiver_headlength = 5.0_wp
+        character(len=10) :: quiver_units = 'width'
         ! Axis assignment (primary by default)
         integer :: axis = AXIS_PRIMARY
     contains


### PR DESCRIPTION
## Summary
- Add quiver plot type for visualizing discrete vector fields with arrows at grid points
- This complements the existing streamplot which shows continuous flow lines
- Both OO interface (`fig%quiver()`) and stateful interface (`call quiver()`) supported

## Implementation
- Add `PLOT_TYPE_QUIVER` constant and quiver data fields in `plot_data_t`
- Create `fortplot_figure_quiver` module with validation and figure operations
- Add `quiver` method to `figure_t` for OO interface
- Add `render_quiver_plot` for PNG/PDF/ASCII backend rendering
- Export `quiver()` and `add_quiver()` in public matplotlib API
- Add `quiver_demo` example demonstrating circular flow visualization

## API
```fortran
! OO interface
call fig%quiver(x, y, u, v, scale=1.0_wp, color=[0.0_wp, 0.0_wp, 0.0_wp])

! Stateful interface  
call quiver(x, y, u, v, scale=1.0_wp)
```

## Verification
```bash
# Build succeeds
fpm build
# All tests pass
fpm test
# Example runs and generates output
fpm run --example quiver_demo
```

Output files generated:
- `output/example/fortran/quiver_demo/quiver_demo.png` (19KB, 800x600 PNG)
- `output/example/fortran/quiver_demo/quiver_demo.pdf` (4KB)
- `output/example/fortran/quiver_demo/quiver_demo.txt` (ASCII art with directional arrows)
- Scaled variants also generated

ASCII output shows proper directional characters (`\`, `^`, `<`, `>`) representing the circular flow field.