### PR TITLE
fix: apply config tick font sizes to raster tick labels

### DIFF
--- a/src/backends/raster/fortplot_raster_config.f90
+++ b/src/backends/raster/fortplot_raster_config.f90
@@ -1,0 +1,14 @@
+module fortplot_raster_config
+    !! Configurable rendering overrides for the raster backend.
+    !!
+    !! Set these before calling rendering subroutines. Negative values
+    !! mean "use the hardcoded default".
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    real(wp) :: config_title_font_size = -1.0_wp
+    real(wp) :: config_label_font_size = -1.0_wp
+    real(wp) :: config_tick_font_size = -1.0_wp
+
+end module fortplot_raster_config

--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -23,6 +23,8 @@ module fortplot_raster_labels
                                      Y_TICK_LABEL_RIGHT_PAD, &
                                      Y_TICK_LABEL_LEFT_PAD, X_TICK_LABEL_TOP_PAD, &
                                      X_TICK_LABEL_PAD
+    use fortplot_raster_config, only: config_title_font_size, &
+        config_label_font_size, config_tick_font_size
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -37,11 +39,9 @@ module fortplot_raster_labels
     public :: compute_ylabel_x_pos
     public :: y_tick_label_right_edge_at_axis
 
-    ! Configurable font size overrides (set before rendering)
-    ! Negative means use the hardcoded default.
-    real(wp), public :: config_title_font_size = -1.0_wp
-    real(wp), public :: config_label_font_size = -1.0_wp
-    real(wp), public :: config_tick_font_size = -1.0_wp
+    ! Import configurable overrides from shared config module
+    public :: config_title_font_size, config_label_font_size, &
+              config_tick_font_size
 
 contains
 

--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -17,6 +17,7 @@ module fortplot_raster_ticks
     use fortplot_raster_line_styles, only: draw_styled_line
     use fortplot_raster_core, only: raster_image_t, scale_px, REFERENCE_DPI
     use fortplot_scales, only: apply_scale_transform
+    use fortplot_raster_config, only: config_tick_font_size
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -93,7 +94,11 @@ contains
         integer :: j
         integer :: label_width, label_height
         real(wp) :: font_px
-        font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        if (config_tick_font_size > 0.0_wp) then
+            font_px = config_tick_font_size
+        else
+            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        end if
 
         last_y_tick_max_width = 0
         do j = 1, size(yticks)
@@ -220,7 +225,11 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        if (config_tick_font_size > 0.0_wp) then
+            font_px = config_tick_font_size
+        else
+            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        end if
 
         ! Track maximum label height for xlabel positioning
         last_x_tick_max_height_bottom = 0
@@ -286,7 +295,11 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        if (config_tick_font_size > 0.0_wp) then
+            font_px = config_tick_font_size
+        else
+            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        end if
 
         last_y_tick_max_width = 0
 
@@ -431,7 +444,11 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        if (config_tick_font_size > 0.0_wp) then
+            font_px = config_tick_font_size
+        else
+            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        end if
 
         min_t = apply_scale_transform(y_min, yscale, symlog_threshold)
         max_t = apply_scale_transform(y_max, yscale, symlog_threshold)
@@ -568,7 +585,11 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        if (config_tick_font_size > 0.0_wp) then
+            font_px = config_tick_font_size
+        else
+            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
+        end if
 
         min_t = apply_scale_transform(x_min, xscale, symlog_threshold)
         max_t = apply_scale_transform(x_max, xscale, symlog_threshold)

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -74,7 +74,7 @@ contains
                                   annotation_count)
         !! Render a single-axis figure.
         use fortplot_annotations, only: text_annotation_t
-        use fortplot_raster_labels, only: config_title_font_size, &
+        use fortplot_raster_config, only: config_title_font_size, &
             config_label_font_size, config_tick_font_size
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), intent(inout) :: plots(:)


### PR DESCRIPTION
## Summary

- Extract raster config overrides into `fortplot_raster_config` module (breaks circular dep)
- All 5 tick label rendering sites now use `config_tick_font_size` when set
- Falls back to `DEFAULT_FONT_SIZE * dpi / REFERENCE_DPI` when unset

## RMSE improvement

| Example | Before | After | Delta |
|---------|--------|-------|-------|
| scale_examples | 37.24 | 36.59 | -0.65 |
| basic_plots | 40.16 | 39.90 | -0.26 |
| format_string | 32.73 | 32.51 | -0.22 |

## Test plan

- [x] `fpm build` compiles
- [x] `fpm test` 4/4 pass, 0 failures
- [x] RMSE comparison shows improvement