### PR TITLE
fix: expose edgecolor/facecolor/linewidth in wrappers (fixes #1544)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -46,7 +46,7 @@ contains
         idx = fig%current_subplot
 
         if (nrows > 0 .and. ncols > 0 .and. idx >= 1 .and. idx <= nrows*ncols) then
-            row = (idx - 1) / ncols + 1
+            row = (idx - 1)/ncols + 1
             col = mod(idx - 1, ncols) + 1
             call fig%subplot_plot(row, col, x, y, label=label, linestyle=linestyle)
         else
@@ -86,7 +86,7 @@ contains
         bar_width = 0.8_wp
         if (present(width)) bar_width = width
 
-        allocate(bar_bottom(size(x)))
+        allocate (bar_bottom(size(x)))
         bar_bottom = 0.0_wp
         if (present(bottom)) then
             if (size(bottom) == size(x)) then
@@ -95,7 +95,6 @@ contains
                 bar_bottom = bottom(1)
             else
                 call log_error("bar: bottom array size must match x array or be scalar")
-                deallocate(bar_bottom)
                 return
             end if
         end if
@@ -105,7 +104,6 @@ contains
 
         call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, label=label, &
                       color=color)
-        deallocate(bar_bottom)
     end subroutine bar
 
     subroutine barh(y, width, height, left, label, color, edgecolor, align)
@@ -124,7 +122,7 @@ contains
         bar_height = 0.8_wp
         if (present(height)) bar_height = height
 
-        allocate(bar_left(size(y)))
+        allocate (bar_left(size(y)))
         bar_left = 0.0_wp
         if (present(left)) then
             if (size(left) == size(y)) then
@@ -133,7 +131,6 @@ contains
                 bar_left = left(1)
             else
                 call log_error("barh: left array size must match y array or be scalar")
-                deallocate(bar_left)
                 return
             end if
         end if
@@ -143,7 +140,6 @@ contains
 
         call barh_impl(fig, y, width, height=bar_height, left=bar_left, label=label, &
                        color=color)
-        deallocate(bar_left)
     end subroutine barh
 
     subroutine hist(data, bins, density, label, color)
@@ -183,7 +179,7 @@ contains
     end subroutine boxplot
 
     subroutine scatter(x, y, s, c, label, marker, markersize, color, &
-                          linewidths, edgecolors, alpha)
+                       linewidths, edgecolors, alpha)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: s
         real(wp), intent(in), optional :: c(:)
@@ -194,11 +190,25 @@ contains
         real(wp), intent(in), optional :: edgecolors(3)
         real(wp), intent(in), optional :: alpha
 
-        call scatter_2d_entry(x, y, label=label, marker=marker)
+        if (present(markersize)) then
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  markersize=markersize, color=color, &
+                                  linewidth=linewidths, edgecolor=edgecolors, &
+                                  alpha=alpha)
+        else if (present(s)) then
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  markersize=s, color=color, &
+                                  linewidth=linewidths, edgecolor=edgecolors, &
+                                  alpha=alpha)
+        else
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  color=color, linewidth=linewidths, &
+                                  edgecolor=edgecolors, alpha=alpha)
+        end if
     end subroutine scatter
 
     subroutine add_scatter_2d_wrapper(x, y, s, c, label, marker, markersize, &
-                                          color, linewidths, edgecolors, alpha)
+                                      color, linewidths, edgecolors, alpha)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: s
         real(wp), intent(in), optional :: c(:)
@@ -209,11 +219,25 @@ contains
         real(wp), intent(in), optional :: edgecolors(3)
         real(wp), intent(in), optional :: alpha
 
