### PR TITLE
fix: use shared assertions in spy reset test (fixes #1561)

### DIFF
--- a/test/test_spy_backend_reset.f90
+++ b/test/test_spy_backend_reset.f90
@@ -7,8 +7,6 @@ program test_spy_backend_reset
     type(spy_context_t) :: backend
     type(test_result_t) :: test_result
 
-    test_result = test_result_t()
-
     backend%current_color = [0.5_wp, 0.25_wp, 0.75_wp]
     backend%expected_fill = [1.0_wp, 2.0_wp, 3.0_wp]
     backend%expected_edge = [4.0_wp, 5.0_wp, 6.0_wp]


### PR DESCRIPTION
### **User description**
Fixes #1561.

- Replace the local `assert_true` helper in `test/test_spy_backend_reset.f90` with shared helpers from `src/testing/fortplot_testing.f90`.
- Test failures now return a nonzero process status via `test_result%get_status()`.

Verification:
- `make build`
  - `fpm build --flag -fPIC` -> `Project is up to date`
- `make test`
  - `test_spy_backend_reset` builds and runs:
    - `[  0%]     test_spy_backend_reset.f90`
    - `[100%]         test_spy_backend_reset  done.`
  - `ALL TESTS PASSED (fpm test)`


___

### **PR Type**
Bug fix


___

### **Description**
- Replace local `assert_true` helper with shared testing utilities

- Use `test_result_t` type for proper test status tracking

- Reorder assertion parameters to match shared helper signature

- Return nonzero exit code via `test_result%get_status()` on failure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local assert_true helper"] -->|"Replace with"| B["Shared fortplot_testing module"]
  C["Manual failed flag"] -->|"Replace with"| D["test_result_t type"]
  E["stop 1 on failure"] -->|"Replace with"| F["test_result%get_status()"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_spy_backend_reset.f90</strong><dd><code>Refactor to use shared testing framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_spy_backend_reset.f90

<ul><li>Removed local <code>assert_true</code> subroutine and replaced with shared <br><code>assert_true</code> from <code>fortplot_testing</code> module<br> <li> Replaced manual <code>failed</code> logical flag with <code>test_result_t</code> object for <br>centralized test result tracking<br> <li> Updated all 16 assertion calls to use new signature with condition <br>first, message second, and test_result object last<br> <li> Changed exit behavior from <code>stop 1</code> to <code>stop test_result%get_status()</code> for <br>proper status code handling<br> <li> Added error message output using <code>test_result%message</code> on test failure</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1562/files#diff-203b7dc60531c75f493a55677052730585aa92f0767b8fa728a861cb034a71d5">+33/-40</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

