### PR TITLE
fix: replace magic numbers in raster rendering with named constants

### DIFF
--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -3,7 +3,8 @@ module fortplot_raster_labels
     !! Extracted from fortplot_raster_axes.f90 for single responsibility principle
     use fortplot_constants, only: XLABEL_VERTICAL_OFFSET, TICK_MARK_LENGTH, &
                                   YLABEL_EXTRA_GAP, TITLE_VERTICAL_OFFSET, &
-                                  REFERENCE_DPI
+                                  REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
+                                  MIN_LABEL_MARGIN_PX
     use fortplot_text_rendering, only: render_text_to_image, calculate_text_width, &
                                        calculate_text_height, &
                                        calculate_text_descent, &
@@ -277,7 +278,7 @@ contains
         dpi_val = REFERENCE_DPI
         if (present(dpi)) dpi_val = dpi
 
-        min_left_margin = max(15, rotated_width/4)
+        min_left_margin = max(MIN_LABEL_MARGIN_PX, rotated_width/4)
 
         ideal_x = y_tick_label_edge - scale_px(YLABEL_EXTRA_GAP, dpi_val) - &
                   rotated_width
@@ -341,7 +342,7 @@ contains
 
         label_width = calculate_text_width(trim(escaped_text))
         label_height = calculate_text_height(trim(escaped_text))
-        if (label_height <= 0) label_height = 12
+        if (label_height <= 0) label_height = FALLBACK_LABEL_HEIGHT_PX
 
         label_x = plot_area%left + plot_area%width/2 - label_width/2
         label_y = compute_top_xlabel_y_pos(plot_area, label_height, raster%dpi)

--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -4,7 +4,7 @@ module fortplot_raster_labels
     use fortplot_constants, only: XLABEL_VERTICAL_OFFSET, TICK_MARK_LENGTH, &
                                   YLABEL_EXTRA_GAP, TITLE_VERTICAL_OFFSET, &
                                   REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
-                                  MIN_LABEL_MARGIN_PX
+                                  MIN_LABEL_MARGIN_PX, CANVAS_EDGE_PADDING_PX
     use fortplot_text_rendering, only: render_text_to_image, calculate_text_width, &
                                        calculate_text_height, &
                                        calculate_text_descent, &
@@ -78,9 +78,9 @@ contains
             ! Position xlabel below x-tick labels with measured clearance
             label_y = plot_area%bottom + plot_area%height + &
                       scale_px(X_TICK_LABEL_PAD, raster%dpi) + &
-                      max(last_x_tick_max_height_bottom, 12) + &
+                      max(last_x_tick_max_height_bottom, FALLBACK_LABEL_HEIGHT_PX) + &
                       scale_px(XLABEL_VERTICAL_OFFSET, raster%dpi)/3
-            label_y = min(label_y, height - label_height - 5)
+            label_y = min(label_y, height - label_height - CANVAS_EDGE_PADDING_PX)
             call render_text_to_image(raster%image_data, width, height, &
                                       label_x, label_y, &
                                       trim(escaped_text), 0_1, 0_1, 0_1)
@@ -187,9 +187,9 @@ contains
 
         compute_ylabel_right_x_pos = y_tick_label_edge + &
                                      scale_px(YLABEL_EXTRA_GAP, dpi_val)
-        if (compute_ylabel_right_x_pos + rotated_width > canvas_width - 15) then
-            compute_ylabel_right_x_pos = max(plot_area%left + plot_area%width + 5, &
-                                             canvas_width - rotated_width - 15)
+        if (compute_ylabel_right_x_pos + rotated_width > canvas_width - MIN_LABEL_MARGIN_PX) then
+            compute_ylabel_right_x_pos = max(plot_area%left + plot_area%width + CANVAS_EDGE_PADDING_PX, &
+                                             canvas_width - rotated_width - MIN_LABEL_MARGIN_PX)
         end if
     end function compute_ylabel_right_x_pos
 
@@ -317,7 +317,7 @@ contains
 
         compute_top_xlabel_y_pos = max(1, plot_area%bottom - &
                                        scale_px(X_TICK_LABEL_TOP_PAD, dpi_val) - &
-                                       last_x_tick_max_height_top - label_height - 5)
+                                       last_x_tick_max_height_top - label_height - CANVAS_EDGE_PADDING_PX)
     end function compute_top_xlabel_y_pos
 
     subroutine raster_draw_top_xlabel(raster, width, height, plot_area, xlabel)

