### PR TITLE
fix: polish: factor plot_context spy backend for rendering tests (fixes #1557)

### DIFF
--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -1,0 +1,261 @@
+module fortplot_spy_backend
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
+    use fortplot_plot_data, only: plot_data_t
+    implicit none
+
+    private
+    public :: spy_context_t
+
+    type, extends(plot_context) :: spy_context_t
+        real(wp) :: current_color(3) = [0.0_wp, 0.0_wp, 0.0_wp]
+        real(wp) :: expected_fill(3) = [0.0_wp, 0.0_wp, 0.0_wp]
+        real(wp) :: expected_edge(3) = [0.0_wp, 0.0_wp, 0.0_wp]
+        integer :: fill_calls = 0
+        integer :: line_calls = 0
+        integer :: unexpected_calls = 0
+        logical :: fill_color_ok = .true.
+        logical :: line_color_ok = .true.
+    contains
+        procedure :: reset => spy_reset
+        procedure :: line => spy_line
+        procedure :: color => spy_color
+        procedure :: text => spy_text
+        procedure :: save => spy_save
+        procedure :: set_line_width => spy_set_line_width
+        procedure :: set_line_style => spy_set_line_style
+        procedure :: draw_marker => spy_draw_marker
+        procedure :: set_marker_colors => spy_set_marker_colors
+        procedure :: set_marker_colors_with_alpha => spy_set_marker_colors_with_alpha
+        procedure :: draw_arrow => spy_draw_arrow
+        procedure :: get_ascii_output => spy_get_ascii_output
+        procedure :: get_width_scale => spy_get_width_scale
+        procedure :: get_height_scale => spy_get_height_scale
+        procedure :: fill_quad => spy_fill_quad
+        procedure :: fill_heatmap => spy_fill_heatmap
+        procedure :: extract_rgb_data => spy_extract_rgb_data
+        procedure :: get_png_data_backend => spy_get_png_data_backend
+        procedure :: prepare_3d_data => spy_prepare_3d_data
+        procedure :: render_ylabel => spy_render_ylabel
+        procedure :: draw_axes_and_labels_backend => spy_draw_axes_and_labels_backend
+        procedure :: save_coordinates => spy_save_coordinates
+        procedure :: set_coordinates => spy_set_coordinates
+        procedure :: render_axes => spy_render_axes
+    end type spy_context_t
+
+contains
+
+    pure logical function colors_close(a, b) result(ok)
+        real(wp), intent(in) :: a(3), b(3)
+        real(wp), parameter :: tol = 1.0e-12_wp
+
+        ok = all(abs(a - b) <= tol)
+    end function colors_close
+
+    subroutine spy_reset(this)
+        class(spy_context_t), intent(inout) :: this
+
+        this%current_color = [0.0_wp, 0.0_wp, 0.0_wp]
+        this%fill_calls = 0
+        this%line_calls = 0
+        this%unexpected_calls = 0
+        this%fill_color_ok = .true.
+        this%line_color_ok = .true.
+    end subroutine spy_reset
+
+    subroutine spy_line(this, x1, y1, x2, y2)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x1, y1, x2, y2
+
+        this%line_calls = this%line_calls + 1
+        this%line_color_ok = this%line_color_ok .and. &
+                             colors_close(this%current_color, this%expected_edge)
+    end subroutine spy_line
+
+    subroutine spy_color(this, r, g, b)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: r, g, b
+
+        this%current_color = [r, g, b]
+    end subroutine spy_color
+
+    subroutine spy_text(this, x, y, text)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x, y
+        character(len=*), intent(in) :: text
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_text
+
+    subroutine spy_save(this, filename)
+        class(spy_context_t), intent(inout) :: this
+        character(len=*), intent(in) :: filename
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_save
+
+    subroutine spy_set_line_width(this, width)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: width
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_set_line_width
+
+    subroutine spy_set_line_style(this, style)
+        class(spy_context_t), intent(inout) :: this
+        character(len=*), intent(in) :: style
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_set_line_style
+
+    subroutine spy_draw_marker(this, x, y, style)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x, y
+        character(len=*), intent(in) :: style
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_draw_marker
+
+    subroutine spy_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, face_g, &
+                                     face_b)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: edge_r, edge_g, edge_b
+        real(wp), intent(in) :: face_r, face_g, face_b
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_set_marker_colors
+
+    subroutine spy_set_marker_colors_with_alpha(this, edge_r, edge_g, edge_b, &
+                                                edge_alpha, face_r, face_g, face_b, &
+                                                face_alpha)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: edge_r, edge_g, edge_b, edge_alpha
+        real(wp), intent(in) :: face_r, face_g, face_b, face_alpha
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_set_marker_colors_with_alpha
+
+    subroutine spy_draw_arrow(this, x, y, dx, dy, size, style)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_draw_arrow
+
+    function spy_get_ascii_output(this) result(output)
+        class(spy_context_t), intent(in) :: this
+        character(len=:), allocatable :: output
+
+        output = ""
+    end function spy_get_ascii_output
+
+    function spy_get_width_scale(this) result(scale)
+        class(spy_context_t), intent(in) :: this
+        real(wp) :: scale
+
+        scale = 1.0_wp
+    end function spy_get_width_scale
+
+    function spy_get_height_scale(this) result(scale)
+        class(spy_context_t), intent(in) :: this
+        real(wp) :: scale
+
+        scale = 1.0_wp
+    end function spy_get_height_scale
+
+    subroutine spy_fill_quad(this, x_quad, y_quad)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x_quad(4), y_quad(4)
+
+        this%fill_calls = this%fill_calls + 1
+        this%fill_color_ok = this%fill_color_ok .and. &
+                             colors_close(this%current_color, this%expected_fill)
+    end subroutine spy_fill_quad
+
+    subroutine spy_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
+        real(wp), intent(in) :: z_min, z_max
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_fill_heatmap
+
+    subroutine spy_extract_rgb_data(this, width, height, rgb_data)
+        class(spy_context_t), intent(in) :: this
+        integer, intent(in) :: width, height
+        real(wp), intent(out) :: rgb_data(width, height, 3)
+
+        rgb_data = 0.0_wp
+    end subroutine spy_extract_rgb_data
+
+    subroutine spy_get_png_data_backend(this, width, height, png_data, status)
+        class(spy_context_t), intent(in) :: this
+        integer, intent(in) :: width, height
+        integer(1), allocatable, intent(out) :: png_data(:)
+        integer, intent(out) :: status
+
+        allocate (png_data(0))
+        status = 1
+    end subroutine spy_get_png_data_backend
+
+    subroutine spy_prepare_3d_data(this, plots)
+        class(spy_context_t), intent(inout) :: this
+        type(plot_data_t), intent(in) :: plots(:)
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_prepare_3d_data
+
+    subroutine spy_render_ylabel(this, ylabel)
+        class(spy_context_t), intent(inout) :: this
+        character(len=*), intent(in) :: ylabel
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_render_ylabel
+
+    subroutine spy_draw_axes_and_labels_backend(this, xscale, yscale, &
+                                                symlog_threshold, x_min, x_max, &
+                                                y_min, y_max, title, xlabel, ylabel, &
+                                                x_date_format, y_date_format, z_min, &
+                                                z_max, has_3d_plots)
+        class(spy_context_t), intent(inout) :: this
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        character(len=:), allocatable, intent(in), optional :: title, xlabel, ylabel
+        character(len=*), intent(in), optional :: x_date_format, y_date_format
+        real(wp), intent(in), optional :: z_min, z_max
+        logical, intent(in) :: has_3d_plots
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_draw_axes_and_labels_backend
+
+    subroutine spy_save_coordinates(this, x_min, x_max, y_min, y_max)
+        class(spy_context_t), intent(in) :: this
+        real(wp), intent(out) :: x_min, x_max, y_min, y_max
+
+        x_min = this%x_min
+        x_max = this%x_max
+        y_min = this%y_min
+        y_max = this%y_max
+    end subroutine spy_save_coordinates
+
+    subroutine spy_set_coordinates(this, x_min, x_max, y_min, y_max)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+
+        this%x_min = x_min
+        this%x_max = x_max
+        this%y_min = y_min
+        this%y_max = y_max
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_set_coordinates
+
+    subroutine spy_render_axes(this, title_text, xlabel_text, ylabel_text)
+        class(spy_context_t), intent(inout) :: this
+        character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_render_axes
+
+end module fortplot_spy_backend

