### PR TITLE
fix: Remove duplicate fortplot title in GitHub Pages (fixes #1485)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,8 @@ doc:
 	$(MAKE) example ARGS="marker_demo" >/dev/null
 	# Generate animation demo so MP4 is available for docs (fixes #1085)
 	$(MAKE) example ARGS="save_animation_demo" >/dev/null
-	# Generate doc.md from README.md (strip badge, it's circular on the docs site)
-	grep -v 'img.shields.io' README.md > doc.md
+	# Generate doc.md from README.md (strip badge and title - FORD adds title from fpm.toml)
+	grep -v 'img.shields.io' README.md | sed '1{/^# fortplot$$/d}' > doc.md
 	# Run FORD to generate documentation structure
 	ford doc.md
 	# Copy example media files to BOTH possible link roots used in pages

--- a/doc.md
+++ b/doc.md
@@ -1,4 +1,3 @@
-# fortplot
 
 
 Fortran plotting. No dependencies. PNG/PDF/ASCII output.


### PR DESCRIPTION
## Summary

- Modify Makefile to strip the `# fortplot` header when generating `doc.md` from `README.md`
- FORD already adds the project title from `fpm.toml`'s `[extra.ford]` section, causing duplicate `<h1>fortplot</h1>` tags on the documentation site

## Verification

Built documentation locally and verified only one `<h1>fortplot</h1>` tag in `build/doc/index.html`:

```bash
$ rm -rf build/doc && make doc
$ grep -i "<h1>fortplot" build/doc/index.html
<h1>fortplot</h1>
```

Before fix, there were two h1 tags; after fix, only one.

All tests pass:
```
ALL TESTS PASSED (fpm test)
```