### PR TITLE
feat: configurable font preference from config axis labelFont

### DIFF
--- a/src/rendering/fortplot_spec_config_apply.f90
+++ b/src/rendering/fortplot_spec_config_apply.f90
@@ -8,6 +8,7 @@ module fortplot_spec_config_apply
     use fortplot_spec_types, only: spec_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_colors, only: parse_color
+    use fortplot_text_fonts, only: set_preferred_font
     implicit none
 
     private
@@ -43,6 +44,7 @@ contains
         call apply_mark_defaults(cfg, state)
         call apply_axis_config(cfg, state)
         call apply_title_config(cfg, state)
+        call apply_font_preference(cfg)
     end subroutine apply_config_to_state
 
     subroutine apply_color_palette(cfg, state)
@@ -108,6 +110,29 @@ contains
             state%title_font_size = cfg%title_config%font_size
         end if
     end subroutine apply_title_config
+
+    subroutine apply_font_preference(cfg)
+        !! Set the preferred font based on config axis label font.
+        !! Maps common CSS font families to system font names.
+        type(config_t), intent(in) :: cfg
+
+        character(len=40) :: font_name
+
+        if (.not. cfg%axis%defined) return
+        if (.not. cfg%axis%label_font_set) return
+
+        font_name = cfg%axis%label_font
+        ! Map CSS font family strings to font discovery names
+        if (index(font_name, 'DejaVu') > 0) then
+            call set_preferred_font('DejaVu Sans')
+        else if (index(font_name, 'Arial') > 0) then
+            call set_preferred_font('Arial')
+        else if (index(font_name, 'Helvetica') > 0) then
+            call set_preferred_font('Helvetica')
+        else if (index(font_name, 'Liberation') > 0) then
+            call set_preferred_font('Liberation Sans')
+        end if
+    end subroutine apply_font_preference
 
     subroutine apply_padding_to_margins(pad, state)
         !! Convert pixel padding to fractional margins.

--- a/src/text/fortplot_text_fonts.f90
+++ b/src/text/fortplot_text_fonts.f90
@@ -8,11 +8,13 @@ module fortplot_text_fonts
     public :: init_text_system, cleanup_text_system, get_font_metrics
     public :: get_font_ascent_ratio, find_font_by_name, find_any_available_font
     public :: get_global_font, get_font_scale, is_font_initialized, get_font_scale_for_size
-    
+    public :: set_preferred_font
+
     ! Module state - shared with text rendering
     type(truetype_font_t) :: global_font
     logical :: font_initialized = .false.
     real(wp) :: font_scale = 0.0_wp
+    character(len=40) :: preferred_font_name = ''
     
     
 contains
@@ -37,34 +39,59 @@ contains
     end function init_text_system
 
     function discover_and_init_font() result(success)
-        !! Discover and initialize font from system locations
+        !! Discover and initialize font from system locations.
+        !! If preferred_font_name is set, try it first.
         logical :: success
         character(len=256) :: font_path
-        
+
         success = .false.
-        
-        ! Priority order: Helvetica -> Liberation Sans -> Arial -> DejaVu Sans
+
+        ! Try preferred font first (set by config)
+        if (len_trim(preferred_font_name) > 0) then
+            if (find_font_by_name(trim(preferred_font_name), &
+                                  font_path)) then
+                success = try_init_font(font_path)
+                if (success) return
+            end if
+        end if
+
+        ! Fallback priority: Helvetica > Liberation Sans > Arial > DejaVu Sans
         if (find_font_by_name("Helvetica", font_path)) then
             success = try_init_font(font_path)
             if (success) return
         end if
-        
+
         if (find_font_by_name("Liberation Sans", font_path)) then
             success = try_init_font(font_path)
             if (success) return
         end if
-        
+
         if (find_font_by_name("Arial", font_path)) then
             success = try_init_font(font_path)
             if (success) return
         end if
-        
+
         if (find_font_by_name("DejaVu Sans", font_path)) then
             success = try_init_font(font_path)
             if (success) return
         end if
-        
+
     end function discover_and_init_font
+
+    subroutine set_preferred_font(font_name)
+        !! Set preferred font and reinitialize if needed.
+        !! Call before rendering to switch fonts for a style mode.
+        character(len=*), intent(in) :: font_name
+
+        logical :: ok
+
+        if (trim(font_name) == trim(preferred_font_name)) return
+        preferred_font_name = font_name
+
+        ! Force reinit with new preference
+        font_initialized = .false.
+        ok = init_text_system()
+    end subroutine set_preferred_font
 
     function find_font_by_name(font_name, font_path) result(found)
         !! Find font by name in typical system locations


### PR DESCRIPTION
## Summary

- Add `set_preferred_font()` to reinitialize the font system with a named font
- Config application maps CSS font-family strings to system font names
- MPL mode prefers DejaVu Sans to match matplotlib rendering

## Test plan

- [x] `fpm build` compiles
- [x] `fpm test` 4/4 pass, 0 failures