### PR TITLE
fix: audit findings -- dedup, drift, and label_font_size bug

### DIFF
--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -55,6 +55,18 @@ module fortplot_raster_ticks
 
 contains
 
+    pure function resolve_tick_font_px(dpi) result(px)
+        !! Resolve tick label font size: config override or default.
+        real(wp), intent(in) :: dpi
+        real(wp) :: px
+
+        if (config_tick_font_size > 0.0_wp) then
+            px = config_tick_font_size
+        else
+            px = real(DEFAULT_FONT_SIZE, wp) * dpi / REFERENCE_DPI
+        end if
+    end function resolve_tick_font_px
+
     subroutine raster_draw_x_axis_ticks(raster, width, height, plot_area, &
                                         xscale, symlog_threshold, xticks, &
                                         xtick_labels, xtick_colors, x_min, x_max)
@@ -94,11 +106,7 @@ contains
         integer :: j
         integer :: label_width, label_height
         real(wp) :: font_px
-        if (config_tick_font_size > 0.0_wp) then
-            font_px = config_tick_font_size
-        else
-            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
-        end if
+        font_px = resolve_tick_font_px(raster%dpi)
 
         last_y_tick_max_width = 0
         do j = 1, size(yticks)
@@ -225,11 +233,7 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        if (config_tick_font_size > 0.0_wp) then
-            font_px = config_tick_font_size
-        else
-            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
-        end if
+        font_px = resolve_tick_font_px(raster%dpi)
 
         ! Track maximum label height for xlabel positioning
         last_x_tick_max_height_bottom = 0
@@ -295,11 +299,7 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        if (config_tick_font_size > 0.0_wp) then
-            font_px = config_tick_font_size
-        else
-            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
-        end if
+        font_px = resolve_tick_font_px(raster%dpi)
 
         last_y_tick_max_width = 0
 
@@ -444,11 +444,7 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        if (config_tick_font_size > 0.0_wp) then
-            font_px = config_tick_font_size
-        else
-            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
-        end if
+        font_px = resolve_tick_font_px(raster%dpi)
 
         min_t = apply_scale_transform(y_min, yscale, symlog_threshold)
         max_t = apply_scale_transform(y_max, yscale, symlog_threshold)
@@ -585,11 +581,7 @@ contains
         character(len=600) :: math_ready
         character(len=600) :: escaped_text
         integer :: processed_len, math_len
-        if (config_tick_font_size > 0.0_wp) then
-            font_px = config_tick_font_size
-        else
-            font_px = real(DEFAULT_FONT_SIZE, wp) * raster%dpi / REFERENCE_DPI
-        end if
+        font_px = resolve_tick_font_px(raster%dpi)
 
         min_t = apply_scale_transform(x_min, xscale, symlog_threshold)
         max_t = apply_scale_transform(x_max, xscale, symlog_threshold)

--- a/src/figures/fortplot_figure_grid.f90
+++ b/src/figures/fortplot_figure_grid.f90
@@ -8,6 +8,7 @@ module fortplot_figure_grid
     use fortplot_context
     use fortplot_ascii, only: ascii_context
     use fortplot_axes, only: compute_scale_ticks
+    use fortplot_colors, only: parse_color
     use fortplot_scales, only: apply_scale_transform
     implicit none
     
@@ -108,10 +109,15 @@ contains
         end select
         
         ! Set grid color from config or fallback to gray
-        if (present(grid_color_hex) .and. len_trim(grid_color_hex) > 0) then
-            call parse_grid_hex(grid_color_hex, grid_color)
-        else
-            grid_color = [0.69_wp, 0.69_wp, 0.69_wp]
+        grid_color = [0.69_wp, 0.69_wp, 0.69_wp]
+        if (present(grid_color_hex)) then
+            if (len_trim(grid_color_hex) > 0) then
+                block
+                    logical :: ok
+                    call parse_color(trim(grid_color_hex), &
+                        grid_color, ok)
+                end block
+            end if
         end if
         alpha_val = max(0.0_wp, min(1.0_wp, grid_alpha))
 
@@ -185,30 +191,5 @@ contains
         call backend%set_line_style('-')
 
     end subroutine render_grid_lines
-
-    subroutine parse_grid_hex(hex_str, rgb)
-        !! Parse a hex color string like #b0b0b0 into RGB [0,1].
-        character(len=*), intent(in) :: hex_str
-        real(wp), intent(out) :: rgb(3)
-
-        integer :: r, g, b, ios
-        character(len=6) :: hex_part
-
-        rgb = [0.69_wp, 0.69_wp, 0.69_wp]
-        if (len_trim(hex_str) < 4) return
-
-        hex_part = hex_str(2:min(len_trim(hex_str), 7))
-        if (len_trim(hex_part) == 6) then
-            read (hex_part(1:2), '(z2)', iostat=ios) r
-            if (ios /= 0) return
-            read (hex_part(3:4), '(z2)', iostat=ios) g
-            if (ios /= 0) return
-            read (hex_part(5:6), '(z2)', iostat=ios) b
-            if (ios /= 0) return
-            rgb = [real(r, wp) / 255.0_wp, &
-                   real(g, wp) / 255.0_wp, &
-                   real(b, wp) / 255.0_wp]
-        end if
-    end subroutine parse_grid_hex
 
 end module fortplot_figure_grid

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -105,7 +105,7 @@ module fortplot_figure_initialization
         logical :: grid_enabled = .false.
         character(len=10) :: grid_which = 'both'
         character(len=1) :: grid_axis = 'b'
