### PR TITLE
fix: harden markercolor pixel-based regression test (fixes #1540)

### DIFF
--- a/test/test_markercolor_line_markers.f90
+++ b/test/test_markercolor_line_markers.f90
@@ -1,13 +1,15 @@
 program test_markercolor_line_markers
-    use, intrinsic :: iso_fortran_env, only: wp => real64, error_unit
-    use fortplot_figure_core, only: figure_t
+    use, intrinsic :: iso_fortran_env, only: dp => real64, error_unit
     use fortplot_2d_plots, only: add_plot
+    use fortplot_figure_core, only: figure_t
+
     implicit none
 
     integer, parameter :: width = 200
     integer, parameter :: height = 150
-    real(wp) :: x(2), y_line(2), y_mark(2)
-    real(wp) :: rgb(width, height, 3)
+
+    real(dp) :: x(2), y_line(2), y_mark(2)
+    real(dp) :: rgb(width, height, 3)
     integer :: i, j
     integer :: i1, i2
     integer :: j_top1, j_top2
@@ -16,34 +18,34 @@ program test_markercolor_line_markers
     integer :: blue_top, blue_bottom
     integer :: marker_red, marker_blue
     integer :: line_red, line_blue
-    real(wp) :: max_r, max_r_g, max_r_b
-    real(wp) :: max_b, max_b_r, max_b_g
+    real(dp) :: max_r, max_r_g, max_r_b
+    real(dp) :: max_b, max_b_r, max_b_g
     type(figure_t) :: fig
 
-    x = [0.2_wp, 0.8_wp]
-    y_line = [0.9_wp, 0.7_wp]
-    y_mark = [0.2_wp, 0.4_wp]
+    x = [0.2_dp, 0.8_dp]
+    y_line = [0.9_dp, 0.7_dp]
+    y_mark = [0.2_dp, 0.4_dp]
 
     call fig%initialize(width=width, height=height, backend='png')
-    call fig%set_xlim(0.0_wp, 1.0_wp)
-    call fig%set_ylim(0.0_wp, 1.0_wp)
+    call fig%set_xlim(0.0_dp, 1.0_dp)
+    call fig%set_ylim(0.0_dp, 1.0_dp)
 
-    call add_plot(fig, x, y_line, linestyle='-', color_rgb=[0.0_wp, 0.0_wp, &
-                                                           1.0_wp])
+    call add_plot(fig, x, y_line, linestyle='-', color_rgb=[0.0_dp, 0.0_dp, &
+                                                            1.0_dp])
 
-    call add_plot(fig, x, y_mark, linestyle='none', color_rgb=[0.0_wp, &
-                                                               1.0_wp, &
-                                                               0.0_wp], &
-                  marker='o', markercolor=[1.0_wp, 0.0_wp, 0.0_wp])
+    call add_plot(fig, x, y_mark, linestyle='none', color_rgb=[0.0_dp, &
+                                                               1.0_dp, &
+                                                               0.0_dp], &
+                  marker='o', markercolor=[1.0_dp, 0.0_dp, 0.0_dp])
 
     call fig%extract_rgb_data_for_animation(rgb)
 
-    max_r = -1.0_wp
-    max_r_g = 0.0_wp
-    max_r_b = 0.0_wp
-    max_b = -1.0_wp
-    max_b_r = 0.0_wp
-    max_b_g = 0.0_wp
+    max_r = -1.0_dp
+    max_r_g = 0.0_dp
+    max_r_b = 0.0_dp
+    max_b = -1.0_dp
+    max_b_r = 0.0_dp
+    max_b_g = 0.0_dp
     do j = 1, height
         do i = 1, width
             if (rgb(i, j, 1) > max_r) then
@@ -62,8 +64,8 @@ program test_markercolor_line_markers
     i1 = width/4
     i2 = 3*width/4
     j_top1 = height/6
-    j_top2 = height/2
-    j_bottom1 = height/2
+    j_top2 = height/2 - 1
+    j_bottom1 = height/2 + 1
     j_bottom2 = 5*height/6
 
     call count_dominant_pixels(rgb, i1, i2, j_top1, j_top2, red_top, blue_top)
@@ -78,7 +80,8 @@ program test_markercolor_line_markers
 
     if (marker_red < 12) then
         write (error_unit, *) "FAIL: expected red marker pixels in ROI"
-        write (error_unit, *) "INFO: red_top:", red_top, "red_bottom:", red_bottom
+        write (error_unit, *) "INFO: red_top:", red_top, "red_bottom:", &
+            red_bottom
         write (error_unit, *) "INFO: max R:", max_r, "at (R,G,B)=", max_r, &
             max_r_g, max_r_b
         stop 1
@@ -86,7 +89,8 @@ program test_markercolor_line_markers
 
     if (line_blue < 12) then
         write (error_unit, *) "FAIL: expected blue line pixels in ROI"
-        write (error_unit, *) "INFO: blue_top:", blue_top, "blue_bottom:", blue_bottom
+        write (error_unit, *) "INFO: blue_top:", blue_top, "blue_bottom:", &
+            blue_bottom
         write (error_unit, *) "INFO: max B:", max_b, "at (R,G,B)=", max_b_r, &
             max_b_g, max_b
         stop 1
@@ -95,7 +99,8 @@ program test_markercolor_line_markers
     if (red_top >= red_bottom) then
         if (blue_top >= blue_bottom) then
             write (error_unit, *) "FAIL: red and blue dominate same ROI (top)"
-            write (error_unit, *) "INFO: red_top:", red_top, "blue_top:", blue_top
+            write (error_unit, *) "INFO: red_top:", red_top, "blue_top:", &
+                blue_top
             stop 1
         end if
     else
@@ -125,18 +130,20 @@ program test_markercolor_line_markers
 contains
 
     pure logical function is_red_pixel(r, g, b) result(is_red)
-        real(wp), intent(in) :: r, g, b
-        is_red = r > 0.65_wp .and. r > g + 0.15_wp .and. r > b + 0.15_wp
+        real(dp), intent(in) :: r, g, b
+
+        is_red = r > 0.65_dp .and. r > g + 0.15_dp .and. r > b + 0.15_dp
     end function is_red_pixel
 
     pure logical function is_blue_pixel(r, g, b) result(is_blue)
-        real(wp), intent(in) :: r, g, b
-        is_blue = b > 0.65_wp .and. b > r + 0.15_wp .and. b > g + 0.15_wp
+        real(dp), intent(in) :: r, g, b
+
+        is_blue = b > 0.65_dp .and. b > r + 0.15_dp .and. b > g + 0.15_dp
     end function is_blue_pixel
 
     subroutine count_dominant_pixels(rgb_in, ii1, ii2, jj1, jj2, red_count, &
-                                    blue_count)
-        real(wp), intent(in) :: rgb_in(width, height, 3)
+                                     blue_count)
+        real(dp), intent(in) :: rgb_in(width, height, 3)
         integer, intent(in) :: ii1, ii2, jj1, jj2
         integer, intent(out) :: red_count, blue_count
         integer :: ii, jj


