### PR TITLE
fix: extend PDF tokenizer string parsing (fixes #1528)

### DIFF
--- a/src/tests/test_pdf_utils.f90
+++ b/src/tests/test_pdf_utils.f90
@@ -380,7 +380,7 @@ contains
         depth = 1
         i = pos + 1
         do while (i <= n)
-            if (text(i:i) == '\') then
+            if (text(i:i) == achar(92)) then
                 if (i == n) then
                     i = i + 1
                     exit

--- a/test/test_pdf_stream_tokenizer_1528.f90
+++ b/test/test_pdf_stream_tokenizer_1528.f90
@@ -4,25 +4,44 @@ program test_pdf_stream_tokenizer_1528
 
     character(len=1), parameter :: bslash = achar(92)
 
-    call assert_tokens2('<48 65 6c6c6f>Tj', '<48 65 6c6c6f>', 14, 'Tj', 2)
+    character(len=*), parameter :: hex_simple = '<48 65 6c6c6f>Tj'
+    character(len=*), parameter :: tok_hex_simple = '<48 65 6c6c6f>'
 
-    call assert_tokens2('<48' // achar(10) // '65' // achar(9) // '6c6c6f>Tj', &
-                       '<48' // achar(10) // '65' // achar(9) // '6c6c6f>', &
-                       len('<48' // achar(10) // '65' // achar(9) // '6c6c6f>'), &
-                       'Tj', 2)
+    character(len=*), parameter :: hex_ws = '<48' // achar(10) // '65' // &
+                                           achar(9) // '6c6c6f>Tj'
+    character(len=*), parameter :: tok_hex_ws = '<48' // achar(10) // '65' // &
+                                               achar(9) // '6c6c6f>'
 
-    call assert_tokens2('(a' // bslash // achar(10) // ')Tj', &
-                       '(a' // bslash // achar(10) // ')', &
-                       len('(a' // bslash // achar(10) // ')'), 'Tj', 2)
+    character(len=*), parameter :: lit_lf = '(a' // bslash // achar(10) // ')Tj'
+    character(len=*), parameter :: tok_lit_lf = '(a' // bslash // achar(10) // &
+                                                ')'
 
-    call assert_tokens2('(a' // bslash // achar(13) // achar(10) // ')Tj', &
-                       '(a' // bslash // achar(13) // achar(10) // ')', &
-                       len('(a' // bslash // achar(13) // achar(10) // ')'), &
-                       'Tj', 2)
+    character(len=*), parameter :: lit_crlf = '(a' // bslash // achar(13) // &
+                                              achar(10) // ')Tj'
+    character(len=*), parameter :: tok_lit_crlf = '(a' // bslash // achar(13) // &
+                                                  achar(10) // ')'
 
-    call assert_tokens2('(a\053\050b\051c\n\r\t\b\f)Tj', &
-                       '(a\053\050b\051c\n\r\t\b\f)', &
-                       len('(a\053\050b\051c\n\r\t\b\f)'), 'Tj', 2)
+    character(len=*), parameter :: lit_escapes = '(a' // bslash // '053' // &
+                                                 bslash // '050b' // bslash // &
+                                                 '051c' // bslash // 'n' // &
+                                                 bslash // 'r' // bslash // 't' // &
+                                                 bslash // 'b' // bslash // 'f)Tj'
+    character(len=*), parameter :: tok_lit_escapes = '(a' // bslash // '053' // &
+                                                     bslash // '050b' // &
+                                                     bslash // '051c' // bslash // &
+                                                     'n' // bslash // 'r' // &
+                                                     bslash // 't' // bslash // &
+                                                     'b' // bslash // 'f)'
+
+    call assert_tokens2(hex_simple, tok_hex_simple, len(tok_hex_simple), 'Tj', 2)
+
+    call assert_tokens2(hex_ws, tok_hex_ws, len(tok_hex_ws), 'Tj', 2)
+
+    call assert_tokens2(lit_lf, tok_lit_lf, len(tok_lit_lf), 'Tj', 2)
+
+    call assert_tokens2(lit_crlf, tok_lit_crlf, len(tok_lit_crlf), 'Tj', 2)
+
+    call assert_tokens2(lit_escapes, tok_lit_escapes, len(tok_lit_escapes), 'Tj', 2)
 
     print *, 'PASS: PDF stream tokenizer handles PDF string edge cases'
 contains


### PR DESCRIPTION
### **User description**
Fixes #1528

- Extend `pdf_scan_literal_string` scanning to handle PDF escape forms (line continuation after backslash+CR/LF, octal escapes, and standard escapes).
- Add `test_pdf_stream_tokenizer_1528` covering literal-string and hex-string edge cases.

## Verification
- `make build`
  - `fpm build --flag -fPIC`
  - `Project is up to date`
- `make test`
  - `[  5%] test_pdf_stream_tokenizer_1528  done.`
  - `ALL TESTS PASSED (fpm test)`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extend PDF literal string parsing to handle escape sequences
  - Line continuation after backslash+CR/LF
  - Octal escape sequences (up to 3 digits)
  - Standard escape characters

- Add helper function `is_octal_digit` for octal validation

- Add comprehensive test suite for PDF string edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PDF Literal String Parser"] -->|Handle Backslash| B["Check Escape Type"]
  B -->|CR/LF| C["Line Continuation"]
  B -->|Octal Digit| D["Parse Octal Escape"]
  B -->|Other| E["Standard Escape"]
  C --> F["Updated Parser"]
  D --> F
  E --> F
  F -->|Test Cases| G["Edge Case Coverage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pdf_utils.f90</strong><dd><code>Enhance PDF literal string escape sequence parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_pdf_utils.f90

<ul><li>Replaced simple boolean <code>escaped</code> flag with comprehensive escape <br>sequence handling<br> <li> Added support for line continuation (backslash followed by CR/LF <br>combinations)<br> <li> Implemented octal escape sequence parsing (1-3 octal digits)<br> <li> Added <code>is_octal_digit</code> helper function to validate octal characters<br> <li> Refactored escape handling logic to use early cycle/exit patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1531/files#diff-fab84acf961a228ff279de29b914b613659fbb850cb3a1558e2099143d578d0c">+50/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pdf_stream_tokenizer_1528.f90</strong><dd><code>Add PDF tokenizer string edge case tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_pdf_stream_tokenizer_1528.f90

<ul><li>New test program covering PDF string tokenization edge cases<br> <li> Tests hex strings with embedded whitespace and newlines<br> <li> Tests literal strings with line continuation (backslash+LF and <br>backslash+CR+LF)<br> <li> Tests octal escape sequences and standard escape characters<br> <li> Validates correct token length and content extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1531/files#diff-4f9419af9502de05c45be51c6bbfece170a172a76eaa55deac0b28de307bfb94">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