-        call scatter_2d_entry(x, y, label=label, marker=marker)
+        if (present(markersize)) then
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  markersize=markersize, color=color, &
+                                  linewidth=linewidths, edgecolor=edgecolors, &
+                                  alpha=alpha)
+        else if (present(s)) then
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  markersize=s, color=color, &
+                                  linewidth=linewidths, edgecolor=edgecolors, &
+                                  alpha=alpha)
+        else
+            call scatter_2d_entry(x, y, c=c, label=label, marker=marker, &
+                                  color=color, linewidth=linewidths, &
+                                  edgecolor=edgecolors, alpha=alpha)
+        end if
     end subroutine add_scatter_2d_wrapper
 
     subroutine add_scatter_3d_wrapper(x, y, z, s, c, label, marker, markersize, &
-                                          color, linewidths, edgecolors, alpha)
+                                      color, linewidths, edgecolors, alpha)
         real(wp), intent(in) :: x(:), y(:), z(:)
         real(wp), intent(in), optional :: s
         real(wp), intent(in), optional :: c(:)
@@ -227,12 +251,23 @@ contains
         real(wp), allocatable :: wx(:), wy(:), wz(:)
 
         call ensure_fig_init()
-        allocate(wx(size(x)), wy(size(y)), wz(size(z)))
+        allocate (wx(size(x)), wy(size(y)), wz(size(z)))
         wx = x
         wy = y
         wz = z
-        call add_scatter_3d(fig, wx, wy, wz, label=label, marker=marker)
-        deallocate(wx, wy, wz)
+        if (present(markersize)) then
+            call add_scatter_3d(fig, wx, wy, wz, c=c, label=label, marker=marker, &
+                                markersize=markersize, color=color, alpha=alpha, &
+                                edgecolor=edgecolors, linewidth=linewidths)
+        else if (present(s)) then
+            call add_scatter_3d(fig, wx, wy, wz, c=c, label=label, marker=marker, &
+                                markersize=s, color=color, alpha=alpha, &
+                                edgecolor=edgecolors, linewidth=linewidths)
+        else
+            call add_scatter_3d(fig, wx, wy, wz, c=c, label=label, marker=marker, &
+                                color=color, alpha=alpha, edgecolor=edgecolors, &
+                                linewidth=linewidths)
+        end if
     end subroutine add_scatter_3d_wrapper
 
     subroutine add_plot(x, y, label, linestyle, color)
@@ -245,7 +280,7 @@ contains
     end subroutine add_plot
 
     subroutine add_errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, &
-                               marker, color, elinewidth, capthick)
+                            marker, color, elinewidth, capthick)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: xerr(:), yerr(:)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
@@ -260,7 +295,7 @@ contains
     end subroutine add_errorbar
 
     subroutine add_3d_plot(x, y, z, label, linestyle, color, linewidth, marker, &
-                              markersize)
+                           markersize)
         real(wp), intent(in) :: x(:), y(:), z(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
@@ -271,18 +306,23 @@ contains
                               marker=marker, markersize=markersize, linewidth=linewidth)
     end subroutine add_3d_plot
 
-    subroutine scatter_2d_entry(x, y, label, marker)
+    subroutine scatter_2d_entry(x, y, c, label, marker, markersize, color, &
+                                linewidth, edgecolor, alpha)
         real(wp), intent(in) :: x(:), y(:)
+        real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker
+        real(wp), intent(in), optional :: markersize, linewidth, alpha
+        real(wp), intent(in), optional :: color(3), edgecolor(3)
 
         real(wp), allocatable :: wx(:), wy(:)
 
         call ensure_fig_init()
-        allocate(wx(size(x)), wy(size(y)))
+        allocate (wx(size(x)), wy(size(y)))
         wx = x
         wy = y
-        call add_scatter_2d(fig, wx, wy, label=label, marker=marker)
-        deallocate(wx, wy)
+        call add_scatter_2d(fig, wx, wy, c=c, label=label, marker=marker, &
+                            markersize=markersize, color=color, alpha=alpha, &
+                            edgecolor=edgecolor, linewidth=linewidth)
     end subroutine scatter_2d_entry
 
 end module fortplot_matplotlib_plot_wrappers

--- a/src/plotting/fortplot_scatter_plots.f90
+++ b/src/plotting/fortplot_scatter_plots.f90
@@ -30,8 +30,9 @@ module fortplot_scatter_plots
 
 contains
 