--- a/test/test_bar_edgecolor_rendering.f90
+++ b/test/test_bar_edgecolor_rendering.f90
@@ -1,239 +1,3 @@
-module test_bar_edgecolor_spy_backend
-    use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_context, only: plot_context
-    use fortplot_plot_data, only: plot_data_t
-    implicit none
-
-    public :: spy_context
-
-    type, extends(plot_context) :: spy_context
-        real(wp) :: current_color(3) = [0.0_wp, 0.0_wp, 0.0_wp]
-        real(wp) :: expected_fill(3) = [0.0_wp, 0.0_wp, 0.0_wp]
-        real(wp) :: expected_edge(3) = [0.0_wp, 0.0_wp, 0.0_wp]
-        integer :: fill_calls = 0
-        integer :: line_calls = 0
-        integer :: other_calls = 0
-        logical :: fill_color_ok = .true.
-        logical :: line_color_ok = .true.
-    contains
-        procedure :: line => spy_line
-        procedure :: color => spy_color
-        procedure :: text => spy_text
-        procedure :: save => spy_save
-        procedure :: set_line_width => spy_set_line_width
-        procedure :: set_line_style => spy_set_line_style
-        procedure :: draw_marker => spy_draw_marker
-        procedure :: set_marker_colors => spy_set_marker_colors
-        procedure :: set_marker_colors_with_alpha => spy_set_marker_colors_with_alpha
-        procedure :: draw_arrow => spy_draw_arrow
-        procedure :: get_ascii_output => spy_get_ascii_output
-        procedure :: get_width_scale => spy_get_width_scale
-        procedure :: get_height_scale => spy_get_height_scale
-        procedure :: fill_quad => spy_fill_quad
-        procedure :: fill_heatmap => spy_fill_heatmap
-        procedure :: extract_rgb_data => spy_extract_rgb_data
-        procedure :: get_png_data_backend => spy_get_png_data_backend
-        procedure :: prepare_3d_data => spy_prepare_3d_data
-        procedure :: render_ylabel => spy_render_ylabel
-        procedure :: draw_axes_and_labels_backend => spy_draw_axes_and_labels_backend
-        procedure :: save_coordinates => spy_save_coordinates
-        procedure :: set_coordinates => spy_set_coordinates
-        procedure :: render_axes => spy_render_axes
-    end type spy_context
-
-contains
-
-    pure logical function colors_close(a, b) result(ok)
-        real(wp), intent(in) :: a(3), b(3)
-        real(wp), parameter :: tol = 1.0e-12_wp
-
-        ok = all(abs(a - b) <= tol)
-    end function colors_close
-
-    subroutine spy_line(this, x1, y1, x2, y2)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x1, y1, x2, y2
-
-        this%line_calls = this%line_calls + 1
-        this%line_color_ok = this%line_color_ok .and. &
-                             colors_close(this%current_color, this%expected_edge)
-    end subroutine spy_line
-
-    subroutine spy_color(this, r, g, b)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: r, g, b
-
-        this%current_color = [r, g, b]
-    end subroutine spy_color
-
-    subroutine spy_text(this, x, y, text)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x, y
-        character(len=*), intent(in) :: text
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_text
-
-    subroutine spy_save(this, filename)
-        class(spy_context), intent(inout) :: this
-        character(len=*), intent(in) :: filename
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_save
-
-    subroutine spy_set_line_width(this, width)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: width
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_set_line_width
-
-    subroutine spy_set_line_style(this, style)
-        class(spy_context), intent(inout) :: this
-        character(len=*), intent(in) :: style
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_set_line_style
-
-    subroutine spy_draw_marker(this, x, y, style)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x, y
-        character(len=*), intent(in) :: style
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_draw_marker
-
-    subroutine spy_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, face_g, &
-                                     face_b)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: edge_r, edge_g, edge_b
-        real(wp), intent(in) :: face_r, face_g, face_b
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_set_marker_colors
-
-    subroutine spy_set_marker_colors_with_alpha(this, edge_r, edge_g, edge_b, &
-                                                edge_alpha, face_r, face_g, face_b, &
-                                                face_alpha)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: edge_r, edge_g, edge_b, edge_alpha
-        real(wp), intent(in) :: face_r, face_g, face_b, face_alpha
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_set_marker_colors_with_alpha
-
-    subroutine spy_draw_arrow(this, x, y, dx, dy, size, style)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x, y, dx, dy, size
-        character(len=*), intent(in) :: style
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_draw_arrow
-
-    function spy_get_ascii_output(this) result(output)
-        class(spy_context), intent(in) :: this
-        character(len=:), allocatable :: output
-
-        output = ''
-    end function spy_get_ascii_output
-
-    function spy_get_width_scale(this) result(scale)
-        class(spy_context), intent(in) :: this
-        real(wp) :: scale
-
-        scale = 1.0_wp
-    end function spy_get_width_scale
-
-    function spy_get_height_scale(this) result(scale)
-        class(spy_context), intent(in) :: this
-        real(wp) :: scale
-
-        scale = 1.0_wp
-    end function spy_get_height_scale
-
-    subroutine spy_fill_quad(this, x_quad, y_quad)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x_quad(4), y_quad(4)
-
-        this%fill_calls = this%fill_calls + 1
-        this%fill_color_ok = this%fill_color_ok .and. &
-                             colors_close(this%current_color, this%expected_fill)
-    end subroutine spy_fill_quad
-
-    subroutine spy_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
-        real(wp), intent(in) :: z_min, z_max
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_fill_heatmap
-
-    subroutine spy_extract_rgb_data(this, width, height, rgb_data)
-        class(spy_context), intent(in) :: this
-        integer, intent(in) :: width, height
-        real(wp), intent(out) :: rgb_data(width, height, 3)
-
-        rgb_data = 0.0_wp
-    end subroutine spy_extract_rgb_data
-
-    subroutine spy_get_png_data_backend(this, width, height, png_data, status)
-        class(spy_context), intent(in) :: this
-        integer, intent(in) :: width, height
-        integer(1), allocatable, intent(out) :: png_data(:)
-        integer, intent(out) :: status
-
-        allocate (png_data(0))
-        status = 1
-    end subroutine spy_get_png_data_backend
-
-    subroutine spy_prepare_3d_data(this, plots)
-        class(spy_context), intent(inout) :: this
-        type(plot_data_t), intent(in) :: plots(:)
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_prepare_3d_data
-
-    subroutine spy_render_ylabel(this, ylabel)
-        class(spy_context), intent(inout) :: this
-        character(len=*), intent(in) :: ylabel
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_render_ylabel
-
-    subroutine spy_draw_axes_and_labels_backend(this, xscale, yscale, &
-                                                symlog_threshold, x_min, x_max, &
-                                                y_min, y_max, title, xlabel, ylabel, &
-                                                x_date_format, y_date_format, z_min, &
-                                                z_max, has_3d_plots)
-        class(spy_context), intent(inout) :: this
-        character(len=*), intent(in) :: xscale, yscale
-        real(wp), intent(in) :: symlog_threshold
-        real(wp), intent(in) :: x_min, x_max, y_min, y_max
-        character(len=:), allocatable, intent(in), optional :: title, xlabel, ylabel
-        character(len=*), intent(in), optional :: x_date_format, y_date_format
-        real(wp), intent(in), optional :: z_min, z_max
-        logical, intent(in) :: has_3d_plots
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_draw_axes_and_labels_backend
-
-    subroutine spy_save_coordinates(this, x_min, x_max, y_min, y_max)
-        class(spy_context), intent(in) :: this
-        real(wp), intent(out) :: x_min, x_max, y_min, y_max
-
-        x_min = this%x_min
-        x_max = this%x_max
-        y_min = this%y_min
-        y_max = this%y_max
-    end subroutine spy_save_coordinates
-
-    subroutine spy_set_coordinates(this, x_min, x_max, y_min, y_max)
-        class(spy_context), intent(inout) :: this
-        real(wp), intent(in) :: x_min, x_max, y_min, y_max
-
-        this%x_min = x_min
-        this%x_max = x_max
-        this%y_min = y_min
-        this%y_max = y_max
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_set_coordinates
-
-    subroutine spy_render_axes(this, title_text, xlabel_text, ylabel_text)
-        class(spy_context), intent(inout) :: this
-        character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
-        this%other_calls = this%other_calls + 1
-    end subroutine spy_render_axes
-
-end module test_bar_edgecolor_spy_backend
-
 program test_bar_edgecolor_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_bar_rendering, only: render_bar_plot
