### PR TITLE
fix: handle string data columns in JSON serializer (fixes #1584)

### DIFF
--- a/src/spec/fortplot_spec_json.f90
+++ b/src/spec/fortplot_spec_json.f90
@@ -294,8 +294,15 @@ contains
             do j = 1, ncols
                 if (.not. first_field) json = json//', '
                 first_field = .false.
-                json = json//Q//d%columns(j)%field//Q// &
-                       ': '//real_to_str(d%columns(j)%values(i))
+                if (d%columns(j)%is_string) then
+                    json = json//Q//d%columns(j)%field//Q// &
+                           ': '//Q// &
+                           trim(d%columns(j)%string_values(i))//Q
+                else
+                    json = json//Q//d%columns(j)%field//Q// &
+                           ': '//real_to_str( &
+                           d%columns(j)%values(i))
+                end if
             end do
             json = json//'}'
         end do

--- a/test/test_spec.f90
+++ b/test/test_spec.f90
@@ -30,6 +30,7 @@ program test_spec
     call test_vl_bar_builder()
     call test_vl_area_builder()
     call test_json_single_view()
+    call test_json_string_data()
     call test_json_mark_properties()
     call test_json_scale_axis()
     call test_json_file_output()
@@ -218,6 +219,48 @@ contains
         call assert(index(json, '"type": "quantitative"') > 0, &
                     'quantitative type present')
     end subroutine test_json_single_view
+
+    subroutine test_json_string_data()
+        !! Test JSON serialization of string data columns
+        type(spec_t) :: spec
+        character(len=:), allocatable :: json
+
+        print *, 'Test: JSON string data columns'
+
+        spec%width = 400
+        spec%height = 300
+        spec%mark%type = 'bar'
+        spec%is_layered = .false.
+
+        allocate (spec%data%columns(2))
+        spec%data%nrows = 3
+
+        spec%data%columns(1)%field = 'category'
+        spec%data%columns(1)%is_string = .true.
+        spec%data%columns(1)%string_values = &
+            [character(len=8) :: 'apple', 'banana', 'cherry']
+
+        spec%data%columns(2)%field = 'count'
+        spec%data%columns(2)%is_string = .false.
+        allocate (spec%data%columns(2)%values(3))
+        spec%data%columns(2)%values = [10.0_wp, 20.0_wp, 15.0_wp]
+
+        spec%encoding%x = vl_channel('category', 'nominal')
+        spec%encoding%y = vl_channel('count', 'quantitative')
+
+        json = spec_to_json(spec)
+
+        call assert(index(json, '"category": "apple"') > 0, &
+                    'string value apple quoted')
+        call assert(index(json, '"category": "banana"') > 0, &
+                    'string value banana quoted')
+        call assert(index(json, '"category": "cherry"') > 0, &
+                    'string value cherry quoted')
+        call assert(index(json, '"count": 10') > 0, &
+                    'numeric value preserved')
+        call assert(index(json, '"count": 20') > 0, &
+                    'numeric value 20 preserved')
+    end subroutine test_json_string_data
 
     subroutine test_json_mark_properties()
         !! Test JSON for mark with extra properties


### PR DESCRIPTION
## Summary

- `serialize_data` in `fortplot_spec_json.f90` unconditionally accessed `values(i)` for every column, which would crash on unallocated memory when `is_string = .true.` and only `string_values` is populated
- Added `is_string` check: string columns emit quoted JSON strings, numeric columns emit numbers as before
- Added `test_json_string_data` test with mixed string/numeric columns (5 assertions)

## Verification

### Test passes after fix
```
$ fpm test test_spec 2>&1 | grep -E 'string|numeric|Summary|PASSED'
   PASS: string value apple quoted
   PASS: string value banana quoted
   PASS: string value cherry quoted
   PASS: numeric value preserved
   PASS: numeric value 20 preserved
 === Spec Test Summary ===
 All spec tests PASSED!
```

### Full suite passes
```
$ make test 2>&1 | tail -1
ALL TESTS PASSED (fpm test)
```

## Test plan

- [x] New test constructs spec with string column (category) + numeric column (count)
- [x] Verifies string values appear as quoted JSON strings
- [x] Verifies numeric values remain unquoted numbers
- [x] Full test suite passes with zero failures