### PR TITLE
feat: parse axis tick values and format from encoding

### DIFF
--- a/src/rendering/fortplot_spec_rendering.f90
+++ b/src/rendering/fortplot_spec_rendering.f90
@@ -642,7 +642,49 @@ contains
             if (y_grid .and. .not. x_grid) grid_axis = 'y'
             call core_grid(state, enabled=.true., axis=grid_axis)
         end if
+
+        ! Note: spec encoding axis.values (explicit tick positions) are
+        ! parsed but not yet applied -- the custom tick rendering path
+        ! needs further convergence work to match the standard path.
     end subroutine apply_spec_metadata
+
+    subroutine apply_custom_ticks(values, fmt, positions, labels, is_set)
+        !! Convert tick values to positions + string labels.
+        real(wp), intent(in) :: values(:)
+        character(len=:), allocatable, intent(in) :: fmt
+        real(wp), allocatable, intent(out) :: positions(:)
+        character(len=50), allocatable, intent(out) :: labels(:)
+        logical, intent(out) :: is_set
+
+        integer :: i, n
+        character(len=50) :: buf
+        logical :: use_int_fmt
+
+        n = size(values)
+        if (n == 0) then
+            is_set = .false.
+            return
+        end if
+
+        allocate (positions(n), labels(n))
+        positions = values
+
+        use_int_fmt = .false.
+        if (allocated(fmt)) then
+            if (trim(fmt) == 'd') use_int_fmt = .true.
+        end if
+
+        do i = 1, n
+            if (use_int_fmt) then
+                write (buf, '(i0)') nint(values(i))
+            else
+                write (buf, '(g0)') values(i)
+            end if
+            labels(i) = adjustl(buf)
+        end do
+
+        is_set = .true.
+    end subroutine apply_custom_ticks
 
     subroutine build_spec_legend_if_needed(state, plots, plot_count)
         type(figure_state_t), intent(inout) :: state

--- a/src/spec/fortplot_spec_json_parse.f90
+++ b/src/spec/fortplot_spec_json_parse.f90
@@ -466,6 +466,13 @@ contains
                 call read_bool(json, pos, ax%grid, status)
             case ('labelAngle')
                 call read_real(json, pos, ax%label_angle, status)
+            case ('values')
+                call parse_real_array(json, pos, ax%tick_values, &
+                                     status)
+            case ('format')
+                call read_string(json, pos, ax%format, status)
+            case ('gridOpacity', 'gridDash')
+                call skip_value(json, pos)
             case default
                 call skip_value(json, pos)
             end select

--- a/src/spec/fortplot_spec_types.f90
+++ b/src/spec/fortplot_spec_types.f90
@@ -24,6 +24,8 @@ module fortplot_spec_types
         logical :: grid = .false.
         real(wp) :: label_angle = 0.0_wp
         logical :: title_set = .false.
+        real(wp), allocatable :: tick_values(:)
+        character(len=:), allocatable :: format
     end type axis_t
 
     type :: scale_t


### PR DESCRIPTION
## Summary

- Add `tick_values(:)` and `format` fields to `axis_t`
- JSON parser reads `axis.values` (real array) and `axis.format` (string)
- Add `apply_custom_ticks` helper that converts tick values to position+label arrays
- Tick values not yet applied to rendering (custom tick path needs convergence work)

## Test plan

- [x] `fpm build` compiles
- [x] `fpm test` 4/4 pass, 0 failures