--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -15,7 +15,8 @@ module fortplot_raster_ticks
     use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_line_styles, only: draw_styled_line
-    use fortplot_constants, only: REFERENCE_DPI
+    use fortplot_constants, only: REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
+                                  MIN_TICK_LABEL_GAP_PX
     use fortplot_raster_core, only: raster_image_t, scale_px
     use fortplot_scales, only: apply_scale_transform
     use fortplot_raster_config, only: config_tick_font_size
@@ -324,7 +325,7 @@ contains
 
             label_width = calculate_text_width_with_size(trim(escaped_text), font_px)
             label_height = calculate_text_height_with_size(font_px)
-            if (label_height <= 0) label_height = scale_px(12, raster%dpi)
+            if (label_height <= 0) label_height = scale_px(FALLBACK_LABEL_HEIGHT_PX, raster%dpi)
 
             last_y_tick_max_width = max(last_y_tick_max_width, label_width)
 
@@ -469,7 +470,7 @@ contains
 
             label_width = calculate_text_width_with_size(trim(escaped_text), font_px)
             label_height = calculate_text_height_with_size(font_px)
-            if (label_height <= 0) label_height = scale_px(12, raster%dpi)
+            if (label_height <= 0) label_height = scale_px(FALLBACK_LABEL_HEIGHT_PX, raster%dpi)
 
             label_x = plot_area%left + plot_area%width + &
                       scale_px(Y_TICK_LABEL_LEFT_PAD, raster%dpi)
@@ -604,7 +605,7 @@ contains
 
             label_width = calculate_text_width_with_size(trim(escaped_text), font_px)
             label_height = calculate_text_height_with_size(font_px)