@@ -241,7 +5,7 @@ program test_bar_edgecolor_rendering
     use fortplot_matplotlib, only: bar, barh, figure, get_global_figure
     use fortplot_figure_core, only: figure_t
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_BAR
-    use test_bar_edgecolor_spy_backend, only: spy_context
+    use fortplot_spy_backend, only: spy_context_t
     implicit none
 
     logical :: failed
@@ -271,7 +35,7 @@ contains
     subroutine test_bar_respects_edgecolor(failed)
         logical, intent(inout) :: failed
         type(figure_t), pointer :: fig
-        type(spy_context) :: backend
+        type(spy_context_t) :: backend
 
         real(wp) :: x(3), heights(3)
         real(wp) :: fill(3), edge(3)
@@ -301,12 +65,12 @@ contains
         call assert_true("bar edgecolor: edge color used", backend%line_color_ok, &
                          failed)
         call assert_true("bar edgecolor: no extra backend calls", &
-                         backend%other_calls == 0, failed)
+                         backend%unexpected_calls == 0, failed)
     end subroutine test_bar_respects_edgecolor
 
     subroutine test_render_bar_plot_draws_quads(failed)
         logical, intent(inout) :: failed
-        type(spy_context) :: backend
+        type(spy_context_t) :: backend
         type(plot_data_t) :: plot
         real(wp) :: fill(3), edge(3)
 
