### PR TITLE
fix: simplify int8->u8 conversion in raster_extract_rgb_data (fixes #1541)

### DIFF
--- a/src/backends/raster/fortplot_raster_rendering.f90
+++ b/src/backends/raster/fortplot_raster_rendering.f90
@@ -274,12 +274,9 @@ contains
                 idx_base = ((y - 1)*width + (x - 1))*3
 
                 ! Extract RGB values (normalized to 0-1) from signed int8 storage.
-                r_u8 = int(raster%image_data(idx_base + 1))
-                g_u8 = int(raster%image_data(idx_base + 2))
-                b_u8 = int(raster%image_data(idx_base + 3))
-                if (r_u8 < 0) r_u8 = r_u8 + 256
-                if (g_u8 < 0) g_u8 = g_u8 + 256
-                if (b_u8 < 0) b_u8 = b_u8 + 256
+                r_u8 = iand(int(raster%image_data(idx_base + 1)), 255)
+                g_u8 = iand(int(raster%image_data(idx_base + 2)), 255)
+                b_u8 = iand(int(raster%image_data(idx_base + 3)), 255)
 
                 rgb_data(x, y, 1) = real(r_u8, wp)/255.0_wp
                 rgb_data(x, y, 2) = real(g_u8, wp)/255.0_wp

--- a/test/test_scatter_style_options_1534.f90
+++ b/test/test_scatter_style_options_1534.f90
@@ -67,7 +67,33 @@ contains
                          linewidth=linewidth)
 
         call fig%extract_rgb_data_for_animation(rgb)
+        call assert_background_white(rgb)
     end subroutine render_scatter
+
+    subroutine assert_background_white(rgb)
+        real(wp), intent(in) :: rgb(width, height, 3)
+        real(wp), parameter :: tol = 1.0e-12_wp
+
+        call assert_pixel_white(rgb, 1, 1, tol)
+        call assert_pixel_white(rgb, width, 1, tol)
+        call assert_pixel_white(rgb, 1, height, tol)
+        call assert_pixel_white(rgb, width, height, tol)
+    end subroutine assert_background_white
+
+    subroutine assert_pixel_white(rgb, i, j, tol)
+        real(wp), intent(in) :: rgb(width, height, 3)
+        integer, intent(in) :: i, j
+        real(wp), intent(in) :: tol
+
+        if (abs(rgb(i, j, 1) - 1.0_wp) > tol .or. &
+            abs(rgb(i, j, 2) - 1.0_wp) > tol .or. &
+            abs(rgb(i, j, 3) - 1.0_wp) > tol) then
+            write (error_unit, *) "FAIL: expected background pixels to be white"
+            write (error_unit, *) "INFO: i:", i, "j:", j
+            write (error_unit, *) "INFO: rgb:", rgb(i, j, 1), rgb(i, j, 2), rgb(i, j, 3)
+            stop 1
+        end if
+    end subroutine assert_pixel_white
 
     subroutine analyze_roi(rgb, min_lum, max_redness, red_count)
         real(wp), intent(in) :: rgb(width, height, 3)


### PR DESCRIPTION
### **User description**
Fixes #1541

Summary
- Simplify PNG raster byte to u8 conversion in `raster_extract_rgb_data` using a mask instead of branches.
- Extend `test_scatter_style_options_1534` to assert corner background pixels remain white, exercising u8 conversion for 255.

Verification
- `make build 2>&1 | tee /tmp/fortplot_make_build.log`
  - `[100%] Project compiled successfully.`
- `make test 2>&1 | tee /tmp/fortplot_make_test.log`
  - `ALL TESTS PASSED (fpm test)`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Simplify int8 to u8 conversion using bitwise AND mask instead of conditional branches

- Add corner pixel assertions to verify white background pixels are correctly converted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["int8 PNG data"] -->|"iand with 255 mask"| B["u8 values"]
  B -->|"normalize to 0-1"| C["RGB data"]
  D["Test scatter plot"] -->|"extract RGB"| E["Assert corners white"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_raster_rendering.f90</strong><dd><code>Replace conditional branches with bitwise AND mask</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/raster/fortplot_raster_rendering.f90

<ul><li>Replace conditional branch logic with bitwise AND operation (<code>iand</code>) for <br>int8 to u8 conversion<br> <li> Simplifies three separate if-statements into single mask operations <br>for R, G, B channels<br> <li> Maintains identical functionality while improving code clarity and <br>performance</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1548/files#diff-00e3ae4df949fbddeee0648d41eca597dcf5b34b1cf89126b40724c062cb5b8c">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scatter_style_options_1534.f90</strong><dd><code>Add corner pixel white background assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_scatter_style_options_1534.f90

<ul><li>Add <code>assert_background_white</code> subroutine to verify all four corner <br>pixels are white<br> <li> Add <code>assert_pixel_white</code> helper subroutine with tolerance-based <br>comparison<br> <li> Call background assertion in <code>render_scatter</code> to exercise u8 conversion <br>for value 255<br> <li> Include detailed error output showing pixel coordinates and RGB values <br>on failure</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1548/files#diff-be6d0edeb2439278505bf065008b605d2665c647a8d492b95076f55ded9df622">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

