### PR TITLE
fix: tighten spec_t intent to in where inout is unnecessary (fixes #1585)

### DIFF
--- a/src/spec/fortplot_spec_builder.f90
+++ b/src/spec/fortplot_spec_builder.f90
@@ -187,7 +187,7 @@ contains
 
     subroutine spec_savefig(spec, filename, status)
         !! Save spec as JSON (.vl.json/.json) or render to image
-        type(spec_t), intent(inout) :: spec
+        type(spec_t), intent(in) :: spec
         character(len=*), intent(in) :: filename
         integer, intent(out), optional :: status
         integer :: ios, dot_pos
@@ -248,7 +248,7 @@ contains
     subroutine render_spec_to_file(spec, filename, status)
         !! Render spec via figure_t and existing backend pipeline
         use fortplot_figure_core, only: figure_t
-        type(spec_t), intent(inout) :: spec
+        type(spec_t), intent(in) :: spec
         character(len=*), intent(in) :: filename
         integer, intent(out) :: status
         type(figure_t) :: fig


### PR DESCRIPTION
## Summary

- Change `intent(inout)` to `intent(in)` for the `spec` argument in `spec_savefig` (line 190) and `render_spec_to_file` (line 251) in `fortplot_spec_builder.f90`
- Neither subroutine modifies `spec`; both callees (`spec_to_json_file`, `spec_to_figure`) already declare it `intent(in)`

## Verification

### Build passes after fix
```
$ make build
[100%] Project compiled successfully.
```

### All tests pass after fix
```
$ make test
ALL TESTS PASSED (fpm test)
```

### Intent correctness verified
- `spec_to_json_file` at `fortplot_spec_json.f90:60`: `type(spec_t), intent(in) :: spec`
- `spec_to_figure` at `fortplot_spec_builder.f90:221`: `type(spec_t), intent(in) :: spec`
- Neither `spec_savefig` nor `render_spec_to_file` assigns to any `spec` component

Fixes #1585.