### PR TITLE
feat: Add minor ticks support (fixes #1465)

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -45,6 +45,8 @@ module fortplot_raster_axes
     public :: raster_draw_y_axis_tick_labels_only
     public :: raster_draw_secondary_y_axis
     public :: raster_draw_secondary_x_axis_top
+    public :: raster_draw_x_minor_ticks
+    public :: raster_draw_y_minor_ticks
 
 contains
 

--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -34,6 +34,9 @@ module fortplot_pdf_axes
     public :: setup_axes_data_ranges
     public :: generate_tick_data
     public :: render_mixed_text
+    public :: draw_pdf_minor_tick_marks
+
+    real(wp), parameter :: PDF_MINOR_TICK_SIZE = 3.0_wp
 
 contains
 
@@ -802,5 +805,39 @@ contains
 
         ctx%stream_data = ctx%stream_data//'ET'//new_line('a')
     end subroutine draw_rotated_pdf_mathtext
+
+    subroutine draw_pdf_minor_tick_marks(ctx, x_minor_positions, y_minor_positions, &
+                                         num_x_minor, num_y_minor, &
+                                         plot_left, plot_bottom)
+        !! Draw minor tick marks (shorter than major ticks)
+        type(pdf_context_core), intent(inout) :: ctx
+        real(wp), intent(in) :: x_minor_positions(:), y_minor_positions(:)
+        integer, intent(in) :: num_x_minor, num_y_minor
+        real(wp), intent(in) :: plot_left, plot_bottom
+
+        integer :: i
+        character(len=2048) :: tick_cmd
+        real(wp) :: bottom_y
+
+        call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
+        call ctx%set_line_width(0.5_wp)
+        ctx%stream_data = ctx%stream_data//'[] 0 d'//new_line('a')
+
+        bottom_y = plot_bottom
+
+        do i = 1, num_x_minor
+            write (tick_cmd, '(F0.3, 1X, F0.3, " m ", F0.3, 1X, F0.3, " l S")') &
+                x_minor_positions(i), bottom_y, &
+                x_minor_positions(i), bottom_y + PDF_MINOR_TICK_SIZE
+            ctx%stream_data = ctx%stream_data//trim(adjustl(tick_cmd))//new_line('a')
+        end do
+
+        do i = 1, num_y_minor
+            write (tick_cmd, '(F0.3, 1X, F0.3, " m ", F0.3, 1X, F0.3, " l S")') &
+                plot_left, y_minor_positions(i), &
+                plot_left + PDF_MINOR_TICK_SIZE, y_minor_positions(i)
+            ctx%stream_data = ctx%stream_data//trim(adjustl(tick_cmd))//new_line('a')
+        end do
+    end subroutine draw_pdf_minor_tick_marks
 
 end module fortplot_pdf_axes

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -100,7 +100,7 @@ module fortplot
                                    add_3d_plot, add_surface, add_scatter, &
                                    set_xscale, set_yscale, xlim, ylim, &
                                    set_line_width, set_ydata, use_axis, &
-                                   get_active_axis, &
+                                   get_active_axis, minorticks_on, &
                                    show, show_viewer, &
                                    ensure_global_figure_initialized, get_global_figure
 
@@ -136,7 +136,7 @@ module fortplot
     public :: figure, subplot, subplots, subplots_grid
     public :: xlabel, ylabel, title, suptitle, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
-    public :: set_line_width, set_ydata, use_axis, get_active_axis
+    public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on
     public :: savefig, savefig_with_status
 
     ! Extended plotting functions

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -127,6 +127,9 @@ module fortplot_figure_core
         procedure :: axvline
         procedure :: hlines
         procedure :: vlines
+        procedure :: set_minor_ticks
+        procedure :: set_minor_tick_count
+        procedure :: minorticks_on
         final :: destroy
     end type figure_t
 
@@ -879,5 +882,37 @@ contains
         call core_vlines(self%plots, self%state, self%plot_count, x, &
                          ymin, ymax, colors, linestyles, linewidth, label)
     end subroutine vlines
+
+    subroutine set_minor_ticks(self, x, y)
+        !! Enable or disable minor ticks on x and/or y axes
+        class(figure_t), intent(inout) :: self
+        logical, intent(in), optional :: x, y
+
+        if (present(x)) self%state%minor_ticks_x = x
+        if (present(y)) self%state%minor_ticks_y = y
+        self%state%rendered = .false.
+    end subroutine set_minor_ticks
+
+    subroutine set_minor_tick_count(self, count)
+        !! Set the number of minor ticks between each pair of major ticks
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: count
+
+        if (count >= 1 .and. count <= 20) then
+            self%state%minor_tick_count = count
+            self%state%rendered = .false.
+        else
+            call log_warning('set_minor_tick_count: count must be between 1 and 20')
+        end if
+    end subroutine set_minor_tick_count
+
+    subroutine minorticks_on(self)
+        !! Enable minor ticks on both axes (matplotlib-compatible convenience method)
+        class(figure_t), intent(inout) :: self
+
+        self%state%minor_ticks_x = .true.
+        self%state%minor_ticks_y = .true.
+        self%state%rendered = .false.
+    end subroutine minorticks_on
 
 end module fortplot_figure_core

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -118,6 +118,11 @@ module fortplot_figure_initialization
 
         ! Streamplot arrow storage (rendered after plots)
         type(arrow_data_t), allocatable :: stream_arrows(:)
+
+        ! Minor ticks configuration
+        logical :: minor_ticks_x = .false.
+        logical :: minor_ticks_y = .false.
+        integer :: minor_tick_count = 5
     end type figure_state_t
 
     contains
@@ -274,6 +279,10 @@ module fortplot_figure_initialization
 
         if (allocated(state%stream_arrows)) &
             call move_alloc(state%stream_arrows, scratch_arrows)
+
+        state%minor_ticks_x = .false.
+        state%minor_ticks_y = .false.
+        state%minor_tick_count = 5
     end subroutine reset_state_for_initialization
 
     subroutine reset_figure_state(state)
@@ -333,6 +342,10 @@ module fortplot_figure_initialization
 
         if (allocated(state%stream_arrows)) &
             call move_alloc(state%stream_arrows, scratch_arrows)
+
+        state%minor_ticks_x = .false.
+        state%minor_ticks_y = .false.
+        state%minor_tick_count = 5
     end subroutine reset_figure_state
 
     subroutine setup_figure_backend(state, backend_name)

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -259,7 +259,8 @@ contains
                                     twiny_x_min=state%twiny_x_min, &
                                     twiny_x_max=state%twiny_x_max, &
                                     twiny_xlabel=state%twiny_xlabel, &
-                                    twiny_xscale=state%twiny_xscale)
+                                    twiny_xscale=state%twiny_xscale, &
+                                    state=state)
         else
             call render_title_only(state%backend, state%title, state%x_min, &
                                    state%x_max, &

--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -104,7 +104,8 @@ contains
                                         subplots_array(i, j)%ylabel, &
                                         subplots_array(i, j)%plots, &
                                         subplots_array(i, j)%plot_count, &
-                                        has_twinx=.false., has_twiny=.false.)
+                                        has_twinx=.false., has_twiny=.false., &
+                                        state=state)
 
                 if (subplots_array(i, j)%plot_count > 0) then
                     call render_all_plots(state%backend, subplots_array(i, j)%plots, &

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -18,7 +18,7 @@ module fortplot_matplotlib
         add_quiver, colorbar, &
         xlabel, ylabel, title, suptitle, legend, grid, &
         xlim, ylim, set_xscale, set_yscale, &
-        set_line_width, set_ydata, use_axis, get_active_axis, &
+        set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
         show, show_viewer, get_global_figure, ensure_global_figure_initialized
 
@@ -44,7 +44,7 @@ module fortplot_matplotlib
     ! Axis and annotation functions
     public :: xlabel, ylabel, title, suptitle, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
-    public :: set_line_width, set_ydata, use_axis, get_active_axis
+    public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on
     public :: text, annotate
 
     ! Figure management functions

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -9,7 +9,8 @@ module fortplot_matplotlib_advanced
         add_contour, add_contour_filled, add_pcolormesh, add_surface
     use fortplot_matplotlib_axes, only: &
         xlabel, ylabel, title, suptitle, legend, grid, xlim, ylim, set_xscale, &
-        set_yscale, set_line_width, set_ydata, use_axis, get_active_axis
+        set_yscale, set_line_width, set_ydata, use_axis, get_active_axis, &
+        minorticks_on
     use fortplot_matplotlib_session, only: &
         ensure_global_figure_initialized, get_global_figure, figure, subplot, &
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
@@ -34,6 +35,7 @@ module fortplot_matplotlib_advanced
     public :: xlabel, ylabel, title, suptitle, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis
+    public :: minorticks_on
     public :: colorbar
 
     public :: figure, subplot, subplots, subplots_grid

--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -23,6 +23,7 @@ module fortplot_matplotlib_axes
     public :: set_ydata
     public :: use_axis
     public :: get_active_axis
+    public :: minorticks_on
 
 contains
 
@@ -158,5 +159,11 @@ contains
         call ensure_fig_init()
         axis_name = fig%get_active_axis()
     end function get_active_axis
+
+    subroutine minorticks_on()
+        !! Enable minor ticks on both axes (matplotlib-compatible)
+        call ensure_fig_init()
+        call fig%minorticks_on()
+    end subroutine minorticks_on
 
 end module fortplot_matplotlib_axes

--- a/src/utilities/ticks/fortplot_ticks.f90
+++ b/src/utilities/ticks/fortplot_ticks.f90
@@ -8,17 +8,19 @@ module fortplot_ticks
     !! - fortplot_tick_scales: Log and symlog scale functions
     
     use fortplot_tick_calculation, only: calculate_tick_labels, calculate_nice_axis_limits, &
-        find_nice_tick_locations
+        find_nice_tick_locations, calculate_minor_tick_positions, &
+        calculate_log_minor_tick_positions
     use fortplot_tick_formatting, only: format_tick_value, format_tick_value_smart, &
         format_log_tick_value
     use fortplot_tick_scales, only: calculate_tick_labels_log, calculate_tick_labels_symlog, &
         generate_scale_aware_tick_labels
     implicit none
-    
+
     private
     public :: calculate_tick_labels, calculate_tick_labels_log, calculate_tick_labels_symlog
     public :: format_tick_value, calculate_nice_axis_limits
     public :: generate_scale_aware_tick_labels, format_tick_value_smart, format_log_tick_value
     public :: find_nice_tick_locations
+    public :: calculate_minor_tick_positions, calculate_log_minor_tick_positions
 
 end module fortplot_ticks

--- a/test/test_minor_ticks.f90
+++ b/test/test_minor_ticks.f90
@@ -1,0 +1,80 @@
+program test_minor_ticks
+    !! Test minor ticks functionality (Issue #1465)
+    use fortplot
+    use test_output_helpers, only: ensure_test_output_dir
+    implicit none
+
+    real(wp), dimension(50) :: x, y
+    character(len=:), allocatable :: output_dir
+    type(figure_t) :: fig
+    integer :: i
+
+    call ensure_test_output_dir('minor_ticks', output_dir)
+
+    x = [(real(i - 1, wp)*0.2_wp, i=1, 50)]
+    y = sin(x)
+
+    ! Test 1: Stateful API - minorticks_on()
+    call figure()
+    call plot(x, y)
+    call title("Minor Ticks - Stateful API")
+    call xlabel("x")
+    call ylabel("sin(x)")
+    call minorticks_on()
+    call savefig(trim(output_dir)//'minor_ticks_stateful.png')
+    print *, "Test 1: Stateful API - PASS"
+
+    ! Test 2: OO API - set_minor_ticks
+    call fig%initialize()
+    call fig%plot(x, y)
+    call fig%set_title("Minor Ticks - OO API set_minor_ticks")
+    call fig%set_xlabel("x")
+    call fig%set_ylabel("sin(x)")
+    call fig%set_minor_ticks(x=.true., y=.true.)
+    call fig%savefig(trim(output_dir)//'minor_ticks_oo_set.png')
+    print *, "Test 2: OO API set_minor_ticks - PASS"
+
+    ! Test 3: OO API - minorticks_on()
+    call fig%initialize()
+    call fig%plot(x, y)
+    call fig%set_title("Minor Ticks - OO API minorticks_on")
+    call fig%set_xlabel("x")
+    call fig%set_ylabel("sin(x)")
+    call fig%minorticks_on()
+    call fig%savefig(trim(output_dir)//'minor_ticks_oo_on.png')
+    print *, "Test 3: OO API minorticks_on - PASS"
+
+    ! Test 4: Custom minor tick count
+    call fig%initialize()
+    call fig%plot(x, y)
+    call fig%set_title("Minor Ticks - Custom Count (9)")
+    call fig%set_xlabel("x")
+    call fig%set_ylabel("sin(x)")
+    call fig%set_minor_tick_count(9)
+    call fig%set_minor_ticks(x=.true., y=.true.)
+    call fig%savefig(trim(output_dir)//'minor_ticks_count_9.png')
+    print *, "Test 4: Custom minor tick count - PASS"
+
+    ! Test 5: X-axis only
+    call fig%initialize()
+    call fig%plot(x, y)
+    call fig%set_title("Minor Ticks - X-axis Only")
+    call fig%set_xlabel("x")
+    call fig%set_ylabel("sin(x)")
+    call fig%set_minor_ticks(x=.true.)
+    call fig%savefig(trim(output_dir)//'minor_ticks_x_only.png')
+    print *, "Test 5: X-axis only - PASS"
+
+    ! Test 6: Y-axis only
+    call fig%initialize()
+    call fig%plot(x, y)
+    call fig%set_title("Minor Ticks - Y-axis Only")
+    call fig%set_xlabel("x")
+    call fig%set_ylabel("sin(x)")
+    call fig%set_minor_ticks(y=.true.)
+    call fig%savefig(trim(output_dir)//'minor_ticks_y_only.png')
+    print *, "Test 6: Y-axis only - PASS"
+
+    print *, "All minor ticks tests completed successfully"
+
+end program test_minor_ticks


### PR DESCRIPTION
## Summary

- Add minor ticks functionality to fortplot with both OO and stateful API support
- Implement `set_minor_ticks(x, y)` for axis-specific control
- Implement `set_minor_tick_count(n)` for configurable subdivisions (default 5)
- Implement `minorticks_on()` for convenience enabling on both axes
- Support PNG and PDF backends with proper log scale handling

## Test plan

- [x] Run `fpm test test_minor_ticks` - all 6 tests pass
- [x] Verify stateful API works (`minorticks_on()`)
- [x] Verify OO API works (`fig%set_minor_ticks()`, `fig%minorticks_on()`)
- [x] Verify custom tick count (`fig%set_minor_tick_count(9)`)
- [x] Verify single-axis support (x-only, y-only)
- [x] Run full test suite - no regressions

## Verification

```
$ fpm test test_minor_ticks
Test 1: Stateful API - PASS
Test 2: OO API set_minor_ticks - PASS
Test 3: OO API minorticks_on - PASS
Test 4: Custom minor tick count - PASS
Test 5: X-axis only - PASS
Test 6: Y-axis only - PASS
All minor ticks tests completed successfully
```

Closes #1465