@@ -339,13 +103,13 @@ contains
         call assert_true("direct render uses fill color", backend%fill_color_ok, failed)
         call assert_true("direct render uses edge color", backend%line_color_ok, failed)
         call assert_true("direct render: no extra backend calls", &
-                         backend%other_calls == 0, failed)
+                         backend%unexpected_calls == 0, failed)
     end subroutine test_render_bar_plot_draws_quads
 
     subroutine test_bar_defaults_edgecolor_to_facecolor(failed)
         logical, intent(inout) :: failed
         type(figure_t), pointer :: fig
-        type(spy_context) :: backend
+        type(spy_context_t) :: backend
 
         real(wp) :: x(2), heights(2)
         real(wp) :: fill(3)
@@ -374,13 +138,13 @@ contains
         call assert_true("bar default edgecolor: edge color used", &
                          backend%line_color_ok, failed)
         call assert_true("bar default edgecolor: no extra backend calls", &
-                         backend%other_calls == 0, failed)
+                         backend%unexpected_calls == 0, failed)
     end subroutine test_bar_defaults_edgecolor_to_facecolor
 
     subroutine test_barh_respects_edgecolor(failed)
         logical, intent(inout) :: failed
         type(figure_t), pointer :: fig
-        type(spy_context) :: backend
+        type(spy_context_t) :: backend
 
         real(wp) :: y(3), widths(3)
         real(wp) :: fill(3), edge(3)
