### PR TITLE
fix: polish: spy_context_t reset should fully clear state (fixes #1559)

### DIFF
--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -56,11 +56,23 @@ contains
         class(spy_context_t), intent(inout) :: this
 
         this%current_color = [0.0_wp, 0.0_wp, 0.0_wp]
+        this%expected_fill = [0.0_wp, 0.0_wp, 0.0_wp]
+        this%expected_edge = [0.0_wp, 0.0_wp, 0.0_wp]
         this%fill_calls = 0
         this%line_calls = 0
         this%unexpected_calls = 0
         this%fill_color_ok = .true.
         this%line_color_ok = .true.
+
+        this%width = 0
+        this%height = 0
+        this%x_min = -1.0_wp
+        this%x_max = 1.0_wp
+        this%y_min = -1.0_wp
+        this%y_max = 1.0_wp
+        this%has_rendered_arrows = .false.
+        this%uses_vector_arrows = .false.
+        this%has_triangular_arrows = .false.
     end subroutine spy_reset
 
     subroutine spy_line(this, x1, y1, x2, y2)

--- a/test/test_spy_backend_reset.f90
+++ b/test/test_spy_backend_reset.f90
@@ -1,0 +1,75 @@
+program test_spy_backend_reset
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_spy_backend, only: spy_context_t
+    implicit none
+
+    logical :: failed
+    type(spy_context_t) :: backend
+
+    failed = .false.
+
+    backend%current_color = [0.5_wp, 0.25_wp, 0.75_wp]
+    backend%expected_fill = [1.0_wp, 2.0_wp, 3.0_wp]
+    backend%expected_edge = [4.0_wp, 5.0_wp, 6.0_wp]
+    backend%fill_calls = 7
+    backend%line_calls = 8
+    backend%unexpected_calls = 9
+    backend%fill_color_ok = .false.
+    backend%line_color_ok = .false.
+
+    backend%width = 123
+    backend%height = 456
+    backend%x_min = -10.0_wp
+    backend%x_max = 20.0_wp
+    backend%y_min = -30.0_wp
+    backend%y_max = 40.0_wp
+    backend%has_rendered_arrows = .true.
+    backend%uses_vector_arrows = .true.
+    backend%has_triangular_arrows = .true.
+
+    call backend%reset()
+
+    call assert_true("reset clears current_color", &
+                     all(backend%current_color == [0.0_wp, 0.0_wp, 0.0_wp]), failed)
+    call assert_true("reset clears expected_fill", &
+                     all(backend%expected_fill == [0.0_wp, 0.0_wp, 0.0_wp]), failed)
+    call assert_true("reset clears expected_edge", &
+                     all(backend%expected_edge == [0.0_wp, 0.0_wp, 0.0_wp]), failed)
+
+    call assert_true("reset clears fill_calls", backend%fill_calls == 0, failed)
+    call assert_true("reset clears line_calls", backend%line_calls == 0, failed)
+    call assert_true("reset clears unexpected_calls", backend%unexpected_calls == 0, &
+                     failed)
+    call assert_true("reset sets fill_color_ok", backend%fill_color_ok, failed)
+    call assert_true("reset sets line_color_ok", backend%line_color_ok, failed)
+
+    call assert_true("reset clears width", backend%width == 0, failed)
+    call assert_true("reset clears height", backend%height == 0, failed)
+    call assert_true("reset sets x_min", backend%x_min == -1.0_wp, failed)
+    call assert_true("reset sets x_max", backend%x_max == 1.0_wp, failed)
+    call assert_true("reset sets y_min", backend%y_min == -1.0_wp, failed)
+    call assert_true("reset sets y_max", backend%y_max == 1.0_wp, failed)
+    call assert_true("reset clears has_rendered_arrows", &
+                     .not. backend%has_rendered_arrows, failed)
+    call assert_true("reset clears uses_vector_arrows", &
+                     .not. backend%uses_vector_arrows, failed)
+    call assert_true("reset clears has_triangular_arrows", &
+                     .not. backend%has_triangular_arrows, failed)
+
+    if (failed) stop 1
+    print *, "spy backend reset tests passed"
+
+contains
+
+    subroutine assert_true(name, condition, failed)
+        character(len=*), intent(in) :: name
+        logical, intent(in) :: condition
+        logical, intent(inout) :: failed
+
+        if (.not. condition) then
+            failed = .true.
+            print *, "FAIL: ", trim(name)
+        end if
+    end subroutine assert_true
+
+end program test_spy_backend_reset


### PR DESCRIPTION
### **User description**
Fixes #1559

- `spy_context_t%reset()` now clears expected colors and inherited `plot_context` state.
- Add `test_spy_backend_reset` to prevent stale-state coupling when reusing a backend.

## Verification

- `make test-ci 2>&1 | tee /tmp/fortplot-test-ci-1559.log`

Excerpt:

```
[ 78%]         test_spy_backend_reset
[ 79%]         test_spy_backend_reset  done.
CI essential test suite completed successfully
```


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `spy_context_t%reset()` to fully clear all state variables

- Add expected color arrays to reset initialization

- Reset plot context dimensions and arrow rendering flags

- Add comprehensive test suite for backend reset behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["spy_context_t reset method"] -- "clears color arrays" --> B["expected_fill, expected_edge"]
  A -- "resets plot dimensions" --> C["width, height, x/y bounds"]
  A -- "clears arrow flags" --> D["has_rendered_arrows, uses_vector_arrows"]
  E["test_spy_backend_reset"] -- "validates" --> A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_spy_backend.f90</strong><dd><code>Expand spy_reset to clear all state variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/testing/fortplot_spy_backend.f90

<ul><li>Added initialization of <code>expected_fill</code> and <code>expected_edge</code> color arrays <br>to zero<br> <li> Added reset of plot context dimensions (<code>width</code>, <code>height</code>, <code>x_min</code>, <code>x_max</code>, <br><code>y_min</code>, <code>y_max</code>)<br> <li> Added reset of arrow rendering flags (<code>has_rendered_arrows</code>, <br><code>uses_vector_arrows</code>, <code>has_triangular_arrows</code>)<br> <li> Ensures complete state cleanup when <code>spy_reset()</code> is called</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1560/files#diff-c7b3a9aae63c76359962011fc82ce717d5e7321f438ebf262cf378463c2c3a36">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_spy_backend_reset.f90</strong><dd><code>Add comprehensive spy backend reset test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_spy_backend_reset.f90

<ul><li>New test program verifying <code>spy_context_t%reset()</code> clears all state<br> <li> Tests color arrays, call counters, and boolean flags<br> <li> Tests plot context dimensions and default values<br> <li> Includes helper assertion subroutine for test validation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1560/files#diff-203b7dc60531c75f493a55677052730585aa92f0767b8fa728a861cb034a71d5">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

