### PR TITLE
Add terminal ASCII output and live display functions

### DIFF
--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -103,6 +103,7 @@ module fortplot
                                    set_line_width, set_ydata, use_axis, &
                                    get_active_axis, minorticks_on, &
                                    show, show_viewer, &
+                                   ion, ioff, draw, pause, &
                                    ensure_global_figure_initialized, get_global_figure
 
     implicit none
@@ -146,6 +147,7 @@ module fortplot
 
     ! Display functions
     public :: show, show_viewer
+    public :: ion, ioff, draw, pause
 
     ! Global figure access
     public :: ensure_global_figure_initialized, get_global_figure

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -21,7 +21,8 @@ module fortplot_matplotlib
         set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, axis, &
         tight_layout, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
-        show, show_viewer, get_global_figure, ensure_global_figure_initialized
+        show, show_viewer, ion, ioff, draw, pause, &
+        get_global_figure, ensure_global_figure_initialized
 
     use fortplot_text_stub, only: &
         text, annotate
@@ -53,6 +54,7 @@ module fortplot_matplotlib
     public :: figure, subplot, subplots, subplots_grid
     public :: savefig, savefig_with_status
     public :: show, show_viewer
+    public :: ion, ioff, draw, pause
 
     ! Testing support
     public :: get_global_figure, ensure_global_figure_initialized

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -14,7 +14,7 @@ module fortplot_matplotlib_advanced
     use fortplot_matplotlib_session, only: &
         ensure_global_figure_initialized, get_global_figure, figure, subplot, &
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
-        show_figure, show_viewer
+        show_figure, show_viewer, ion, ioff, draw, pause
     use fortplot_matplotlib_colorbar, only: colorbar
     use fortplot_matplotlib_plots_new, only: &
         imshow, pie, polar, step, stem, fill, fill_between, twinx, twiny
@@ -41,6 +41,7 @@ module fortplot_matplotlib_advanced
     public :: figure, subplot, subplots, subplots_grid
     public :: savefig, savefig_with_status
     public :: show, show_viewer
+    public :: ion, ioff, draw, pause
     public :: ensure_global_figure_initialized, get_global_figure
 
     interface show

--- a/src/interfaces/fortplot_matplotlib_session.f90
+++ b/src/interfaces/fortplot_matplotlib_session.f90
@@ -31,8 +31,52 @@ module fortplot_matplotlib_session
     public :: show_data
     public :: show_figure
     public :: show_viewer
+    public :: ion, ioff, draw, pause
+
+    logical, save :: interactive_mode = .false.
 
 contains
+
+    subroutine ion()
+        !! Enable interactive mode for live terminal visualization
+        !!
+        !! When interactive mode is enabled, plots are displayed in the terminal
+        !! using ASCII art and can be updated in real-time using draw() or pause().
+        interactive_mode = .true.
+    end subroutine ion
+
+    subroutine ioff()
+        !! Disable interactive mode
+        interactive_mode = .false.
+    end subroutine ioff
+
+    subroutine draw()
+        !! Redraw the current figure to terminal (ASCII output)
+        !!
+        !! Clears the terminal and displays the current plot state.
+        !! Useful for live visualization in loops.
+        call ensure_global_figure_initialized()
+        call execute_command_line("clear", wait=.true.)
+        call fig%savefig("terminal")
+    end subroutine draw
+
+    subroutine pause(seconds)
+        !! Draw the current figure and pause for specified duration
+        !!
+        !! This is the primary function for live visualization. It:
+        !! 1. Clears the terminal
+        !! 2. Displays the current plot as ASCII art
+        !! 3. Waits for the specified number of seconds
+        !!
+        !! @param seconds: Time to pause in seconds
+        real(wp), intent(in) :: seconds
+
+        call draw()
+        if (seconds > 0.0_wp) then
+            call sleep_fortran(nint(seconds * 1000.0_wp))
+        end if
+    end subroutine pause
+
 
     subroutine ensure_fig_init()
         !! Ensure the global figure exists and is initialized

--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -22,18 +22,27 @@ contains
 
     function get_backend_from_filename(filename) result(backend_type)
         !! Determine backend type from file extension
-        !! 
+        !!
+        !! Special filenames:
+        !!   - "terminal": Uses ASCII backend and outputs to stdout
+        !!
         !! @param filename: Output filename
         !! @return backend_type: Backend identifier string
-        
+
         character(len=*), intent(in) :: filename
         character(len=20) :: backend_type
         character(len=10) :: extension
         integer :: dot_pos
-        
+
+        ! Handle special "terminal" filename for direct ASCII output
+        if (trim(filename) == "terminal") then
+            backend_type = 'ascii'
+            return
+        end if
+
         ! Find the last dot in filename
         dot_pos = index(filename, '.', back=.true.)
-        
+
         if (dot_pos > 0) then
             extension = to_lowercase(filename(dot_pos+1:))
             select case (trim(extension))


### PR DESCRIPTION
## Summary
- `savefig("terminal")` now auto-selects ASCII backend and outputs to stdout
- Add `ion()`/`ioff()` for interactive mode toggle
- Add `draw()` to redraw current figure to terminal with screen clear
- Add `pause(seconds)` for live visualization with timing control

Fixes #1563, #1564

## Changes

### Issue #1564: savefig("terminal") auto-selects ASCII
Modified `get_backend_from_filename()` to recognize "terminal" as a special filename that selects the ASCII backend, enabling direct terminal output without needing a `.txt` extension.

### Issue #1563: Live display functions
Added matplotlib-style interactive functions:
- `ion()` - Enable interactive mode
- `ioff()` - Disable interactive mode  
- `draw()` - Clear terminal and redraw current plot
- `pause(seconds)` - Draw and wait for specified duration

## Example Usage
```fortran
use fortplot

call ion()
do i = 1, 100
    call figure()
    call plot(x, y(:i))
    call title("Live Data")
    call pause(0.1_dp)
end do
call ioff()
```

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds
- [ ] Manual testing of live visualization in terminal