### PR DESCRIPTION
### **User description**
Fixes #1540

Summary
- Make `test_markercolor_line_markers` deterministic by counting red/blue-dominant pixels in two fixed ROIs instead of global pixel thresholds.
- Assert behavior via rendered RGB output only (no inspection of internal `marker_color_set`).

Verification
- `make test-ci 2>&1 | tee /tmp/fortplot-test-ci-1540.log`
- Excerpt:
  - `[  0%] test_markercolor_line_markers.`
  - `[100%]  test_markercolor_line_markers  done.`
  - `CI essential test suite completed successfully`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace global pixel thresholds with region-of-interest (ROI) based pixel counting for deterministic test behavior

- Remove internal state inspection (`marker_color_set`) and rely solely on rendered RGB output validation

- Introduce helper functions (`is_red_pixel`, `is_blue_pixel`, `count_dominant_pixels`) for robust color detection

- Add comprehensive validation checks ensuring red markers and blue lines occupy distinct ROIs with sufficient color dominance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global pixel thresholds"] -->|Replace with| B["ROI-based counting"]
  C["Internal marker_color_set check"] -->|Remove| D["RGB output validation only"]
  E["Simple pixel counting"] -->|Enhance with| F["Helper functions for color detection"]
  B --> G["Deterministic test results"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_markercolor_line_markers.f90</strong><dd><code>Implement ROI-based pixel validation for test determinism</code></dd></summary>
<hr>

test/test_markercolor_line_markers.f90

<ul><li>Replaced global pixel threshold approach with two fixed ROIs (top and <br>bottom regions) for deterministic color counting<br> <li> Removed internal state check (<code>marker_color_set</code>) and replaced with pure <br>RGB output validation<br> <li> Added helper functions <code>is_red_pixel()</code>, <code>is_blue_pixel()</code>, and <br><code>count_dominant_pixels()</code> subroutine for robust color detection with <br>stricter thresholds (0.65 intensity, 0.15 channel difference)<br> <li> Enhanced validation logic with multiple assertions: minimum pixel <br>counts per ROI (12 pixels), color separation between ROIs, and color <br>dominance margins (6-pixel difference)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1547/files#diff-9bf4619a250b11fe2095cae4e877fa84f2b68863d845e73a783b2ea83dbad14f">+99/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

