### PR TITLE
feat: Python package with spec parity testing (fixes #1576)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ test-ci:
 	@# Python JSON-pipe wrapper: log scale rendering
 	@$(TIMEOUT_PREFIX) python3 scripts/test_python_scales_via_render.py || exit 1
 	@$(TIMEOUT_PREFIX) python3 scripts/test_python_examples.py || exit 1
+	@# Spec parity: Fortran and Python frontends must produce identical specs
+	@$(TIMEOUT_PREFIX) python3 scripts/test_spec_parity.py || exit 1
 	@# Regression for filled-quad edge coverage (prevents 1px cuts on borders)
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_quad_fill_edges || exit 1
 	@# Guard against redundant pcolormesh tests (Issue #897)

--- a/app/fortplot_spec_parity.f90
+++ b/app/fortplot_spec_parity.f90
@@ -1,0 +1,82 @@
+program fortplot_spec_parity
+    !! Generate reference Vega-Lite JSON specs for parity testing.
+    !! Produces JSON files that the Python API must match structurally.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortplot_spec_builder, only: vl_line, vl_point, vl_bar, &
+                                     spec_savefig
+    use fortplot_spec_types, only: spec_t
+    implicit none
+
+    character(len=256) :: outdir
+    integer :: nargs
+
+    nargs = command_argument_count()
+    if (nargs < 1) then
+        write (*, '(a)') 'Usage: fortplot_spec_parity <output_dir>'
+        error stop 1
+    end if
+    call get_command_argument(1, outdir)
+
+    call generate_line_spec(trim(outdir))
+    call generate_scatter_spec(trim(outdir))
+    call generate_bar_spec(trim(outdir))
+
+    write (*, '(a)') 'All reference specs generated successfully'
+
+contains
+
+    subroutine generate_line_spec(dir)
+        character(len=*), intent(in) :: dir
+        type(spec_t) :: spec
+        real(dp) :: x(5), y(5)
+        integer :: i, status
+
+        do i = 1, 5
+            x(i) = real(i, dp)
+            y(i) = real(i*i, dp)
+        end do
+
+        spec = vl_line(x, y, title='Parity Line', &
+                       xlabel='X Axis', ylabel='Y Axis', &
+                       width=400, height=300)
+        call spec_savefig(spec, dir//'/line.vl.json', status)
+        if (status /= 0) error stop 'Failed to write line spec'
+    end subroutine generate_line_spec
+
+    subroutine generate_scatter_spec(dir)
+        character(len=*), intent(in) :: dir
+        type(spec_t) :: spec
+        real(dp) :: x(5), y(5)
+        integer :: i, status
+
+        do i = 1, 5
+            x(i) = real(i, dp)
+            y(i) = real(i*i, dp)
+        end do
+
+        spec = vl_point(x, y, title='Parity Scatter', &
+                        xlabel='X Axis', ylabel='Y Axis', &
+                        width=400, height=300)
+        call spec_savefig(spec, dir//'/scatter.vl.json', status)
+        if (status /= 0) error stop 'Failed to write scatter spec'
+    end subroutine generate_scatter_spec
+
+    subroutine generate_bar_spec(dir)
+        character(len=*), intent(in) :: dir
+        type(spec_t) :: spec
+        real(dp) :: x(5), y(5)
+        integer :: i, status
+
+        do i = 1, 5
+            x(i) = real(i, dp)
+            y(i) = real(i*i, dp)
+        end do
+
+        spec = vl_bar(x, y, title='Parity Bar', &
+                      xlabel='X Axis', ylabel='Y Axis', &
+                      width=400, height=300)
+        call spec_savefig(spec, dir//'/bar.vl.json', status)
+        if (status /= 0) error stop 'Failed to write bar spec'
+    end subroutine generate_bar_spec
+
+end program fortplot_spec_parity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,18 @@
 [build-system]
-requires = ["scikit-build-core", "cmake", "numpy", "f90wrap>=0.2.16"]
-build-backend = "scikit_build_core.build"
+requires = ["setuptools>=64"]
+build-backend = "setuptools.backends._legacy:_Backend"
 
 [project]
 name = "fortplot"
-version = "0.0.0"
-dependencies = ["numpy", "f90wrap>=0.2.16"]
+version = "2025.6.25"
+description = "Python interface to the fortplot scientific plotting library"
+license = "MIT"
+requires-python = ">=3.9"
+dependencies = []
 
-[tool.scikit-build]
-build-dir = "build_cmake"
-cmake.verbose = true
-cmake.args = ["-DENABLE_PYTHON=ON"]
-wheel.py-api = "py3"
-sdist.include = ["python/**"]
-wheel.packages = ["python/fortplot"]
-wheel.install-dir = "fortplot"
+[project.optional-dependencies]
+numpy = ["numpy"]
+
+[tool.setuptools.packages.find]
+where = ["python"]
+include = ["fortplot*"]

--- a/python/fortplot/fortplot_wrapper.py
+++ b/python/fortplot/fortplot_wrapper.py
@@ -24,6 +24,9 @@ def _to_list(seq):
     return [float(v) for v in seq]
 
 
+VL_SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json'
+
+
 class FortplotModule:
     """Fortplot module that builds Vega-Lite specs and renders via JSON pipe."""
 
@@ -117,6 +120,7 @@ class FortplotModule:
     def _build_spec(self):
         """Assemble the full Vega-Lite spec from accumulated state."""
         spec = {
+            "$schema": VL_SCHEMA,
             "width": self._width,
             "height": self._height,
         }

--- a/scripts/test_spec_parity.py
+++ b/scripts/test_spec_parity.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Spec parity test: Fortran and Python frontends must produce identical specs.
+
+Builds a set of Vega-Lite specs via both the Fortran builder API and the
+Python fortplot API, then compares the parsed JSON structures.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import fortplot
+
+
+def find_fortplot_app(name):
+    """Find a compiled fpm app binary."""
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    if build_dir.exists():
+        for compiler_dir in build_dir.iterdir():
+            if compiler_dir.is_dir():
+                app = compiler_dir / 'app' / name
+                if app.exists() and app.is_file():
+                    return str(app)
+    raise FileNotFoundError(f'{name} not found in {build_dir}')
+
+
+def normalize(obj):
+    """Normalize a parsed JSON value for comparison.
+
+    - Convert all numbers to float so 1 == 1.0
+    - Sort dict keys for deterministic comparison
+    - Recurse into nested structures
+    """
+    if isinstance(obj, dict):
+        return {k: normalize(v) for k, v in sorted(obj.items())}
+    if isinstance(obj, list):
+        return [normalize(v) for v in obj]
+    if isinstance(obj, (int, float)):
+        return float(obj)
+    return obj
+
+
+def compare_specs(fortran_path, python_spec, label):
+    """Compare a Fortran-generated JSON file against a Python spec dict."""
+    with open(fortran_path, encoding='utf-8') as f:
+        fortran_spec = json.load(f)
+
+    fn = normalize(fortran_spec)
+    pn = normalize(python_spec)
+
+    if fn != pn:
+        print(f'FAIL: {label}', file=sys.stderr)
+        print(f'  Fortran: {json.dumps(fn, indent=2)}', file=sys.stderr)
+        print(f'  Python:  {json.dumps(pn, indent=2)}', file=sys.stderr)
+        return False
+
+    print(f'OK: {label}')
+    return True
+
+
+def build_python_line_spec():
+    """Build a line spec matching the Fortran reference."""
+    fortplot.figure(figsize=(4, 3), dpi=100)
+    fortplot.plot([1, 2, 3, 4, 5], [1, 4, 9, 16, 25])
+    fortplot.title('Parity Line')
+    fortplot.xlabel('X Axis')
+    fortplot.ylabel('Y Axis')
+
+    with tempfile.NamedTemporaryFile(
+        suffix='.vl.json', delete=False, mode='w'
+    ) as f:
+        tmp = f.name
+    fortplot.savefig(tmp)
+
+    with open(tmp, encoding='utf-8') as f:
+        spec = json.load(f)
+    os.unlink(tmp)
+    return spec
+
+
+def build_python_scatter_spec():
+    """Build a scatter spec matching the Fortran reference."""
+    fortplot.figure(figsize=(4, 3), dpi=100)
+    fortplot.scatter([1, 2, 3, 4, 5], [1, 4, 9, 16, 25])
+    fortplot.title('Parity Scatter')
+    fortplot.xlabel('X Axis')
+    fortplot.ylabel('Y Axis')
+
+    with tempfile.NamedTemporaryFile(
+        suffix='.vl.json', delete=False, mode='w'
+    ) as f:
+        tmp = f.name
+    fortplot.savefig(tmp)
+
+    with open(tmp, encoding='utf-8') as f:
+        spec = json.load(f)
+    os.unlink(tmp)
+    return spec
+
+
+def main():
+    parity_app = find_fortplot_app('fortplot_spec_parity')
+
+    with tempfile.TemporaryDirectory() as fortran_dir:
+        result = subprocess.run(
+            [parity_app, fortran_dir],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            print(f'fortplot_spec_parity failed: {result.stderr}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+        passed = 0
+        failed = 0
+
+        # Line plot parity
+        py_line = build_python_line_spec()
+        if compare_specs(
+            Path(fortran_dir) / 'line.vl.json', py_line, 'line plot'
+        ):
+            passed += 1
+        else:
+            failed += 1
+
+        # Scatter plot parity
+        py_scatter = build_python_scatter_spec()
+        if compare_specs(
+            Path(fortran_dir) / 'scatter.vl.json', py_scatter,
+            'scatter plot',
+        ):
+            passed += 1
+        else:
+            failed += 1
+
+    print(f'\nSpec parity: {passed} passed, {failed} failed')
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Replace scikit-build/f90wrap `pyproject.toml` with pure setuptools, since the Python package now uses JSON pipe to `fortplot_render` instead of f90wrap Fortran bindings
- Add `$schema` field to Python wrapper spec output for Vega-Lite v5 compliance and parity with Fortran serializer
- Add spec parity test infrastructure: Fortran reference generator + Python structural comparison

## Verification

### Spec parity test passes
```
$ python3 scripts/test_spec_parity.py
OK: line plot
OK: scatter plot

Spec parity: 2 passed, 0 failed
```

### Existing Python tests pass
```
$ python3 scripts/test_python_scales_via_render.py
OK: scales via JSON pipe -> output/python_render_scales_log.png (16711 bytes)

$ python3 scripts/test_python_examples.py
[INFO] Running fortplot example: example/python/basic_plots/basic_plots.py
[INFO] Running fortplot example: example/python/colored_contours/colored_contours.py
[INFO] Running fortplot example: example/python/contour_demo/contour_demo.py
[INFO] Running fortplot example: example/python/format_string_demo/format_string_demo.py
[INFO] Running fortplot example: example/python/legend_demo/legend_demo.py
[INFO] Running fortplot example: example/python/line_styles/line_styles.py
[INFO] Running fortplot example: example/python/marker_demo/marker_demo.py
[INFO] Running fortplot example: example/python/pcolormesh_demo/pcolormesh_demo.py
[INFO] Running fortplot example: example/python/scale_examples/scale_examples.py
[INFO] Running fortplot example: example/python/streamplot_demo/streamplot_demo.py
```

### Full fpm test suite passes
```
$ make test
ALL TESTS PASSED (fpm test)
```

## Test plan

- [x] `python3 scripts/test_spec_parity.py` verifies Fortran and Python produce structurally identical Vega-Lite JSON for line and scatter specs
- [x] Existing Python wrapper tests still pass (scales, examples)
- [x] Full Fortran test suite passes (`make test`)
- [x] `pip install .` works with new pure-setuptools pyproject.toml