-        real(wp) :: grid_alpha = 0.7_wp
+        real(wp) :: grid_alpha = 1.0_wp
         character(len=10) :: grid_linestyle = '-'
         character(len=7) :: grid_color = '#b0b0b0'
 

--- a/src/rendering/fortplot_spec_config_apply.f90
+++ b/src/rendering/fortplot_spec_config_apply.f90
@@ -14,6 +14,7 @@ module fortplot_spec_config_apply
     private
     public :: apply_config_to_state, apply_padding_to_margins
     public :: apply_style_defaults
+    public :: set_legend_position_from_orient
 
 contains
 
@@ -104,9 +105,6 @@ contains
             state%label_font_size = cfg%axis%label_font_size
             state%tick_font_size = cfg%axis%label_font_size
         end if
-        if (cfg%axis%title_font_size >= 0.0_wp) then
-            state%label_font_size = cfg%axis%title_font_size
-        end if
     end subroutine apply_axis_config
 
     subroutine apply_title_config(cfg, state)
@@ -128,17 +126,26 @@ contains
         if (.not. cfg%legend%defined) return
         if (.not. cfg%legend%orient_set) return
 
-        select case (trim(cfg%legend%orient))
-        case ('top-left')
-            state%legend_data%position = 1
-        case ('top-right')
-            state%legend_data%position = 2
-        case ('bottom-left')
-            state%legend_data%position = 3
-        case ('bottom-right')
-            state%legend_data%position = 4
-        end select
+        call set_legend_position_from_orient( &
+            cfg%legend%orient, state%legend_data%position)
     end subroutine apply_legend_config
+
+    subroutine set_legend_position_from_orient(orient, position)
+        !! Single source of truth for orient string -> position int.
+        character(len=*), intent(in) :: orient
+        integer, intent(inout) :: position
+
+        select case (trim(orient))
+        case ('top-left')
+            position = 1
+        case ('top-right')
+            position = 2
+        case ('bottom-left')
+            position = 3
+        case ('bottom-right')
+            position = 4
+        end select
+    end subroutine set_legend_position_from_orient
 
     subroutine apply_font_preference(cfg)
         !! Set the preferred font based on config axis label font.

--- a/src/rendering/fortplot_spec_rendering.f90
+++ b/src/rendering/fortplot_spec_rendering.f90
@@ -26,7 +26,8 @@ module fortplot_spec_rendering
                                    layer_t, mark_t
     use fortplot_annotations, only: text_annotation_t
     use fortplot_spec_config_apply, only: apply_config_to_state, &
-                                          apply_padding_to_margins
+                                          apply_padding_to_margins, &
+                                          set_legend_position_from_orient
 
     implicit none
     private
@@ -193,16 +194,9 @@ contains
         ! Apply legend position from config AFTER legend is built
         if (spec%config%defined .and. spec%config%legend%defined &
             .and. spec%config%legend%orient_set) then
-            select case (trim(spec%config%legend%orient))
-            case ('top-left')
-                state%legend_data%position = 1
-            case ('top-right')
-                state%legend_data%position = 2
-            case ('bottom-left')
-                state%legend_data%position = 3
-            case ('bottom-right')
-                state%legend_data%position = 4
-            end select
+            call set_legend_position_from_orient( &
+                spec%config%legend%orient, &
+                state%legend_data%position)
         end if
     end subroutine apply_spec_to_render_state
 

--- a/src/spec/fortplot_spec_config_defaults.f90
+++ b/src/spec/fortplot_spec_config_defaults.f90
@@ -71,7 +71,7 @@ contains
         cfg%mark%point_size = pts_to_px(6.0_wp, dpi)**2
         cfg%mark%point_filled = .true.
         cfg%mark%point_filled_set = .true.
-        cfg%mark%bar_fill = '#1f77b4'
+        cfg%mark%bar_fill = cfg%category_colors(1)
         cfg%mark%bar_fill_set = .true.
 
         ! Title: MPL centered, 12pt, normal weight
@@ -151,7 +151,7 @@ contains
         cfg%mark%point_size = 30.0_wp
         cfg%mark%point_filled = .true.
         cfg%mark%point_filled_set = .true.
-        cfg%mark%bar_fill = '#4c78a8'
+        cfg%mark%bar_fill = cfg%category_colors(1)
         cfg%mark%bar_fill_set = .true.
 
         ! Title: groupTitle=13, bold (from src/config.ts)


### PR DESCRIPTION
## Summary

Full code audit findings addressed:

**Bug fix:** `apply_axis_config` clobbered `label_font_size` with `title_font_size`

**DRY (5 fixes):**
- Extract `resolve_tick_font_px()` (was 5 identical blocks in raster_ticks)
- Delete `parse_grid_hex`, use existing `parse_color`
- `bar_fill` derived from `category_colors(1)` (was hardcoded duplicate)
- Legend orient mapping extracted to shared `set_legend_position_from_orient`

**Drift (1 fix):**
- `grid_alpha` default 0.7 -> 1.0 (matching matplotlib rcsetup.py and MPL config)

Net -26 lines.

## Test plan

- [x] fpm build + fpm test 4/4 pass
- [x] SSIM identical to pre-audit (no regression)