### PR TITLE
fix: deduplicate Tab10 palette to single source

### DIFF
--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -174,4 +174,26 @@ module fortplot_constants
     !! Used by line style pattern generation for solid line rendering.
     real(wp), parameter, public :: SOLID_LINE_PATTERN_LENGTH = 1000.0_wp
 
+    ! ========================================================================
+    ! TAB10 COLOR PALETTE (single source of truth)
+    ! ========================================================================
+
+    integer, parameter, public :: TAB10_COUNT = 10
+
+    character(len=7), parameter, public :: TAB10_HEX(10) = [ &
+        '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', &
+        '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf' ]
+
+    real(wp), parameter, public :: TAB10_RGB(3, 10) = reshape([ &
+        0.1216_wp, 0.4667_wp, 0.7059_wp, &
+        1.0_wp,    0.498_wp,  0.0549_wp, &
+        0.1725_wp, 0.6275_wp, 0.1725_wp, &
+        0.8392_wp, 0.1529_wp, 0.1569_wp, &
+        0.5804_wp, 0.4039_wp, 0.7412_wp, &
+        0.549_wp,  0.3373_wp, 0.2941_wp, &
+        0.8902_wp, 0.4667_wp, 0.7608_wp, &
+        0.498_wp,  0.498_wp,  0.498_wp,  &
+        0.7373_wp, 0.7412_wp, 0.1333_wp, &
+        0.0902_wp, 0.7451_wp, 0.8118_wp], [3, 10])
+
 end module fortplot_constants

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -5,7 +5,7 @@ module fortplot_figure_initialization
     !! Extracted from fortplot_figure_core to reduce file size and improve modularity
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: REFERENCE_DPI
+    use fortplot_constants, only: REFERENCE_DPI, TAB10_RGB
     use fortplot_context
     use fortplot_utils, only: initialize_backend
     use fortplot_legend, only: legend_t, legend_entry_t
@@ -78,19 +78,7 @@ module fortplot_figure_initialization
         character(len=:), allocatable :: suptitle
         real(wp) :: suptitle_fontsize = 14.0_wp
 
-        ! Color palette: matplotlib tab10 (Tableau-10)
-        real(wp), dimension(3, 10) :: colors = reshape([ &
-            0.1216_wp, 0.4667_wp, 0.7059_wp, & ! #1f77b4
-            1.0_wp,    0.498_wp,  0.0549_wp, & ! #ff7f0e
-            0.1725_wp, 0.6275_wp, 0.1725_wp, & ! #2ca02c
-            0.8392_wp, 0.1529_wp, 0.1569_wp, & ! #d62728
-            0.5804_wp, 0.4039_wp, 0.7412_wp, & ! #9467bd
-            0.549_wp,  0.3373_wp, 0.2941_wp, & ! #8c564b
-            0.8902_wp, 0.4667_wp, 0.7608_wp, & ! #e377c2
-            0.498_wp,  0.498_wp,  0.498_wp,  & ! #7f7f7f
-            0.7373_wp, 0.7412_wp, 0.1333_wp, & ! #bcbd22
-            0.0902_wp, 0.7451_wp, 0.8118_wp],& ! #17becf
-            [3, 10])
+        real(wp), dimension(3, 10) :: colors = TAB10_RGB
 
         ! Legend support
         type(legend_t) :: legend_data

--- a/src/spec/fortplot_spec_config_defaults.f90
+++ b/src/spec/fortplot_spec_config_defaults.f90
@@ -2,6 +2,7 @@ module fortplot_spec_config_defaults
     !! Built-in style presets for MPL and Vega-Lite rendering modes.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: TAB10_HEX, TAB10_COUNT
     use fortplot_spec_config_types, only: config_t, config_axis_t, &
         config_view_t, config_mark_defaults_t, config_title_t, &
         config_legend_t, padding_t
@@ -27,18 +28,8 @@ contains
         cfg%background = '#ffffff'
         cfg%background_set = .true.
 
-        ! Tab10 color cycle (same as matplotlib default)
-        cfg%category_color_count = 10
-        cfg%category_colors(1) = '#1f77b4'
-        cfg%category_colors(2) = '#ff7f0e'
-        cfg%category_colors(3) = '#2ca02c'
-        cfg%category_colors(4) = '#d62728'
-        cfg%category_colors(5) = '#9467bd'
-        cfg%category_colors(6) = '#8c564b'
-        cfg%category_colors(7) = '#e377c2'
-        cfg%category_colors(8) = '#7f7f7f'
-        cfg%category_colors(9) = '#bcbd22'
-        cfg%category_colors(10) = '#17becf'
+        cfg%category_color_count = TAB10_COUNT
+        cfg%category_colors(1:TAB10_COUNT) = TAB10_HEX
 
         ! Axis: MPL style (no Vega domain line, use view stroke)
         cfg%axis%defined = .true.


### PR DESCRIPTION
## Summary
- Added `TAB10_HEX` and `TAB10_RGB` parameter arrays to `fortplot_constants` as the single source of truth for the Tab10 color palette
- `spec_config_defaults` now references `TAB10_HEX` instead of 10 independent hex string assignments
- `figure_initialization` now references `TAB10_RGB` instead of an independent `reshape([...])` literal

Closes #1626

## Verification

### Test passes after fix
```
$ make test
ALL TESTS PASSED (fpm test)
```

## Test plan
- [x] `make build` compiles without errors
- [x] `make test` all tests pass