### PR TITLE
feat: Add stacked bar charts (fixes #1460)

### DIFF
--- a/example/fortran/bar_chart_demo/bar_chart_demo.f90
+++ b/example/fortran/bar_chart_demo/bar_chart_demo.f90
@@ -14,6 +14,7 @@ program bar_chart_demo
     call demo_stateful_horizontal()
     call demo_object_grouped()
     call demo_categorical_labels()
+    call demo_stacked_bars()
 
 contains
 
@@ -168,5 +169,46 @@ contains
             print *, 'WARNING: failed to save categorical labels bar outputs'
         end if
     end subroutine demo_categorical_labels
+
+    subroutine demo_stacked_bars()
+        !! Demonstrates stacked bar charts (Issue #1460)
+        !! Uses bottom parameter to stack bars on top of each other
+        real(dp) :: x(4), layer1(4), layer2(4), layer3(4)
+        integer :: status
+        logical :: ok
+
+        x = [1.0d0, 2.0d0, 3.0d0, 4.0d0]
+        layer1 = [15.0d0, 20.0d0, 18.0d0, 22.0d0]
+        layer2 = [8.0d0, 10.0d0, 12.0d0, 9.0d0]
+        layer3 = [5.0d0, 7.0d0, 6.0d0, 8.0d0]
+
+        call figure(figsize=[7.5d0, 5.0d0])
+
+        ! First layer at base
+        call bar(x, layer1, label='Manufacturing')
+        ! Second layer stacked on first
+        call bar(x, layer2, bottom=layer1, label='Sales')
+        ! Third layer stacked on first + second
+        call bar(x, layer3, bottom=layer1 + layer2, label='R&D')
+
+        call xlabel('Quarter')
+        call ylabel('Expenses (million $)')
+        call title('Stacked Bar Chart - Department Expenses')
+        call legend()
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stacked_bars.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stacked_bars.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stacked_bars.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save stacked bar outputs'
+        end if
+    end subroutine demo_stacked_bars
 
 end program bar_chart_demo

--- a/src/backends/memory/fortplot_bar_rendering.f90
+++ b/src/backends/memory/fortplot_bar_rendering.f90
@@ -28,6 +28,7 @@ contains
         real(wp) :: x_data(4), y_data(4)
         real(wp) :: x_screen(4), y_screen(4)
         real(wp) :: effective_width
+        real(wp) :: base_val, top_val
 
         if (.not. allocated(plot_data%bar_x)) return
         if (.not. allocated(plot_data%bar_heights)) return
@@ -42,24 +43,28 @@ contains
         call backend%color(plot_data%color(1), plot_data%color(2), plot_data%color(3))
 
         do i = 1, n
+            ! Get base offset (bottom for vertical, left for horizontal)
+            if (allocated(plot_data%bar_bottom) .and. i <= size(plot_data%bar_bottom)) then
+                base_val = plot_data%bar_bottom(i)
+            else
+                base_val = 0.0_wp
+            end if
+            top_val = base_val + plot_data%bar_heights(i)
+
             if (plot_data%bar_horizontal) then
-                x_data = [min(0.0_wp, plot_data%bar_heights(i)), &
-                          max(0.0_wp, plot_data%bar_heights(i)), &
-                          max(0.0_wp, plot_data%bar_heights(i)), &
-                          min(0.0_wp, plot_data%bar_heights(i))]
+                ! Horizontal bars: base_val is left edge, top_val is right edge
+                x_data = [base_val, top_val, top_val, base_val]
                 y_data = [plot_data%bar_x(i) - half_width, &
                           plot_data%bar_x(i) - half_width, &
                           plot_data%bar_x(i) + half_width, &
                           plot_data%bar_x(i) + half_width]
             else
+                ! Vertical bars: base_val is bottom, top_val is top
                 x_data = [plot_data%bar_x(i) - half_width, &
                           plot_data%bar_x(i) + half_width, &
                           plot_data%bar_x(i) + half_width, &
                           plot_data%bar_x(i) - half_width]
-                y_data = [min(0.0_wp, plot_data%bar_heights(i)), &
-                          min(0.0_wp, plot_data%bar_heights(i)), &
-                          max(0.0_wp, plot_data%bar_heights(i)), &
-                          max(0.0_wp, plot_data%bar_heights(i))]
+                y_data = [base_val, base_val, top_val, top_val]
             end if
 
             do j = 1, 4

--- a/src/figures/fortplot_figure_data_ranges.f90
+++ b/src/figures/fortplot_figure_data_ranges.f90
@@ -444,6 +444,7 @@ contains
         real(wp) :: y_min_bar, y_max_bar
         real(wp) :: left_edge, right_edge
         real(wp) :: lower_edge, upper_edge
+        real(wp) :: base_val, top_val
 
         if (.not. allocated(plot%bar_x)) return
         if (.not. allocated(plot%bar_heights)) return
@@ -461,16 +462,26 @@ contains
         y_max_bar = -huge(0.0_wp)
 
         do i = 1, n
+            ! Get base offset (bottom for vertical, left for horizontal)
+            if (allocated(plot%bar_bottom) .and. i <= size(plot%bar_bottom)) then
+                base_val = plot%bar_bottom(i)
+            else
+                base_val = 0.0_wp
+            end if
+            top_val = base_val + plot%bar_heights(i)
+
             if (plot%bar_horizontal) then
-                left_edge = min(0.0_wp, plot%bar_heights(i))
-                right_edge = max(0.0_wp, plot%bar_heights(i))
+                ! Horizontal bars: base_val is left edge, top_val is right edge
+                left_edge = min(base_val, top_val)
+                right_edge = max(base_val, top_val)
                 lower_edge = plot%bar_x(i) - half_width
                 upper_edge = plot%bar_x(i) + half_width
             else
+                ! Vertical bars: base_val is bottom, top_val is top
                 left_edge = plot%bar_x(i) - half_width
                 right_edge = plot%bar_x(i) + half_width
-                lower_edge = min(0.0_wp, plot%bar_heights(i))
-                upper_edge = max(0.0_wp, plot%bar_heights(i))
+                lower_edge = min(base_val, top_val)
+                upper_edge = max(base_val, top_val)
             end if
 
             x_min_bar = min(x_min_bar, left_edge)

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -103,7 +103,8 @@ contains
         bar_align = 'center'
         if (present(align)) bar_align = align
 
-        call bar_impl(fig, x, height, width=bar_width, label=label, color=color)
+        call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, label=label, &
+                      color=color)
         deallocate(bar_bottom)
     end subroutine bar
 
@@ -140,7 +141,8 @@ contains
         bar_align = 'center'
         if (present(align)) bar_align = align
 
-        call barh_impl(fig, y, width, height=bar_height, label=label, color=color)
+        call barh_impl(fig, y, width, height=bar_height, left=bar_left, label=label, &
+                       color=color)
         deallocate(bar_left)
     end subroutine barh
 

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -90,7 +90,7 @@ module fortplot_plot_data
         ! Pcolormesh data
         type(pcolormesh_t) :: pcolormesh_data
         ! Bar chart data
-        real(wp), allocatable :: bar_x(:), bar_heights(:)
+        real(wp), allocatable :: bar_x(:), bar_heights(:), bar_bottom(:)
         real(wp) :: bar_width = 0.8_wp
         logical :: bar_horizontal = .false.
         ! Histogram data

--- a/test/test_stacked_bar_charts.f90
+++ b/test/test_stacked_bar_charts.f90
@@ -1,0 +1,192 @@
+program test_stacked_bar_charts
+    !! Tests for stacked bar chart functionality (Issue #1460)
+    !!
+    !! This test covers:
+    !! - Basic stacked vertical bar charts with bottom parameter
+    !! - Basic stacked horizontal bar charts with left parameter
+    !! - Proper range calculation including stacked values
+    !! - Legend support for stacked bar layers
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_plotting_advanced, only: bar_impl, barh_impl
+    implicit none
+
+    integer :: test_count = 0
+    integer :: pass_count = 0
+    integer :: fail_count = 0
+
+    print *, "=== STACKED BAR CHART TESTS (Issue #1460) ==="
+
+    call test_stacked_vertical_bars()
+    call test_stacked_horizontal_bars()
+    call test_stacked_bar_ranges()
+    call test_stacked_bar_stateful()
+    call print_test_summary()
+
+    if (fail_count > 0) stop 1
+
+contains
+
+    subroutine test_stacked_vertical_bars()
+        type(figure_t) :: fig
+        real(wp) :: x(3) = [1.0_wp, 2.0_wp, 3.0_wp]
+        real(wp) :: heights1(3) = [10.0_wp, 15.0_wp, 12.0_wp]
+        real(wp) :: heights2(3) = [5.0_wp, 8.0_wp, 6.0_wp]
+        real(wp), dimension(3) :: c1 = [0.2_wp, 0.4_wp, 0.8_wp]
+        real(wp), dimension(3) :: c2 = [0.8_wp, 0.4_wp, 0.2_wp]
+
+        call start_test("Stacked vertical bars with bottom parameter")
+
+        call fig%initialize(640, 480)
+
+        ! First layer at base (bottom=0 by default)
+        call bar_impl(fig, x, heights1, label='Product A', color=c1)
+        call assert_equal(real(fig%plot_count, wp), 1.0_wp, "First bar layer added")
+
+        ! Second layer stacked on top
+        call bar_impl(fig, x, heights2, bottom=heights1, label='Product B', color=c2)
+        call assert_equal(real(fig%plot_count, wp), 2.0_wp, "Second bar layer stacked")
+
+        call fig%legend()
+        call fig%set_title('Stacked Vertical Bar Chart')
+        call fig%set_xlabel('Categories')
+        call fig%set_ylabel('Values')
+
+        call fig%savefig('test/output/stacked_vertical_bars.png')
+        print *, '  Output: test/output/stacked_vertical_bars.png'
+
+        call end_test()
+    end subroutine test_stacked_vertical_bars
+
+    subroutine test_stacked_horizontal_bars()
+        type(figure_t) :: fig
+        real(wp) :: y(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        real(wp) :: widths1(4) = [20.0_wp, 25.0_wp, 18.0_wp, 22.0_wp]
+        real(wp) :: widths2(4) = [10.0_wp, 12.0_wp, 8.0_wp, 11.0_wp]
+        real(wp), dimension(3) :: c1 = [0.3_wp, 0.6_wp, 0.3_wp]
+        real(wp), dimension(3) :: c2 = [0.6_wp, 0.3_wp, 0.6_wp]
+
+        call start_test("Stacked horizontal bars with left parameter")
+
+        call fig%initialize(640, 480)
+
+        ! First layer at base (left=0 by default)
+        call barh_impl(fig, y, widths1, label='Category 1', color=c1)
+        call assert_equal(real(fig%plot_count, wp), 1.0_wp, "First horizontal bar added")
+
+        ! Second layer stacked to the right
+        call barh_impl(fig, y, widths2, left=widths1, label='Category 2', color=c2)
+        call assert_equal(real(fig%plot_count, wp), 2.0_wp, "Second horizontal bar stacked")
+
+        call fig%legend()
+        call fig%set_title('Stacked Horizontal Bar Chart')
+        call fig%set_xlabel('Values')
+        call fig%set_ylabel('Categories')
+
+        call fig%savefig('test/output/stacked_horizontal_bars.png')
+        print *, '  Output: test/output/stacked_horizontal_bars.png'
+
+        call end_test()
+    end subroutine test_stacked_horizontal_bars
+
+    subroutine test_stacked_bar_ranges()
+        type(figure_t) :: fig
+        real(wp) :: x(2) = [1.0_wp, 2.0_wp]
+        real(wp) :: h1(2) = [10.0_wp, 20.0_wp]
+        real(wp) :: h2(2) = [5.0_wp, 10.0_wp]
+
+        call start_test("Data range calculation for stacked bars")
+
+        call fig%initialize(400, 300)
+
+        call bar_impl(fig, x, h1)
+        call bar_impl(fig, x, h2, bottom=h1)
+
+        ! The y-range should include the full stacked height (h1 + h2)
+        ! For x=2: h1=20, h2=10, so max y should be 30
+        call assert_true(fig%state%y_max >= 25.0_wp, &
+                        "Y-max includes stacked heights")
+
+        call end_test()
+    end subroutine test_stacked_bar_ranges
+
+    subroutine test_stacked_bar_stateful()
+        real(wp) :: x(3) = [1.0_wp, 2.0_wp, 3.0_wp]
+        real(wp) :: heights1(3) = [5.0_wp, 10.0_wp, 7.0_wp]
+        real(wp) :: heights2(3) = [3.0_wp, 5.0_wp, 4.0_wp]
+        real(wp) :: heights3(3) = [2.0_wp, 3.0_wp, 2.0_wp]
+        real(wp), dimension(3) :: c1 = [0.2_wp, 0.6_wp, 0.8_wp]
+        real(wp), dimension(3) :: c2 = [0.8_wp, 0.6_wp, 0.2_wp]
+        real(wp), dimension(3) :: c3 = [0.4_wp, 0.8_wp, 0.4_wp]
+
+        call start_test("Stacked bars via stateful interface")
+
+        call figure(figsize=[6.4_wp, 4.8_wp])
+
+        ! Three layers of stacked bars
+        call bar(x, heights1, label='Layer 1', color=c1)
+        call bar(x, heights2, bottom=heights1, label='Layer 2', color=c2)
+        call bar(x, heights3, bottom=heights1 + heights2, label='Layer 3', color=c3)
+
+        call legend()
+        call title('Three-Layer Stacked Bar Chart')
+        call xlabel('Categories')
+        call ylabel('Values')
+
+        call savefig('test/output/stacked_bars_stateful.png')
+        print *, '  Output: test/output/stacked_bars_stateful.png'
+
+        call end_test()
+    end subroutine test_stacked_bar_stateful
+
+    subroutine start_test(test_name)
+        character(len=*), intent(in) :: test_name
+        test_count = test_count + 1
+        write(*, '(A, I0, A, A)') 'Test ', test_count, ': ', test_name
+    end subroutine start_test
+
+    subroutine end_test()
+        pass_count = pass_count + 1
+        write(*, '(A)') '  PASS'
+        write(*, *)
+    end subroutine end_test
+
+    subroutine assert_equal(actual, expected, description)
+        real(wp), intent(in) :: actual, expected
+        character(len=*), intent(in) :: description
+
+        if (abs(actual - expected) < 1.0e-10_wp) then
+            print *, '  PASS: ', description
+        else
+            print *, '  FAIL: ', description, ' (expected ', expected, ', got ', actual, ')'
+            fail_count = fail_count + 1
+        end if
+    end subroutine assert_equal
+
+    subroutine assert_true(condition, description)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: description
+
+        if (condition) then
+            print *, '  PASS: ', description
+        else
+            print *, '  FAIL: ', description
+            fail_count = fail_count + 1
+        end if
+    end subroutine assert_true
+
+    subroutine print_test_summary()
+        write(*, '(A)') '============================================'
+        write(*, '(A)') 'Stacked Bar Chart Test Summary (Issue #1460)'
+        write(*, '(A, I0, A, I0, A, I0)') 'Tests run: ', test_count, &
+            ' | Passed: ', pass_count, ' | Failed: ', fail_count
+        if (fail_count == 0) then
+            write(*, '(A)') 'ALL TESTS PASSED!'
+        else
+            write(*, '(A)') 'SOME TESTS FAILED!'
+        end if
+        write(*, '(A)') '============================================'
+    end subroutine print_test_summary
+
+end program test_stacked_bar_charts


### PR DESCRIPTION
## Summary

Add stacked bar chart support by introducing `bottom` parameter for vertical bars and `left` parameter for horizontal bars. This enables users to stack multiple data series on top of each other.

- Add `bottom` parameter to `bar()` for stacking vertical bars
- Add `left` parameter to `barh()` for stacking horizontal bars
- Proper data range calculation includes stacked values
- Legend support for each stacked layer

## API Usage

```fortran
! Stacked vertical bars
call bar(x, layer1, label='Product A')
call bar(x, layer2, bottom=layer1, label='Product B')
call bar(x, layer3, bottom=layer1 + layer2, label='Product C')

! Stacked horizontal bars
call barh(y, width1, label='Category 1')
call barh(y, width2, left=width1, label='Category 2')
```

## Verification

```
$ fpm test test_stacked_bar_charts 2>&1
=== STACKED BAR CHART TESTS (Issue #1460) ===
Test 1: Stacked vertical bars with bottom parameter
   PASS: First bar layer added
   PASS: Second bar layer stacked
  PASS
Test 2: Stacked horizontal bars with left parameter
   PASS: First horizontal bar added
   PASS: Second horizontal bar stacked
  PASS
Test 3: Data range calculation for stacked bars
   PASS: Y-max includes stacked heights
  PASS
Test 4: Stacked bars via stateful interface
  PASS
============================================
Tests run: 4 | Passed: 4 | Failed: 0
ALL TESTS PASSED!
```

Output files generated:
- `test/output/stacked_vertical_bars.png`
- `test/output/stacked_horizontal_bars.png`
- `test/output/stacked_bars_stateful.png`

## Test Plan

- [x] Build succeeds
- [x] Stacked bar test passes (4/4 tests)
- [x] Full test suite passes without regressions
- [x] Example updated with stacked bars demo