@@ -410,7 +174,7 @@ contains
         call assert_true("barh edgecolor: edge color used", backend%line_color_ok, &
                          failed)
         call assert_true("barh edgecolor: no extra backend calls", &
-                         backend%other_calls == 0, failed)
+                         backend%unexpected_calls == 0, failed)
     end subroutine test_barh_respects_edgecolor
 
 end program test_bar_edgecolor_rendering


### PR DESCRIPTION
### **Description long**
- Extract spy backend into reusable module `fortplot_spy_backend.f90`
  - Enables code reuse across multiple rendering tests
  - Centralizes mock implementation in testing infrastructure
- Rename `spy_context` to `spy_context_t` for consistency
  - Aligns with Fortran naming conventions for derived types
- Replace `other_calls` counter with `unexpected_calls` for clarity
  - Better semantic meaning for tracking unwanted backend calls
- Add `reset` procedure to spy backend for test isolation
  - Allows resetting state between test cases



___

### **User description**
Fixes #1557.

- Extract reusable `spy_context_t` backend into `src/testing/fortplot_spy_backend.f90`.
- Update `test/test_bar_edgecolor_rendering.f90` to use shared helper and assert `unexpected_calls == 0`.

## Verification
- `make test ARGS="--target test_bar_edgecolor_rendering" 2>&1 | tee /tmp/fortplot_test_bar_edgecolor_rendering.log`
- Log excerpt:
  - `bar/barh edgecolor rendering tests passed`
  - `ALL TESTS PASSED (fpm test)`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extract spy backend into reusable module `fortplot_spy_backend.f90`