-    subroutine add_scatter_2d_impl(self, x, y, s, c, label, marker, markersize, color, &
-                                   colormap, vmin, vmax, show_colorbar, alpha)
+    subroutine add_scatter_2d_impl(self, x, y, s, c, label, marker, markersize, &
+                                   color, colormap, vmin, vmax, show_colorbar, &
+                                   alpha, edgecolor, facecolor, linewidth)
         !! Add 2D scatter plot to figure
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
@@ -45,17 +46,21 @@ contains
         real(wp), intent(in), optional :: vmin, vmax
         logical, intent(in), optional :: show_colorbar
         real(wp), intent(in), optional :: alpha
+        real(wp), intent(in), optional :: edgecolor(3), facecolor(3), linewidth
 
         call add_scatter_plot_data(self, x, y, s=s, c=c, label=label, &
                                    marker=marker, markersize=markersize, color=color, &
                                    colormap=colormap, vmin=vmin, vmax=vmax, &
-                                   show_colorbar=show_colorbar, alpha=alpha)
+                                   show_colorbar=show_colorbar, alpha=alpha, &
+                                   edgecolor=edgecolor, facecolor=facecolor, &
+                                   linewidth=linewidth)
     end subroutine add_scatter_2d_impl
 
     subroutine add_scatter_3d_impl(self, x, y, z, s, c, label, marker, &
                                    markersize, &
                                    color, colormap, vmin, vmax, &
-                                   show_colorbar, alpha)
+                                   show_colorbar, alpha, edgecolor, facecolor, &
+                                   linewidth)
         !! Add 3D scatter plot to figure
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:), z(:)
@@ -69,22 +74,27 @@ contains
         real(wp), intent(in), optional :: vmin, vmax
         logical, intent(in), optional :: show_colorbar
         real(wp), intent(in), optional :: alpha
+        real(wp), intent(in), optional :: edgecolor(3), facecolor(3), linewidth
 
-        call add_scatter_plot_data(self, x, y, z, s, c, label, marker, &
-                                   markersize, &
-                                   color, colormap, vmin, vmax, &
-                                   show_colorbar, alpha)
+        call add_scatter_plot_data(self, x, y, z=z, s=s, c=c, label=label, &
+                                   marker=marker, markersize=markersize, &
+                                   color=color, colormap=colormap, vmin=vmin, &
+                                   vmax=vmax, show_colorbar=show_colorbar, &
+                                   alpha=alpha, edgecolor=edgecolor, &
+                                   facecolor=facecolor, linewidth=linewidth)
     end subroutine add_scatter_3d_impl
 
     subroutine add_scatter_plot_data(self, x, y, z, s, c, label, marker, &
                                      markersize, &
                                      color, colormap, vmin, vmax, &
-                                     show_colorbar, alpha)
+                                     show_colorbar, alpha, edgecolor, facecolor, &
+                                     linewidth)
         !! Add scatter plot data with optional properties
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: z(:), s(:), c(:), markersize
         real(wp), intent(in), optional :: color(3), vmin, vmax, alpha
+        real(wp), intent(in), optional :: edgecolor(3), facecolor(3), linewidth
         character(len=*), intent(in), optional :: label, marker, colormap
         logical, intent(in), optional :: show_colorbar
 
@@ -127,6 +137,8 @@ contains
                               s=s, c=c, marker=marker, markersize=markersize, &
                               color=color, colormap=colormap, vmin=vmin, &
                               vmax=vmax, &
+                              edgecolor=edgecolor, facecolor=facecolor, &
+                              linewidth=linewidth, &
                               alpha=alpha, label=label, &
                               show_colorbar=show_colorbar, &
                               default_color=default_color)
@@ -134,7 +146,9 @@ contains
             call core_scatter(self%plots, self%state, self%plot_count, x, y, &
                               s=s, c=c, &
                               marker=marker, markersize=markersize, color=color, &
-                              colormap=colormap, alpha=alpha, vmin=vmin, &
+                              colormap=colormap, alpha=alpha, &
+                              edgecolor=edgecolor, facecolor=facecolor, &
+                              linewidth=linewidth, vmin=vmin, &
                               vmax=vmax, &
                               label=label, show_colorbar=show_colorbar, &
                               default_color=default_color)

