### PR TITLE
Fix ASCII backend: configurable canvas size and animation frame clearing

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -110,15 +110,28 @@ contains
         type(ascii_context) :: ctx
         integer :: w, h
 
-        ! Suppress unused parameter warnings
-        associate (unused_w => width, unused_h => height); end associate
-
-        ! ASCII backend uses a 4:3 aspect ratio, accounting for terminal character
-        ! dimensions.
-        ! Terminal characters are taller than they are wide; a 24-row canvas keeps the
-        ! legend heuristics inside ASCII mode while preserving enough vertical space.
-        w = 80
-        h = 24
+        ! Use caller-specified dimensions, scaling pixel values to characters.
+        ! Values <= 200 are treated as direct character counts (e.g. dpi=1).
+        ! Larger values are assumed to be pixels and scaled down, accounting
+        ! for the ~2:1 character aspect ratio (chars are taller than wide).
+        if (present(width) .and. width > 0) then
+            if (width > 200) then
+                w = max(80, min(120, nint(real(width, wp) / 10.0_wp)))
+            else
+                w = width
+            end if
+        else
+            w = 80
+        end if
+        if (present(height) .and. height > 0) then
+            if (height > 60) then
+                h = max(20, min(30, nint(real(height, wp) / 20.0_wp)))
+            else
+                h = height
+            end if
+        else
+            h = 24
+        end if
 
         call setup_canvas(ctx, w, h)
 

--- a/src/figures/core/fortplot_figure_core_io_compat.f90
+++ b/src/figures/core/fortplot_figure_core_io_compat.f90
@@ -126,6 +126,16 @@ contains
 
         if (need_backend_switch) then
             call setup_figure_backend(state, required_backend)
+        else
+            ! Clear ASCII canvas before re-rendering to prevent frame ghosting
+            select type (backend => state%backend)
+            type is (ascii_context)
+                if (.not. state%rendered) then
+                    backend%canvas = ' '
+                    backend%num_text_elements = 0
+                    backend%num_legend_lines = 0
+                end if
+            end select
         end if
 
         ! Render if not already rendered (with annotations if provided)


### PR DESCRIPTION
## Summary
- ASCII backend now respects caller-specified width/height instead of hardcoding 80x24, with automatic pixel-to-character scaling for large values
- Fix animation frame ghosting: clear ASCII canvas before re-rendering to prevent old curve data from accumulating across frames

## Test plan
- [x] `fpm run --example probability_animation_demo` produces clean frames without ghosting
- [x] `fpm run --example probability_showcase` still produces correct output at default 80x24
- [x] Custom dimensions via `figure(figsize=[120.0, 28.0], dpi=1)` produce 120x28 character output