- Rename `spy_context` to `spy_context_t` for consistency

- Replace `other_calls` counter with `unexpected_calls` for clarity

- Add `reset` procedure to spy backend for test isolation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_bar_edgecolor_rendering.f90<br/>inline spy_context"] -->|extract| B["fortplot_spy_backend.f90<br/>spy_context_t module"]
  B -->|import| C["test_bar_edgecolor_rendering.f90<br/>refactored tests"]
  D["other_calls counter"] -->|rename| E["unexpected_calls counter"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_spy_backend.f90</strong><dd><code>New reusable spy backend testing module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/testing/fortplot_spy_backend.f90

<ul><li>New module containing reusable <code>spy_context_t</code> derived type extending <br><code>plot_context</code><br> <li> Implements all required backend procedures with spy/mock behavior<br> <li> Tracks fill and line calls with color validation via <code>colors_close</code> <br>helper<br> <li> Increments <code>unexpected_calls</code> counter for untracked operations<br> <li> Provides <code>reset</code> procedure for test state initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1558/files#diff-c7b3a9aae63c76359962011fc82ce717d5e7321f438ebf262cf378463c2c3a36">+261/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_bar_edgecolor_rendering.f90</strong><dd><code>Refactor to use shared spy backend module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_bar_edgecolor_rendering.f90

<ul><li>Remove 248 lines of inline spy backend implementation<br> <li> Import <code>spy_context_t</code> from <code>fortplot_spy_backend</code> module<br> <li> Replace all <code>spy_context</code> type references with <code>spy_context_t</code><br> <li> Replace <code>other_calls</code> assertions with <code>unexpected_calls</code> (4 occurrences)<br> <li> Simplify test file to focus on test logic only</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1558/files#diff-fcc11c7740210e9f4ea0beb31f2aa9a017d3ba1a1e4c2d7298825cfbd9494c6e">+9/-245</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