-            if (label_height <= 0) label_height = scale_px(12, raster%dpi)
+            if (label_height <= 0) label_height = scale_px(FALLBACK_LABEL_HEIGHT_PX, raster%dpi)
 
             label_x = tick_x - label_width/2
             label_y = max(1, plot_area%bottom - &
@@ -645,7 +646,7 @@ contains
         end if
 
         ! Minimum gap between labels (pixels) - increased for better readability
-        min_gap = 8
+        min_gap = MIN_TICK_LABEL_GAP_PX
 
         allocate (label_lefts(n), label_rights(n))
 

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -103,7 +103,6 @@ module fortplot_constants
     integer, parameter, public :: MIN_TICK_LABEL_GAP_PX = 8
     integer, parameter, public :: MIN_LABEL_MARGIN_PX = 15
     integer, parameter, public :: CANVAS_EDGE_PADDING_PX = 5
-    real(wp), parameter, public :: TITLE_PADDING_PX = 4.0_wp
     real(wp), parameter, public :: FALLBACK_GRID_GRAY = 0.69_wp
     real(wp), parameter, public :: APPROX_EQUAL_TOLERANCE = 1.0e-6_wp
 

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -96,6 +96,23 @@ module fortplot_constants
     integer, parameter, public :: YLABEL_EXTRA_GAP = 25
 
     ! ========================================================================
+    ! RASTER RENDERING CONSTANTS
+    ! ========================================================================
+
+    integer, parameter, public :: FALLBACK_LABEL_HEIGHT_PX = 12
+    integer, parameter, public :: MIN_TICK_LABEL_GAP_PX = 8
+    integer, parameter, public :: MIN_LABEL_MARGIN_PX = 15
+    integer, parameter, public :: CANVAS_EDGE_PADDING_PX = 5
+    real(wp), parameter, public :: TITLE_PADDING_PX = 4.0_wp
+    real(wp), parameter, public :: FALLBACK_GRID_GRAY = 0.69_wp
+    real(wp), parameter, public :: APPROX_EQUAL_TOLERANCE = 1.0e-6_wp
+
+    ! Vega-Lite stroke-dash thresholds for line style detection
+    real(wp), parameter, public :: DASH_LONG = 6.0_wp
+    real(wp), parameter, public :: DASH_GAP = 3.0_wp
+    real(wp), parameter, public :: DASH_SHORT = 2.0_wp
+
+    ! ========================================================================
     ! DPI CONSTANTS
     ! ========================================================================
 

--- a/src/figures/fortplot_figure_grid.f90
+++ b/src/figures/fortplot_figure_grid.f90
@@ -5,6 +5,7 @@ module fortplot_figure_grid
     !! Extracted from fortplot_figure_core to improve modularity
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: FALLBACK_GRID_GRAY
     use fortplot_context
     use fortplot_ascii, only: ascii_context
     use fortplot_axes, only: compute_scale_ticks
@@ -109,7 +110,7 @@ contains
         end select
         
         ! Set grid color from config or fallback to gray
-        grid_color = [0.69_wp, 0.69_wp, 0.69_wp]
+        grid_color = [FALLBACK_GRID_GRAY, FALLBACK_GRID_GRAY, FALLBACK_GRID_GRAY]
         if (present(grid_color_hex)) then
             if (len_trim(grid_color_hex) > 0) then
                 block

--- a/src/rendering/fortplot_spec_rendering.f90
+++ b/src/rendering/fortplot_spec_rendering.f90
@@ -5,6 +5,8 @@ module fortplot_spec_rendering
     !! existing backends without routing through figure_t.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: APPROX_EQUAL_TOLERANCE, &
+                                  DASH_LONG, DASH_GAP, DASH_SHORT
     use fortplot_colors, only: parse_color
     use fortplot_figure_core_advanced, only: core_scatter
     use fortplot_figure_core_config, only: core_grid, core_set_line_width, &
@@ -870,21 +872,21 @@ contains
         linestyle = '-'
 
         if (size(mark%stroke_dash) == 2) then
-            if (approx_equal(mark%stroke_dash(1), 6.0_wp) .and. &
-                approx_equal(mark%stroke_dash(2), 3.0_wp)) then
+            if (approx_equal(mark%stroke_dash(1), DASH_LONG) .and. &
+                approx_equal(mark%stroke_dash(2), DASH_GAP)) then
                 linestyle = '--'
                 return
             end if
-            if (approx_equal(mark%stroke_dash(1), 2.0_wp) .and. &
-                approx_equal(mark%stroke_dash(2), 3.0_wp)) then
+            if (approx_equal(mark%stroke_dash(1), DASH_SHORT) .and. &
+                approx_equal(mark%stroke_dash(2), DASH_GAP)) then
                 linestyle = ':'
                 return
             end if
         else if (size(mark%stroke_dash) == 4) then
-            if (approx_equal(mark%stroke_dash(1), 6.0_wp) .and. &
-                approx_equal(mark%stroke_dash(2), 3.0_wp) .and. &
-                approx_equal(mark%stroke_dash(3), 2.0_wp) .and. &
-                approx_equal(mark%stroke_dash(4), 3.0_wp)) then
+            if (approx_equal(mark%stroke_dash(1), DASH_LONG) .and. &
+                approx_equal(mark%stroke_dash(2), DASH_GAP) .and. &
+                approx_equal(mark%stroke_dash(3), DASH_SHORT) .and. &
+                approx_equal(mark%stroke_dash(4), DASH_GAP)) then
                 linestyle = '-.'
                 return
             end if
@@ -894,7 +896,7 @@ contains
     logical function approx_equal(a, b) result(equal)
         real(wp), intent(in) :: a, b
 
-        equal = abs(a - b) < 1.0e-6_wp
+        equal = abs(a - b) < APPROX_EQUAL_TOLERANCE
     end function approx_equal
 
     subroutine parse_mark_color(color_spec, rgb, success)


### PR DESCRIPTION
## Summary
- Added 10 named constants to `fortplot_constants` for raster rendering magic numbers
- Replaced fallback label height (12px), min tick label gap (8px), min margin (15px), grid gray (0.69), approx-equal tolerance (1e-6), and stroke dash thresholds (6.0/3.0/2.0) across 5 files

Closes #1628

## Verification

### Test passes after fix
```
$ make test
ALL TESTS PASSED (fpm test)
```

## Test plan
- [x] `make build` compiles without errors
- [x] `make test` all tests pass
- [x] Pure refactor -- no behavioral change