--- a/test/test_scatter_wrapper_styles_1544.f90
+++ b/test/test_scatter_wrapper_styles_1544.f90
@@ -1,0 +1,65 @@
+program test_scatter_wrapper_styles_1544
+    use fortplot, only: figure_t, wp
+    use fortplot_scatter_plots, only: add_scatter_2d, add_scatter_3d
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp) :: x(3), y(3), z(3)
+    real(wp) :: edge_color(3), face_color(3)
+    real(wp) :: tol
+    integer :: failures
+
+    tol = 1.0e-12_wp
+    failures = 0
+
+    x = [1.0_wp, 2.0_wp, 3.0_wp]
+    y = [4.0_wp, 5.0_wp, 6.0_wp]
+    z = [7.0_wp, 8.0_wp, 9.0_wp]
+
+    edge_color = [0.1_wp, 0.2_wp, 0.3_wp]
+    face_color = [0.9_wp, 0.8_wp, 0.7_wp]
+
+    call fig%initialize()
+    call add_scatter_2d(fig, x, y, edgecolor=edge_color, facecolor=face_color, &
+                        linewidth=2.5_wp)
+
+    if (.not. fig%plots(fig%plot_count)%marker_edgecolor_set) failures = failures + 1
+    if (.not. fig%plots(fig%plot_count)%marker_facecolor_set) failures = failures + 1
+
+    if (any(abs(fig%plots(fig%plot_count)%marker_edgecolor - edge_color) > tol)) then
+        failures = failures + 1
+    end if
+    if (any(abs(fig%plots(fig%plot_count)%marker_facecolor - face_color) > tol)) then
+        failures = failures + 1
+    end if
+    if (abs(fig%plots(fig%plot_count)%marker_linewidth - 2.5_wp) > tol) then
+        failures = failures + 1
+    end if
+
+    edge_color = [0.4_wp, 0.5_wp, 0.6_wp]
+    face_color = [0.6_wp, 0.5_wp, 0.4_wp]
+
+    call add_scatter_3d(fig, x, y, z, edgecolor=edge_color, facecolor=face_color, &
+                        linewidth=1.25_wp)
+
+    if (.not. fig%plots(fig%plot_count)%marker_edgecolor_set) failures = failures + 1
+    if (.not. fig%plots(fig%plot_count)%marker_facecolor_set) failures = failures + 1
+
+    if (any(abs(fig%plots(fig%plot_count)%marker_edgecolor - edge_color) > tol)) then
+        failures = failures + 1
+    end if
+    if (any(abs(fig%plots(fig%plot_count)%marker_facecolor - face_color) > tol)) then
+        failures = failures + 1
+    end if
+    if (abs(fig%plots(fig%plot_count)%marker_linewidth - 1.25_wp) > tol) then
+        failures = failures + 1
+    end if
+
+    if (failures == 0) then
+        print *, "PASS: test_scatter_wrapper_styles_1544"
+        stop 0
+    end if
+
+    print *, "FAIL: test_scatter_wrapper_styles_1544 failures=", failures
+    stop 1
+end program test_scatter_wrapper_styles_1544


### PR DESCRIPTION
### **User description**
Fixes #1544

Summary
- Extend `add_scatter_2d` / `add_scatter_3d` / `add_scatter_plot_data` to accept optional `edgecolor(3)`, `facecolor(3)`, and `linewidth` and forward them to `core_scatter`.
- Thread `edgecolors`/`linewidths` through `fortplot_matplotlib_plot_wrappers` so matplotlib-style scatter calls can reach the underlying scatter implementation.

Verification
- `make build 2>&1 | tee /tmp/fortplot-make-build.log`
  - `Project compiled successfully.`
- `make test 2>&1 | tee /tmp/fortplot-make-test.log`
  - `PASS: test_scatter_wrapper_styles_1544`
  - `ALL TESTS PASSED (fpm test)`
