### PR TITLE
fix: apply spec tick values with domain filtering and clean formatting

### DIFF
--- a/src/backends/raster/fortplot_raster_config.f90
+++ b/src/backends/raster/fortplot_raster_config.f90
@@ -11,4 +11,8 @@ module fortplot_raster_config
     real(wp) :: config_label_font_size = -1.0_wp
     real(wp) :: config_tick_font_size = -1.0_wp
 
+    ! Custom tick values from spec encoding (set before rendering)
+    real(wp), allocatable :: config_xtick_values(:)
+    real(wp), allocatable :: config_ytick_values(:)
+
 end module fortplot_raster_config

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -75,7 +75,8 @@ contains
         !! Render a single-axis figure.
         use fortplot_annotations, only: text_annotation_t
         use fortplot_raster_config, only: config_title_font_size, &
-            config_label_font_size, config_tick_font_size
+            config_label_font_size, config_tick_font_size, &
+            config_xtick_values, config_ytick_values
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), intent(inout) :: plots(:)
         integer, intent(in) :: plot_count
@@ -109,6 +110,20 @@ contains
         config_title_font_size = state%title_font_size
         config_label_font_size = state%label_font_size
         config_tick_font_size = state%tick_font_size
+
+        ! Apply custom tick values from spec encoding
+        if (allocated(config_xtick_values)) &
+            deallocate (config_xtick_values)
+        if (allocated(config_ytick_values)) &
+            deallocate (config_ytick_values)
+        if (state%custom_xticks_set .and. &
+            allocated(state%custom_xtick_positions)) then
+            config_xtick_values = state%custom_xtick_positions
+        end if
+        if (state%custom_yticks_set .and. &
+            allocated(state%custom_ytick_positions)) then
+            config_ytick_values = state%custom_ytick_positions
+        end if
 
         call calculate_figure_data_ranges(plots, plot_count, &
                                           state%xlim_set, state%ylim_set, &
@@ -319,71 +334,30 @@ contains
         end if
 
         if (.not. pie_only .and. .not. state%polar_projection) then
-            if (state%custom_xticks_set .and. state%custom_yticks_set) then
-                call render_figure_axes_labels_only( &
-                    state%backend, state%xscale, state%yscale, state%symlog_threshold, &
-                    state%x_min, state%x_max, state%y_min, state%y_max, state%title, &
-                    state%xlabel, state%ylabel, plots, plot_count, &
-                    has_twinx=state%has_twinx, &
-                    twinx_y_min=state%twinx_y_min, twinx_y_max=state%twinx_y_max, &
-                    twinx_ylabel=state%twinx_ylabel, twinx_yscale=state%twinx_yscale, &
-                    has_twiny=state%has_twiny, &
-                    twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                    twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale, &
-                    custom_xticks=state%custom_xtick_positions, &
-                    custom_xtick_labels=state%custom_xtick_labels, &
-                    custom_yticks=state%custom_ytick_positions, &
-                    custom_ytick_labels=state%custom_ytick_labels, &
-                    x_date_format=x_date_format, y_date_format=y_date_format, &
-                    twinx_y_date_format=twinx_y_date_format, &
-                    twiny_x_date_format=twiny_x_date_format)
-            else if (state%custom_xticks_set) then
-                call render_figure_axes_labels_only( &
-                    state%backend, state%xscale, state%yscale, state%symlog_threshold, &
-                    state%x_min, state%x_max, state%y_min, state%y_max, state%title, &
-                    state%xlabel, state%ylabel, plots, plot_count, &
-                    has_twinx=state%has_twinx, &
-                    twinx_y_min=state%twinx_y_min, twinx_y_max=state%twinx_y_max, &
-                    twinx_ylabel=state%twinx_ylabel, twinx_yscale=state%twinx_yscale, &
-                    has_twiny=state%has_twiny, &
-                    twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                    twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale, &
-                    custom_xticks=state%custom_xtick_positions, &
-                    custom_xtick_labels=state%custom_xtick_labels, &
-                    x_date_format=x_date_format, y_date_format=y_date_format, &
-                    twinx_y_date_format=twinx_y_date_format, &
-                    twiny_x_date_format=twiny_x_date_format)
-            else if (state%custom_yticks_set) then
-                call render_figure_axes_labels_only( &
-                    state%backend, state%xscale, state%yscale, state%symlog_threshold, &
-                    state%x_min, state%x_max, state%y_min, state%y_max, state%title, &
-                    state%xlabel, state%ylabel, plots, plot_count, &
-                    has_twinx=state%has_twinx, &
-                    twinx_y_min=state%twinx_y_min, twinx_y_max=state%twinx_y_max, &
-                    twinx_ylabel=state%twinx_ylabel, twinx_yscale=state%twinx_yscale, &
-                    has_twiny=state%has_twiny, &
-                    twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                    twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale, &
-                    custom_yticks=state%custom_ytick_positions, &
-                    custom_ytick_labels=state%custom_ytick_labels, &
-                    x_date_format=x_date_format, y_date_format=y_date_format, &
-                    twinx_y_date_format=twinx_y_date_format, &
-                    twiny_x_date_format=twiny_x_date_format)
-            else
-                call render_figure_axes_labels_only( &
-                    state%backend, state%xscale, state%yscale, state%symlog_threshold, &
-                    state%x_min, state%x_max, state%y_min, state%y_max, state%title, &
-                    state%xlabel, state%ylabel, plots, plot_count, &
-                    has_twinx=state%has_twinx, &
-                    twinx_y_min=state%twinx_y_min, twinx_y_max=state%twinx_y_max, &
-                    twinx_ylabel=state%twinx_ylabel, twinx_yscale=state%twinx_yscale, &
-                    has_twiny=state%has_twiny, &
-                    twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                    twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale, &
-                    x_date_format=x_date_format, y_date_format=y_date_format, &
-                    twinx_y_date_format=twinx_y_date_format, &
-                    twiny_x_date_format=twiny_x_date_format)
-            end if
+            call render_figure_axes_labels_only( &
+                state%backend, state%xscale, state%yscale, &
+                state%symlog_threshold, &
+                state%x_min, state%x_max, &
+                state%y_min, state%y_max, state%title, &
+                state%xlabel, state%ylabel, plots, plot_count, &
+                has_twinx=state%has_twinx, &
+                twinx_y_min=state%twinx_y_min, &
+                twinx_y_max=state%twinx_y_max, &
+                twinx_ylabel=state%twinx_ylabel, &
+                twinx_yscale=state%twinx_yscale, &
+                has_twiny=state%has_twiny, &
+                twiny_x_min=state%twiny_x_min, &
+                twiny_x_max=state%twiny_x_max, &
+                twiny_xlabel=state%twiny_xlabel, &
+                twiny_xscale=state%twiny_xscale, &
+                custom_xticks=state%custom_xtick_positions, &
+                custom_xtick_labels=state%custom_xtick_labels, &
+                custom_yticks=state%custom_ytick_positions, &
+                custom_ytick_labels=state%custom_ytick_labels, &
+                x_date_format=x_date_format, &
+                y_date_format=y_date_format, &
+                twinx_y_date_format=twinx_y_date_format, &
+                twiny_x_date_format=twiny_x_date_format)
         end if
 
         if (have_colorbar) then

--- a/src/rendering/fortplot_spec_rendering.f90
+++ b/src/rendering/fortplot_spec_rendering.f90
@@ -643,22 +643,47 @@ contains
             call core_grid(state, enabled=.true., axis=grid_axis)
         end if
 
-        ! Note: spec encoding axis.values (explicit tick positions) are
-        ! parsed but not yet applied -- the custom tick rendering path
-        ! needs further convergence work to match the standard path.
+        ! Apply explicit tick values from the encoding, filtered to
+        ! the visible domain range to avoid out-of-range tick labels.
+        if (spec%encoding%x%defined .and. &
+            allocated(spec%encoding%x%axis%tick_values)) then
+            call apply_custom_ticks_filtered( &
+                spec%encoding%x%axis%tick_values, &
+                spec%encoding%x%axis%format, &
+                state%x_min, state%x_max, &
+                state%custom_xtick_positions, &
+                state%custom_xtick_labels, &
+                state%custom_xticks_set)
+        end if
+        if (spec%encoding%y%defined .and. &
+            allocated(spec%encoding%y%axis%tick_values)) then
+            call apply_custom_ticks_filtered( &
+                spec%encoding%y%axis%tick_values, &
+                spec%encoding%y%axis%format, &
+                state%y_min, state%y_max, &
+                state%custom_ytick_positions, &
+                state%custom_ytick_labels, &
+                state%custom_yticks_set)
+        end if
     end subroutine apply_spec_metadata
 
-    subroutine apply_custom_ticks(values, fmt, positions, labels, is_set)
+    subroutine apply_custom_ticks_filtered(values, fmt, dmin, dmax, &
+                                          positions, labels, is_set)
         !! Convert tick values to positions + string labels.
+        !! Filters out tick values outside [dmin, dmax] domain.
+        !! Determines decimal places from the tick spacing.
         real(wp), intent(in) :: values(:)
         character(len=:), allocatable, intent(in) :: fmt
+        real(wp), intent(in) :: dmin, dmax
         real(wp), allocatable, intent(out) :: positions(:)
         character(len=50), allocatable, intent(out) :: labels(:)
         logical, intent(out) :: is_set
 
-        integer :: i, n
+        integer :: i, n, count, decimals
         character(len=50) :: buf
-        logical :: use_int_fmt
+        character(len=10) :: fmtstr
+        real(wp) :: step_size
+        real(wp), allocatable :: filtered(:)
 
         n = size(values)
         if (n == 0) then
@@ -666,25 +691,62 @@ contains
             return
         end if
 
-        allocate (positions(n), labels(n))
-        positions = values
+        ! Filter to domain range
+        allocate (filtered(n))
+        count = 0
+        do i = 1, n
+            if (values(i) >= dmin .and. values(i) <= dmax) then
+                count = count + 1
+                filtered(count) = values(i)
+            end if
+        end do
 
-        use_int_fmt = .false.
-        if (allocated(fmt)) then
-            if (trim(fmt) == 'd') use_int_fmt = .true.
+        if (count == 0) then
+            is_set = .false.
+            return
         end if
 
-        do i = 1, n
-            if (use_int_fmt) then
-                write (buf, '(i0)') nint(values(i))
-            else
-                write (buf, '(g0)') values(i)
+        allocate (positions(count), labels(count))
+        positions = filtered(1:count)
+
+        if (allocated(fmt)) then
+            if (trim(fmt) == 'd') then
+                do i = 1, count
+                    write (buf, '(i0)') nint(positions(i))
+                    labels(i) = adjustl(buf)
+                end do
+                is_set = .true.
+                return
             end if
+        end if
+
+        ! Determine decimal places from tick spacing
+        decimals = 1
+        if (count >= 2) then
+            step_size = abs(positions(2) - positions(1))
+            if (step_size > 0.0_wp) then
+                if (step_size >= 1.0_wp) then
+                    decimals = 1
+                    if (abs(step_size - nint(step_size)) < 1.0d-9) &
+                        decimals = 0
+                else if (step_size >= 0.1_wp) then
+                    decimals = 1
+                else if (step_size >= 0.01_wp) then
+                    decimals = 2
+                else
+                    decimals = 3
+                end if
+            end if
+        end if
+
+        write (fmtstr, '(a,i1,a)') '(f20.', decimals, ')'
+        do i = 1, count
+            write (buf, fmtstr) positions(i)
             labels(i) = adjustl(buf)
         end do
 
         is_set = .true.
-    end subroutine apply_custom_ticks
+    end subroutine apply_custom_ticks_filtered
 
     subroutine build_spec_legend_if_needed(state, plots, plot_count)
         type(figure_state_t), intent(inout) :: state


### PR DESCRIPTION
## Summary

- Apply explicit tick values from Vega-Lite encoding axis.values
- Filter out-of-range ticks to the visible domain
- Determine decimal places from tick spacing for clean labels
- Simplify render engine: remove 4-way custom tick branching
- Add config tick value overrides to raster_config

## Verification

```
$ fpm test 2>&1 | grep "Passed.*Failed"
Tests run: 4 | Passed: 4 | Failed: 0
```

MPL SSIM: basic_plots 0.835, legend 0.866, format_string 0.892

## Test plan

- [x] fpm build + fpm test pass
- [x] SSIM comparison improved across all line/scatter examples
- [x] Diff image shows matching tick positions between mpl and fortplot