### PR TITLE
fix: pass labels through JSON pipe rendering path (fixes #1596)

### DIFF
--- a/app/fortplot_spec_parity.f90
+++ b/app/fortplot_spec_parity.f90
@@ -3,7 +3,7 @@ program fortplot_spec_parity
     !! Produces JSON files that the Python API must match structurally.
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use fortplot_spec_builder, only: vl_line, vl_point, vl_bar, &
-                                     spec_savefig
+                                     vl_layer_add, spec_savefig
     use fortplot_spec_types, only: spec_t
     implicit none
 
@@ -20,6 +20,7 @@ program fortplot_spec_parity
     call generate_line_spec(trim(outdir))
     call generate_scatter_spec(trim(outdir))
     call generate_bar_spec(trim(outdir))
+    call generate_labeled_spec(trim(outdir))
 
     write (*, '(a)') 'All reference specs generated successfully'
 
@@ -78,5 +79,25 @@ contains
         call spec_savefig(spec, dir//'/bar.vl.json', status)
         if (status /= 0) error stop 'Failed to write bar spec'
     end subroutine generate_bar_spec
+
+    subroutine generate_labeled_spec(dir)
+        character(len=*), intent(in) :: dir
+        type(spec_t) :: spec
+        real(dp) :: x(5), y1(5), y2(5)
+        integer :: i, status
+
+        do i = 1, 5
+            x(i) = real(i, dp)
+            y1(i) = real(i*i, dp)
+            y2(i) = real(i*i*i, dp)
+        end do
+
+        spec = vl_line(x, y1, title='Parity Labeled', &
+                       xlabel='X Axis', ylabel='Y Axis', &
+                       width=400, height=300)
+        call vl_layer_add(spec, 'line', x, y2, label='cubic')
+        call spec_savefig(spec, dir//'/labeled.vl.json', status)
+        if (status /= 0) error stop 'Failed to write labeled spec'
+    end subroutine generate_labeled_spec
 
 end program fortplot_spec_parity

--- a/python/fortplot/fortplot_wrapper.py
+++ b/python/fortplot/fortplot_wrapper.py
@@ -138,13 +138,19 @@ class FortplotModule:
             layer = self._layers[0]
             spec["data"] = {"values": layer["values"]}
             spec["mark"] = layer["mark"]
-            spec["encoding"] = {"x": x_enc, "y": y_enc}
+            enc = {"x": x_enc, "y": y_enc}
+            if "label" in layer:
+                enc["color"] = {"value": layer["label"]}
+            spec["encoding"] = enc
         else:
             layers = []
             for layer in self._layers:
+                enc = {"x": x_enc, "y": y_enc}
+                if "label" in layer:
+                    enc["color"] = {"value": layer["label"]}
                 layers.append({
                     "mark": layer["mark"],
-                    "encoding": {"x": x_enc, "y": y_enc},
+                    "encoding": enc,
                     "data": {"values": layer["values"]},
                 })
             spec["layer"] = layers
@@ -160,18 +166,18 @@ class FortplotModule:
     def plot(self, x, y, label="", linestyle="-"):
         """Create a line plot."""
         values = self._make_xy_values(x, y)
-        self._layers.append({
-            "mark": "line",
-            "values": values,
-        })
+        layer = {"mark": "line", "values": values}
+        if label:
+            layer["label"] = label
+        self._layers.append(layer)
 
     def scatter(self, x, y, label=""):
         """Create a scatter plot."""
         values = self._make_xy_values(x, y)
-        self._layers.append({
-            "mark": "point",
-            "values": values,
-        })
+        layer = {"mark": "point", "values": values}
+        if label:
+            layer["label"] = label
+        self._layers.append(layer)
 
     def histogram(self, data, label=""):
         """Create a histogram via Python-side binning rendered as bar chart."""

--- a/scripts/test_spec_parity.py
+++ b/scripts/test_spec_parity.py
@@ -103,6 +103,65 @@ def build_python_scatter_spec():
     return spec
 
 
+def build_python_bar_spec():
+    """Build a bar spec matching the Fortran reference."""
+    fortplot.figure(figsize=(4, 3), dpi=100)
+    fortplot.histogram([1, 2, 3, 4, 5])
+    fortplot.title('Parity Bar')
+    fortplot.xlabel('X Axis')
+    fortplot.ylabel('Y Axis')
+
+    with tempfile.NamedTemporaryFile(
+        suffix='.vl.json', delete=False, mode='w'
+    ) as f:
+        tmp = f.name
+    fortplot.savefig(tmp)
+
+    with open(tmp, encoding='utf-8') as f:
+        spec = json.load(f)
+    os.unlink(tmp)
+    return spec
+
+
+def test_label_emission():
+    """Verify that labels are emitted in the Vega-Lite spec."""
+    fortplot.figure(figsize=(4, 3), dpi=100)
+    fortplot.plot([1, 2, 3], [1, 4, 9], label='quadratic')
+    fortplot.plot([1, 2, 3], [1, 8, 27], label='cubic')
+
+    with tempfile.NamedTemporaryFile(
+        suffix='.vl.json', delete=False, mode='w'
+    ) as f:
+        tmp = f.name
+    fortplot.savefig(tmp)
+
+    with open(tmp, encoding='utf-8') as f:
+        spec = json.load(f)
+    os.unlink(tmp)
+
+    if 'layer' not in spec:
+        print('FAIL: label emission - no layers in spec', file=sys.stderr)
+        return False
+
+    labels_found = []
+    for layer in spec['layer']:
+        enc = layer.get('encoding', {})
+        color = enc.get('color', {})
+        if 'value' in color:
+            labels_found.append(color['value'])
+
+    if labels_found != ['quadratic', 'cubic']:
+        print(
+            f'FAIL: label emission - expected [quadratic, cubic], '
+            f'got {labels_found}',
+            file=sys.stderr,
+        )
+        return False
+
+    print('OK: label emission')
+    return True
+
+
 def main():
     parity_app = find_fortplot_app('fortplot_spec_parity')
 
@@ -134,6 +193,12 @@ def main():
             Path(fortran_dir) / 'scatter.vl.json', py_scatter,
             'scatter plot',
         ):
+            passed += 1
+        else:
+            failed += 1
+
+        # Label emission (independent of Fortran structure)
+        if test_label_emission():
             passed += 1
         else:
             failed += 1

--- a/src/spec/fortplot_spec_builder.f90
+++ b/src/spec/fortplot_spec_builder.f90
@@ -295,12 +295,34 @@ contains
         real(wp), intent(in) :: x(:), y(:)
         type(encoding_t), intent(in) :: enc
         real(wp), allocatable :: zeros(:)
+        character(len=:), allocatable :: label
+        integer :: vlen
+
+        ! Extract label from color encoding value (strip JSON quotes)
+        if (enc%color%defined .and. allocated(enc%color%value)) then
+            vlen = len(enc%color%value)
+            if (vlen >= 2 .and. &
+                enc%color%value(1:1) == '"' .and. &
+                enc%color%value(vlen:vlen) == '"') then
+                label = enc%color%value(2:vlen - 1)
+            else
+                label = enc%color%value
+            end if
+        end if
 
         select case (m%type)
         case ('line')
-            call fig%add_plot(x, y)
+            if (allocated(label)) then
+                call fig%add_plot(x, y, label=label)
+            else
+                call fig%add_plot(x, y)
+            end if
         case ('point')
-            call fig%scatter(x, y)
+            if (allocated(label)) then
+                call fig%scatter(x, y, label=label)
+            else
+                call fig%scatter(x, y)
+            end if
         case ('bar')
             call bar_impl(fig, x, y)
         case ('area')
@@ -310,7 +332,11 @@ contains
                 call fig%add_fill_between(x, y1=y, y2=zeros)
             end if
         case default
-            call fig%add_plot(x, y)
+            if (allocated(label)) then
+                call fig%add_plot(x, y, label=label)
+            else
+                call fig%add_plot(x, y)
+            end if
         end select
     end subroutine add_mark_to_figure
 


### PR DESCRIPTION
## Summary

- Python wrapper (`fortplot_wrapper.py`) now stores labels in layer dicts and emits `"color": {"value": "<label>"}` in the Vega-Lite spec, matching the Fortran `vl_layer_add` convention
- Fortran renderer (`fortplot_spec_builder.f90`) now extracts labels from the color encoding in `add_mark_to_figure` and passes them to `fig%add_plot`/`fig%scatter`
- Spec parity test extended with label emission verification
- Fortran parity app extended with labeled multi-layer reference spec

## Verification

### Test passes after fix
```
$ make test 2>&1 | tail -3
 Tests completed - check output files
ALL TESTS PASSED (fpm test)

$ PYTHONPATH=python python scripts/test_spec_parity.py
OK: line plot
OK: scatter plot
OK: label emission

Spec parity: 3 passed, 0 failed
```

### Label emission verified
```python
fortplot.figure(figsize=(6, 4), dpi=100)
fortplot.plot(x, np.sin(x), label='sin(x)')
fortplot.plot(x, np.cos(x), label='cos(x)')
fortplot.savefig('test.vl.json')
# JSON now contains: "color": {"value": "sin(x)"} per layer
```

### Rendered output with labels
Labeled plots render with differentiated colors via the JSON pipe path (both Python wrapper and direct fortplot_render).

## Test plan

- [x] All fpm tests pass
- [x] Spec parity tests pass (line, scatter, label emission)
- [x] Python wrapper emits labels in JSON output
- [x] Fortran renderer extracts labels from JSON and passes to figure
- [x] End-to-end labeled plot renders correctly via Python wrapper