- `make verify-artifacts 2>&1 | tee /tmp/fortplot-verify-artifacts.log`
  - `Artifact verification passed.`
  - Artifacts checked include:
    - `output/example/fortran/scale_examples/symlog_scale.pdf`
    - `output/example/fortran/pcolormesh_demo/pcolormesh_basic.pdf`
    - `output/example/fortran/unicode_demo/unicode_demo.pdf`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Expose `edgecolor`, `facecolor`, and `linewidth` parameters in scatter plot wrappers

- Thread matplotlib-style scatter styling parameters through wrapper functions to core implementation

- Add support for marker edge/face colors and line width in 2D and 3D scatter plots

- Implement comprehensive test coverage for scatter wrapper styling functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Matplotlib-style scatter<br/>wrappers"] -->|"forward edgecolor,<br/>facecolor, linewidth"| B["scatter_2d_entry<br/>scatter_3d_entry"]
  B -->|"pass styling params"| C["add_scatter_2d<br/>add_scatter_3d"]
  C -->|"forward to core"| D["core_scatter"]
  D -->|"apply styles"| E["Plot markers<br/>with styles"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_matplotlib_plot_wrappers.f90</strong><dd><code>Thread scatter styling parameters through wrapper functions</code></dd></summary>
<hr>

src/interfaces/fortplot_matplotlib_plot_wrappers.f90

<ul><li>Updated <code>scatter</code> and <code>add_scatter_2d_wrapper</code> to accept and forward <br><code>linewidths</code> and <code>edgecolors</code> parameters<br> <li> Enhanced <code>add_scatter_3d_wrapper</code> to pass styling parameters <br>(<code>linewidths</code>, <code>edgecolors</code>, <code>c</code>, <code>alpha</code>) to <code>add_scatter_3d</code><br> <li> Modified <code>scatter_2d_entry</code> signature to accept <code>c</code>, <code>markersize</code>, <code>color</code>, <br><code>linewidth</code>, <code>edgecolor</code>, and <code>alpha</code> parameters<br> <li> Forwarded all styling parameters to underlying <code>add_scatter_2d</code> calls<br> <li> Applied code formatting/indentation standardization throughout the <br>file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1553/files#diff-7c5493ac7947d49effe392895f87ec2ac77d0f0f8b4c79399d26f7bd329bbe88">+325/-279</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortplot_scatter_plots.f90</strong><dd><code>Add scatter styling parameters to core scatter functions</code>&nbsp; </dd></summary>
<hr>

src/plotting/fortplot_scatter_plots.f90

<ul><li>Added <code>edgecolor</code>, <code>facecolor</code>, and <code>linewidth</code> optional parameters to <br><code>add_scatter_2d_impl</code><br> <li> Added <code>edgecolor</code>, <code>facecolor</code>, and <code>linewidth</code> optional parameters to <br><code>add_scatter_3d_impl</code><br> <li> Extended <code>add_scatter_plot_data</code> to accept and forward styling <br>parameters to <code>core_scatter</code><br> <li> Updated both 2D and 3D projection code paths to pass styling <br>parameters to core implementation<br> <li> Applied code formatting/indentation standardization throughout the <br>file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1553/files#diff-89cc5e53ad81c3758f0f7d562140a5f674266cb09534dd4ae1a31018037cd1f0">+161/-147</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scatter_wrapper_styles_1544.f90</strong><dd><code>Add comprehensive test for scatter wrapper styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_scatter_wrapper_styles_1544.f90

<ul><li>Created new test program to verify scatter wrapper styling <br>functionality<br> <li> Tests 2D scatter plots with <code>edgecolor</code>, <code>facecolor</code>, and <code>linewidth</code> <br>parameters<br> <li> Tests 3D scatter plots with the same styling parameters<br> <li> Validates that marker colors and line width are correctly set in plot <br>objects<br> <li> Verifies both parameter values and their corresponding <code>_set</code> flags</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1553/files#diff-782371b10bed7a1a91f744355712fd72105e895bde1c09e25b36f7a263bb33d3">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

