### PR TITLE
[codex] restore macOS flang build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,5 +223,38 @@ jobs:
       run: |
         timeout 2m fpm test --target test_system_fpm_example || echo "FPM example test skipped due to timeout"
         timeout 2m fpm test --target test_system_cmake_example || echo "CMake example test skipped due to timeout"
+
+  flang-macos:
+    name: flang (macOS)
+    if: github.event_name == 'pull_request'
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Homebrew downloads (macOS)
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/Homebrew
+        key: ${{ runner.os }}-${{ runner.arch }}-homebrew-flang-fpm-${{ hashFiles('.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-homebrew-flang-fpm-
+
+    - name: Install flang and fpm (macOS)
+      shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        brew list --versions flang >/dev/null 2>&1 || brew install flang
+        brew list --versions fpm >/dev/null 2>&1 || brew install fpm
+        flang-new --version
+        fpm --version
+
+    - name: Verify flang build (macOS)
+      shell: bash
+      run: |
+        fpm build --compiler=flang-new
       
   # Coverage job removed intentionally; no coverage analysis for now

--- a/scripts/verify_ci_fpm_targets.sh
+++ b/scripts/verify_ci_fpm_targets.sh
@@ -12,12 +12,31 @@ if [[ -n "${FPM_FLAGS_TEST:-}" ]]; then
   extra_args=(${FPM_FLAGS_TEST})
 fi
 
-mapfile -t available < <(fpm test "${extra_args[@]}" --list 2>&1 \
+fpm_cmd=(fpm test)
+if (( ${#extra_args[@]} > 0 )); then
+  fpm_cmd+=("${extra_args[@]}")
+fi
+fpm_cmd+=(--list)
+
+available=()
+while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
+  available+=("${line}")
+done < <("${fpm_cmd[@]}" 2>&1 \
   | awk '$1 != "Matched" {print $1}')
 
 missing=()
 for target in "$@"; do
-  if ! printf '%s\n' "${available[@]}" | grep -Fxq "${target}"; then
+  found=1
+  if (( ${#available[@]} > 0 )); then
+    for listed_target in "${available[@]}"; do
+      if [[ "${listed_target}" == "${target}" ]]; then
+        found=0
+        break
+      fi
+    done
+  fi
+  if (( found != 0 )); then
     missing+=("${target}")
   fi
 done

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -236,6 +236,65 @@ module fortplot_figure_core
             character(len=*), intent(in), optional :: colors(:)
             real(wp), intent(in), optional :: explode(:)
         end subroutine add_pie
+
+        module subroutine add_pie_annotations(self, pie_plot)
+            class(figure_t), intent(inout) :: self
+            type(plot_data_t), intent(in) :: pie_plot
+        end subroutine add_pie_annotations
+
+        module subroutine add_ascii_pie_entries(backend, pie_plot)
+            use fortplot_ascii, only: ascii_context
+            class(ascii_context), intent(inout) :: backend
+            type(plot_data_t), intent(in) :: pie_plot
+        end subroutine add_ascii_pie_entries
+
+        module subroutine add_autopct_annotations(self, pie_plot)
+            class(figure_t), intent(inout) :: self
+            type(plot_data_t), intent(in) :: pie_plot
+        end subroutine add_autopct_annotations
+
+        module subroutine add_label_annotations(self, pie_plot)
+            class(figure_t), intent(inout) :: self
+            type(plot_data_t), intent(in) :: pie_plot
+        end subroutine add_label_annotations
+
+        module subroutine append_figure_annotation(self, x, y, text, ha_value, va_value)
+            class(figure_t), intent(inout) :: self
+            real(wp), intent(in) :: x, y
+            character(len=*), intent(in) :: text
+            character(len=*), intent(in) :: ha_value, va_value
+        end subroutine append_figure_annotation
+
+        module subroutine format_autopct_value(value, total_value, fmt, text, warned)
+            real(wp), intent(in) :: value, total_value
+            character(len=*), intent(in) :: fmt
+            character(len=:), allocatable, intent(out) :: text
+            logical, intent(inout) :: warned
+        end subroutine format_autopct_value
+
+        module subroutine parse_autopct_spec(fmt, start_pos, spec_end, width, &
+                                             precision, plus_flag, space_flag, &
+                                             left_flag, zero_flag, ok)
+            character(len=*), intent(in) :: fmt
+            integer, intent(in) :: start_pos
+            integer, intent(out) :: spec_end
+            integer, intent(out) :: width, precision
+            logical, intent(out) :: plus_flag, space_flag, left_flag, zero_flag
+            logical, intent(out) :: ok
+        end subroutine parse_autopct_spec
+
+        module subroutine build_autopct_chunk(percent, width, precision, plus_flag, &
+                                              space_flag, left_flag, zero_flag, chunk)
+            real(wp), intent(in) :: percent
+            integer, intent(in) :: width, precision
+            logical, intent(in) :: plus_flag, space_flag, left_flag, zero_flag
+            character(len=:), allocatable, intent(out) :: chunk
+        end subroutine build_autopct_chunk
+
+        pure module function determine_alignment(angle) result(alignment)
+            real(wp), intent(in) :: angle
+            character(len=8) :: alignment
+        end function determine_alignment
     end interface
 
     interface


### PR DESCRIPTION
## Summary
- declare the pie helper submodule procedures in `fortplot_figure_core` so LLVM Flang on macOS accepts `fortplot_figure_core_pie`
- add a PR-only `flang (macOS)` GitHub Actions job on `macos-15` with cached Homebrew downloads for `flang` and `fpm`
- make `scripts/verify_ci_fpm_targets.sh` work on macOS Bash 3 so `make test-ci` runs cleanly on macOS too

Closes #1566.

## Verification

### Test fails before fix
```bash
$ fpm build --compiler=flang-new
...
error: Semantic errors in ././src/figures/core/fortplot_figure_core_pie.f90
./././src/figures/core/fortplot_figure_core_pie.f90:30:23: error: 'add_pie_annotations' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:55:23: error: 'add_ascii_pie_entries' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:100:23: error: 'add_autopct_annotations' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:126:23: error: 'add_label_annotations' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:158:23: error: 'append_figure_annotation' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:193:23: error: 'format_autopct_value' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:283:23: error: 'parse_autopct_spec' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:391:23: error: 'build_autopct_chunk' was not declared a separate module procedure
./././src/figures/core/fortplot_figure_core_pie.f90:454:26: error: 'determine_alignment' was not declared a separate module procedure
<ERROR> stopping due to failed compilation
STOP 1
```

### Test passes after fix
```bash
$ fpm build --compiler=flang-new
...
[100%] Project compiled successfully.

$ make test-ci
...
CI essential test suite completed successfully
```
