### PR TITLE
Improve ASCII backend text and axis rendering

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -9,7 +9,7 @@ module fortplot_ascii
 
     use fortplot_context, only: plot_context, setup_canvas
     use fortplot_logging, only: log_info, log_error
-    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_constants, only: EPSILON_COMPARE
     use fortplot_ascii_utils, only: text_element_t, get_char_density, get_blend_char, &
                                     ASCII_CHARS
@@ -62,6 +62,10 @@ module fortplot_ascii
         character(len=16) :: last_xscale = 'linear'
         character(len=16) :: last_yscale = 'linear'
         real(wp) :: last_symlog_threshold = 1.0_wp
+        !! Optional custom x-tick positions/labels forwarded by the render
+        !! engine so the ASCII axis honours ``set_xticks`` (issue #1714).
+        real(wp), allocatable :: custom_xtick_positions(:)
+        character(len=64), allocatable :: custom_xtick_labels(:)
     contains
         procedure :: line => ascii_draw_line
         procedure :: color => ascii_set_color
@@ -199,19 +203,48 @@ contains
     end subroutine ascii_set_line_style
 
     subroutine ascii_draw_text(this, x, y, text)
+        !! Store a text element at the given position. Coordinates in the
+        !! range [1, plot_width] x [1, plot_height] are treated as screen
+        !! coordinates (legend helpers work that way); otherwise the input
+        !! is projected from data coordinates onto the canvas so callers
+        !! that pass world-space positions (polar tick labels, annotations,
+        !! secondary-axis labels) render at the correct location.
         class(ascii_context), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
 
-        if (this%num_text_elements < size(this%text_elements)) then
-            this%num_text_elements = this%num_text_elements + 1
-            this%text_elements(this%num_text_elements)%text = trim(text)
-            this%text_elements(this%num_text_elements)%x = nint(x)
-            this%text_elements(this%num_text_elements)%y = nint(y)
-            this%text_elements(this%num_text_elements)%color_r = this%current_r
-            this%text_elements(this%num_text_elements)%color_g = this%current_g
-            this%text_elements(this%num_text_elements)%color_b = this%current_b
+        character(len=500) :: processed_text
+        integer :: processed_len, text_x, text_y, pw, ph
+
+        if (this%num_text_elements >= size(this%text_elements)) return
+
+        call sanitize_ascii_text(text, processed_text, processed_len)
+
+        pw = this%plot_width
+        ph = this%plot_height
+        if (x >= 1.0_wp .and. x <= real(pw, wp) .and. &
+            y >= 1.0_wp .and. y <= real(ph, wp)) then
+            text_x = nint(x)
+            text_y = nint(y)
+        else if (this%x_max > this%x_min .and. this%y_max > this%y_min) then
+            text_x = nint((x - this%x_min)/(this%x_max - this%x_min)*real(pw, wp))
+            text_y = nint((this%y_max - y)/(this%y_max - this%y_min)*real(ph, wp))
+        else
+            text_x = nint(x)
+            text_y = nint(y)
         end if
+
+        text_x = max(1, min(text_x, max(1, pw - processed_len + 1)))
+        text_y = max(1, min(text_y, ph))
+
+        this%num_text_elements = this%num_text_elements + 1
+        this%text_elements(this%num_text_elements)%text = &
+            processed_text(1:processed_len)
+        this%text_elements(this%num_text_elements)%x = text_x
+        this%text_elements(this%num_text_elements)%y = text_y
+        this%text_elements(this%num_text_elements)%color_r = this%current_r
+        this%text_elements(this%num_text_elements)%color_g = this%current_g
+        this%text_elements(this%num_text_elements)%color_b = this%current_b
     end subroutine ascii_draw_text
 
     subroutine ascii_set_title(this, title)
@@ -221,8 +254,8 @@ contains
         character(len=500) :: processed_title
         integer :: processed_len
 
-        ! Process LaTeX commands in title
-        call process_latex_in_text(title, processed_title, processed_len)
+        ! Normalize title for the ASCII canvas.
+        call sanitize_ascii_text(title, processed_title, processed_len)
         this%title_text = processed_title(1:processed_len)
         this%title_set = .true.
     end subroutine ascii_set_title
@@ -350,8 +383,9 @@ contains
         type(legend_t), intent(in) :: legend
         real(wp), intent(in) :: legend_x, legend_y
 
-        integer :: i
+        integer :: i, label_len
         character(len=96) :: line_buffer
+        character(len=256) :: sanitized_label
         character(len=:), allocatable :: label_text
         character(len=1) :: marker_char
 
@@ -367,7 +401,9 @@ contains
 
         do i = 1, legend%num_entries
             if (allocated(legend%entries(i)%label)) then
-                label_text = trim(legend%entries(i)%label)
+                call sanitize_ascii_text(legend%entries(i)%label, sanitized_label, &
+                                         label_len)
+                label_text = sanitized_label(1:label_len)
             else
                 label_text = ''
             end if
@@ -523,18 +559,40 @@ contains
         this%last_yscale = trim(yscale)
         this%last_symlog_threshold = symlog_threshold
 
-        ! Call the module version with all required parameters
-        call draw_ascii_axes_and_labels(this%canvas, xscale, yscale, symlog_threshold, &
-                                        x_min, x_max, y_min, y_max, &
-                                        title, xlabel, ylabel, &
-                                        x_date_format, y_date_format, &
-                                        z_min, z_max, has_3d_plots, &
-                                        this%current_r, this%current_g, &
-                                        this%current_b, &
-                                        this%plot_width, this%plot_height, &
-                                        this%title_text, this%xlabel_text, &
-                                        this%ylabel_text, &
-                                        this%text_elements, this%num_text_elements)
+        if (allocated(this%custom_xtick_positions) .and. &
+            allocated(this%custom_xtick_labels)) then
+            call draw_ascii_axes_and_labels(this%canvas, xscale, yscale, &
+                                            symlog_threshold, &
+                                            x_min, x_max, y_min, y_max, &
+                                            title, xlabel, ylabel, &
+                                            x_date_format, y_date_format, &
+                                            z_min, z_max, has_3d_plots, &
+                                            this%current_r, this%current_g, &
+                                            this%current_b, &
+                                            this%plot_width, this%plot_height, &
+                                            this%title_text, this%xlabel_text, &
+                                            this%ylabel_text, &
+                                            this%text_elements, &
+                                            this%num_text_elements, &
+                                            custom_xticks= &
+                                                this%custom_xtick_positions, &
+                                            custom_xtick_labels= &
+                                                this%custom_xtick_labels)
+        else
+            call draw_ascii_axes_and_labels(this%canvas, xscale, yscale, &
+                                            symlog_threshold, &
+                                            x_min, x_max, y_min, y_max, &
+                                            title, xlabel, ylabel, &
+                                            x_date_format, y_date_format, &
+                                            z_min, z_max, has_3d_plots, &
+                                            this%current_r, this%current_g, &
+                                            this%current_b, &
+                                            this%plot_width, this%plot_height, &
+                                            this%title_text, this%xlabel_text, &
+                                            this%ylabel_text, &
+                                            this%text_elements, &
+                                            this%num_text_elements)
+        end if
     end subroutine ascii_draw_axes_and_labels
 
     subroutine ascii_save_coordinates(this, x_min, x_max, y_min, y_max)

--- a/src/backends/ascii/fortplot_ascii_mathtext.f90
+++ b/src/backends/ascii/fortplot_ascii_mathtext.f90
@@ -1,0 +1,103 @@
+module fortplot_ascii_mathtext
+    !! ASCII mathtext and Unicode fallback utilities.
+    !!
+    !! Centralises the cleanup steps needed so that text produced for the
+    !! ASCII backend is readable: LaTeX command expansion, math scope
+    !! stripping, mathtext brace removal, and transliteration of common
+    !! Unicode symbols to ASCII equivalents. Applied at text emission time
+    !! so that tick labels, legend entries, annotations, axis labels, and
+    !! titles all render without raw markup or U+XXXX escape fragments.
+
+    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_unicode, only: escape_unicode_for_ascii
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    private
+    public :: sanitize_ascii_text
+
+contains
+
+    subroutine sanitize_ascii_text(input, output, out_len)
+        !! Produce an ASCII-safe version of ``input`` suitable for placement
+        !! onto the canvas: LaTeX commands become Unicode (or ASCII words),
+        !! math delimiters and mathtext braces are stripped, and any
+        !! remaining Unicode symbols are transliterated.
+        character(len=*), intent(in) :: input
+        character(len=*), intent(out) :: output
+        integer, intent(out) :: out_len
+
+        character(len=len(output)) :: latex_out
+        character(len=len(output)) :: math_stripped
+        character(len=len(output)) :: flattened
+        character(len=len(output)) :: unicode_out
+        integer :: latex_len, stripped_len, flat_len
+
+        call process_latex_in_text(input, latex_out, latex_len)
+        call strip_math_delimiters(latex_out(1:latex_len), math_stripped, &
+                                   stripped_len)
+        call simplify_mathtext(math_stripped(1:stripped_len), flattened, &
+                               flat_len)
+        call escape_unicode_for_ascii(flattened(1:flat_len), unicode_out)
+        output = unicode_out
+        out_len = len_trim(unicode_out)
+    end subroutine sanitize_ascii_text
+
+    subroutine strip_math_delimiters(input, output, out_len)
+        !! Remove ``$`` math-scope delimiters while preserving content.
+        character(len=*), intent(in) :: input
+        character(len=*), intent(out) :: output
+        integer, intent(out) :: out_len
+        integer :: i, j, n
+
+        n = len_trim(input)
+        j = 0
+        output = ''
+        do i = 1, n
+            if (input(i:i) == '$') cycle
+            j = j + 1
+            output(j:j) = input(i:i)
+        end do
+        out_len = j
+    end subroutine strip_math_delimiters
+
+    subroutine simplify_mathtext(input, output, out_len)
+        !! Convert mathtext constructs like ``10^{3}`` to ``10^3`` and
+        !! drop braces produced by mathtext commands.
+        character(len=*), intent(in) :: input
+        character(len=*), intent(out) :: output
+        integer, intent(out) :: out_len
+        integer :: i, j, n
+
+        n = len_trim(input)
+        i = 1
+        j = 0
+        output = ''
+        do while (i <= n)
+            if ((input(i:i) == '^' .or. input(i:i) == '_') .and. &
+                i < n .and. input(i + 1:i + 1) == '{') then
+                j = j + 1
+                output(j:j) = input(i:i)
+                i = i + 2
+                do while (i <= n .and. input(i:i) /= '}')
+                    j = j + 1
+                    output(j:j) = input(i:i)
+                    i = i + 1
+                end do
+                if (i <= n) i = i + 1
+                cycle
+            end if
+
+            if (input(i:i) == '{' .or. input(i:i) == '}') then
+                i = i + 1
+                cycle
+            end if
+
+            j = j + 1
+            output(j:j) = input(i:i)
+            i = i + 1
+        end do
+        out_len = j
+    end subroutine simplify_mathtext
+
+end module fortplot_ascii_mathtext

--- a/src/backends/ascii/fortplot_ascii_mathtext.f90
+++ b/src/backends/ascii/fortplot_ascii_mathtext.f90
@@ -74,18 +74,20 @@ contains
         j = 0
         output = ''
         do while (i <= n)
-            if ((input(i:i) == '^' .or. input(i:i) == '_') .and. &
-                i < n .and. input(i + 1:i + 1) == '{') then
-                j = j + 1
-                output(j:j) = input(i:i)
-                i = i + 2
-                do while (i <= n .and. input(i:i) /= '}')
+            if ((input(i:i) == '^' .or. input(i:i) == '_') .and. i < n) then
+                if (input(i + 1:i + 1) == '{') then
                     j = j + 1
                     output(j:j) = input(i:i)
-                    i = i + 1
-                end do
-                if (i <= n) i = i + 1
-                cycle
+                    i = i + 2
+                    do while (i <= n)
+                        if (input(i:i) == '}') exit
+                        j = j + 1
+                        output(j:j) = input(i:i)
+                        i = i + 1
+                    end do
+                    if (i <= n) i = i + 1
+                    cycle
+                end if
             end if
 
             if (input(i:i) == '{' .or. input(i:i) == '}') then

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -7,7 +7,7 @@ module fortplot_ascii_primitives
     !! Author: fortplot contributors
     
     use fortplot_ascii_utils, only: get_char_density, get_blend_char, ASCII_CHARS
-    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
@@ -231,10 +231,10 @@ contains
         
         character(len=500) :: processed_text
         integer :: processed_len
-        
-        ! Process LaTeX commands to Unicode
-        call process_latex_in_text(text_input, processed_text, processed_len)
-        
+
+        ! Produce ASCII-safe text matching the other ASCII text paths.
+        call sanitize_ascii_text(text_input, processed_text, processed_len)
+
         ! Convert coordinates - check if already in screen coordinates
         if (x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &
             y >= 1.0_wp .and. y <= real(plot_height, wp)) then
@@ -246,19 +246,12 @@ contains
             text_x = nint((x - x_min) / (x_max - x_min) * real(plot_width, wp))
             text_y = nint((y_max - y) / (y_max - y_min) * real(plot_height, wp))
         end if
-        
-        ! Clamp to canvas bounds
-        ! For legend text (already in screen coordinates), don't truncate based on length
-        if (x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &
-            y >= 1.0_wp .and. y <= real(plot_height, wp)) then
-            ! For legend text, only clamp starting position, let text extend as needed
-            text_x = max(1, min(text_x, plot_width))
-        else
-            ! For other text, prevent overflow
-            text_x = max(1, min(text_x, plot_width - processed_len))
-        end if
+
+        ! Clamp to canvas bounds so the trailing character stays inside
+        ! the frame border (issue #1706).
+        text_x = max(1, min(text_x, max(1, plot_width - processed_len + 1)))
         text_y = max(1, min(text_y, plot_height))
-        
+
         text = processed_text(1:processed_len)
         
         ! Note: Color values are passed but not used for storage here

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -9,7 +9,7 @@ module fortplot_ascii_text
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
     use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
                                          format_tick_value_consistent
-    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_ascii_utils, only: text_element_t, is_legend_entry_text, &
                                     is_registered_legend_label, is_autopct_text
     use fortplot_ascii_primitives, only: ascii_draw_text_primitive
@@ -30,7 +30,8 @@ contains
                                           current_r, current_g, current_b, &
                                           plot_width, plot_height, &
                                           title_text, xlabel_text, ylabel_text, &
-                                          text_elements, num_text_elements)
+                                          text_elements, num_text_elements, &
+                                          custom_xticks, custom_xtick_labels)
         !! Draw axes and labels for ASCII backend
         character(len=1), intent(inout) :: canvas(:, :)
         character(len=*), intent(in) :: xscale, yscale
@@ -46,6 +47,8 @@ contains
                                                         ylabel_text
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(inout) :: num_text_elements
+        real(wp), intent(in), optional :: custom_xticks(:)
+        character(len=*), intent(in), optional :: custom_xtick_labels(:)
 
         real(wp) :: x_tick_positions(MAX_TICKS), y_tick_positions(MAX_TICKS)
         integer :: num_x_ticks, num_y_ticks, i
@@ -56,6 +59,7 @@ contains
         character(len=1) :: line_char
         character(len=500) :: processed_title
         integer :: processed_len
+        logical :: use_custom_xticks
         ! For y-axis ASCII label de-duplication by row
         integer :: row
         integer, allocatable :: row_best_len(:)
@@ -69,7 +73,7 @@ contains
         ! ASCII backend: explicitly set title and draw simple axes
         if (present(title)) then
             if (allocated(title)) then
-                call process_latex_in_text(title, processed_title, processed_len)
+                call sanitize_ascii_text(title, processed_title, processed_len)
                 title_text = processed_title(1:processed_len)
             end if
         end if
@@ -107,17 +111,31 @@ contains
 
         ! Generate tick marks and labels for ASCII
         ! X-axis ticks (drawn as characters along bottom axis)
-        call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                                 x_tick_positions, num_x_ticks)
+        use_custom_xticks = .false.
+        if (present(custom_xticks) .and. present(custom_xtick_labels)) then
+            if (size(custom_xticks) > 0 .and. &
+                size(custom_xticks) == size(custom_xtick_labels)) then
+                use_custom_xticks = .true.
+                num_x_ticks = min(size(custom_xticks), MAX_TICKS)
+                x_tick_positions(1:num_x_ticks) = custom_xticks(1:num_x_ticks)
+            end if
+        end if
+
+        if (.not. use_custom_xticks) then
+            call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
+                                     x_tick_positions, num_x_ticks)
+        end if
         ! Determine decimals for linear scale based on tick spacing
         decimals = 0
-        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
+        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2 .and. &
+            .not. use_custom_xticks) then
             decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
         end if
         do i = 1, num_x_ticks
             tick_x = x_tick_positions(i)
-            ! For ASCII, draw tick marks as characters in the text output
-            if (trim(xscale) == 'linear') then
+            if (use_custom_xticks) then
+                tick_label = custom_xtick_labels(i)
+            else if (trim(xscale) == 'linear') then
                 tick_label = format_tick_value_consistent(tick_x, decimals)
             else
                 tick_label = format_tick_label(tick_x, xscale, &
@@ -182,14 +200,14 @@ contains
         ! Note: title has already been processed and stored at line 296-300
         if (present(xlabel)) then
             if (allocated(xlabel)) then
-                call process_latex_in_text(xlabel, processed_title, processed_len)
+                call sanitize_ascii_text(xlabel, processed_title, processed_len)
                 xlabel_text = processed_title(1:processed_len)
             end if
         end if
 
         if (present(ylabel)) then
             if (allocated(ylabel)) then
-                call process_latex_in_text(ylabel, processed_title, processed_len)
+                call sanitize_ascii_text(ylabel, processed_title, processed_len)
                 ylabel_text = processed_title(1:processed_len)
             end if
         end if
@@ -254,11 +272,9 @@ contains
         character(len=500) :: processed_text
         integer :: processed_len
 
-        ! Process LaTeX commands to Unicode
-        call process_latex_in_text(text, processed_text, processed_len)
-        ! Simplify mathtext braces for ASCII readability: 10^{3} -> 10^3
-        call simplify_mathtext_for_ascii(processed_text(1:processed_len), &
-                                         processed_text, processed_len)
+        ! Produce ASCII-safe text: LaTeX -> Unicode -> strip math delimiters,
+        ! simplify mathtext, and transliterate remaining symbols.
+        call sanitize_ascii_text(text, processed_text, processed_len)
 
         ! Store text element for later rendering
         if (num_text_elements < size(text_elements)) then
@@ -276,18 +292,10 @@ contains
                 text_y = nint((y_max - y)/(y_max - y_min)*real(plot_height, wp))
             end if
 
-            ! Clamp to canvas bounds
-            ! For legend text (already in screen coordinates), do not truncate based on
-            ! label length.
-            if (x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &
-                y >= 1.0_wp .and. y <= real(plot_height, wp)) then
-                ! For legend text, only clamp the starting position; allow text to
-                ! extend as needed.
-                text_x = max(1, min(text_x, plot_width))
-            else
-                ! For other text, prevent overflow
-                text_x = max(1, min(text_x, plot_width - processed_len))
-            end if
+            ! Clamp to canvas bounds. Always keep the trailing character
+            ! inside the frame so the border ``|`` glyph is never pushed
+            ! off the right edge (issue #1706).
+            text_x = max(1, min(text_x, max(1, plot_width - processed_len + 1)))
             text_y = max(1, min(text_y, plot_height))
 
             text_elements(num_text_elements)%text = processed_text(1:processed_len)
@@ -298,49 +306,6 @@ contains
             text_elements(num_text_elements)%color_b = current_b
         end if
     end subroutine add_text_element
-
-    subroutine simplify_mathtext_for_ascii(input, output, out_len)
-        !! Convert simple mathtext like 10^{3} to 10^3 for ASCII output
-        character(len=*), intent(in) :: input
-        character(len=*), intent(inout) :: output
-        integer, intent(inout) :: out_len
-        integer :: i, j, n
-        character(len=len(output)) :: tmp
-        logical :: in_braces
-
-        n = len_trim(input)
-        i = 1
-        j = 0
-        in_braces = .false.
-        tmp = ''
-        do while (i <= n)
-            if (input(i:i) == '^' .or. input(i:i) == '_') then
-                if (i < n .and. input(i + 1:i + 1) == '{') then
-                    j = j + 1; tmp(j:j) = input(i:i)
-                    i = i + 2  ! skip ^ and opening {
-                    do while (i <= n .and. input(i:i) /= '}')
-                        j = j + 1
-                        tmp(j:j) = input(i:i)
-                        i = i + 1
-                    end do
-                    if (i <= n .and. input(i:i) == '}') then
-                        i = i + 1  ! skip closing }
-                    end if
-                else
-                    j = j + 1
-                    tmp(j:j) = input(i:i)
-                    i = i + 1
-                end if
-            else
-                j = j + 1
-                tmp(j:j) = input(i:i)
-                i = i + 1
-            end if
-        end do
-        output = tmp
-        out_len = j
-        if (j < len(output)) output(j + 1:) = ' '
-    end subroutine simplify_mathtext_for_ascii
 
     subroutine ascii_draw_text_helper(text_elements, num_text_elements, &
                                       legend_lines, num_legend_lines, &

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -111,6 +111,7 @@ contains
     subroutine apply_raster_config(state)
         use fortplot_raster, only: raster_context
         type(figure_state_t), intent(inout) :: state
+        integer :: i, n
 
         select type (bk => state%backend)
         class is (raster_context)
@@ -128,6 +129,23 @@ contains
             if (state%custom_yticks_set .and. &
                 allocated(state%custom_ytick_positions)) then
                 bk%raster%config_ytick_values = state%custom_ytick_positions
+            end if
+        class is (ascii_context)
+            if (allocated(bk%custom_xtick_positions)) &
+                deallocate (bk%custom_xtick_positions)
+            if (allocated(bk%custom_xtick_labels)) &
+                deallocate (bk%custom_xtick_labels)
+            if (state%custom_xticks_set .and. &
+                allocated(state%custom_xtick_positions) .and. &
+                allocated(state%custom_xtick_labels)) then
+                n = min(size(state%custom_xtick_positions), &
+                        size(state%custom_xtick_labels))
+                allocate (bk%custom_xtick_positions(n))
+                allocate (bk%custom_xtick_labels(n))
+                do i = 1, n
+                    bk%custom_xtick_positions(i) = state%custom_xtick_positions(i)
+                    bk%custom_xtick_labels(i) = state%custom_xtick_labels(i)
+                end do
             end if
         class default
         end select

--- a/src/utilities/text/fortplot_unicode.f90
+++ b/src/utilities/text/fortplot_unicode.f90
@@ -95,12 +95,103 @@ contains
         !! Convert Unicode codepoint to ASCII equivalent
         integer, intent(in) :: codepoint
         character(len=*), intent(out) :: ascii_equiv
-        
-        ! Try lowercase Greek first, then uppercase, then default
+
+        ! Try lowercase Greek first, then uppercase, then common math
+        ! symbols with readable names, and finally fall back to the
+        ! placeholder form so unexpected codepoints remain traceable.
         if (codepoint_to_lowercase_greek(codepoint, ascii_equiv)) return
         if (codepoint_to_uppercase_greek(codepoint, ascii_equiv)) return
+        if (codepoint_to_common_symbol(codepoint, ascii_equiv)) return
         call codepoint_to_default_placeholder(codepoint, ascii_equiv)
     end subroutine unicode_codepoint_to_ascii
+
+    logical function codepoint_to_common_symbol(codepoint, ascii_equiv)
+        !! Map frequent math / punctuation codepoints to plain ASCII so the
+        !! ASCII backend stops emitting raw U+XXXX escape fragments for
+        !! routine symbols like ``^2``, ``x``, ``sqrt``, ``+/-``, etc.
+        integer, intent(in) :: codepoint
+        character(len=*), intent(out) :: ascii_equiv
+
+        codepoint_to_common_symbol = .true.
+        select case (codepoint)
+        case (176)   ! U+00B0 degree sign
+            ascii_equiv = 'deg'
+        case (177)   ! U+00B1 plus-minus sign
+            ascii_equiv = '+/-'
+        case (181)   ! U+00B5 micro sign
+            ascii_equiv = 'u'
+        case (183)   ! U+00B7 middle dot
+            ascii_equiv = '.'
+        case (185)   ! U+00B9 superscript 1
+            ascii_equiv = '1'
+        case (178)   ! U+00B2 superscript 2
+            ascii_equiv = '2'
+        case (179)   ! U+00B3 superscript 3
+            ascii_equiv = '3'
+        case (215)   ! U+00D7 multiplication sign
+            ascii_equiv = 'x'
+        case (247)   ! U+00F7 division sign
+            ascii_equiv = '/'
+        case (8201)  ! U+2009 thin space
+            ascii_equiv = ' '
+        case (8211, 8212)  ! U+2013 en dash, U+2014 em dash
+            ascii_equiv = '-'
+        case (8216, 8217)  ! left/right single quotation marks
+            ascii_equiv = "'"
+        case (8220, 8221)  ! left/right double quotation marks
+            ascii_equiv = '"'
+        case (8226)  ! U+2022 bullet
+            ascii_equiv = '*'
+        case (8230)  ! U+2026 horizontal ellipsis
+            ascii_equiv = '...'
+        case (8242)  ! U+2032 prime
+            ascii_equiv = "'"
+        case (8243)  ! U+2033 double prime
+            ascii_equiv = '"'
+        case (8260)  ! U+2044 fraction slash
+            ascii_equiv = '/'
+        case (8592)  ! U+2190 leftwards arrow
+            ascii_equiv = '<-'
+        case (8594)  ! U+2192 rightwards arrow
+            ascii_equiv = '->'
+        case (8596)  ! U+2194 left-right arrow
+            ascii_equiv = '<->'
+        case (8710)  ! U+2206 increment
+            ascii_equiv = 'Delta'
+        case (8719)  ! U+220F n-ary product
+            ascii_equiv = 'prod'
+        case (8721)  ! U+2211 n-ary summation
+            ascii_equiv = 'sum'
+        case (8722)  ! U+2212 minus sign
+            ascii_equiv = '-'
+        case (8730)  ! U+221A square root
+            ascii_equiv = 'sqrt'
+        case (8734)  ! U+221E infinity
+            ascii_equiv = 'inf'
+        case (8743)  ! U+2227 logical and
+            ascii_equiv = 'and'
+        case (8744)  ! U+2228 logical or
+            ascii_equiv = 'or'
+        case (8747)  ! U+222B integral
+            ascii_equiv = 'int'
+        case (8776)  ! U+2248 almost equal to
+            ascii_equiv = '~='
+        case (8800)  ! U+2260 not equal to
+            ascii_equiv = '!='
+        case (8804)  ! U+2264 less-than or equal to
+            ascii_equiv = '<='
+        case (8805)  ! U+2265 greater-than or equal to
+            ascii_equiv = '>='
+        case (8901)  ! U+22C5 dot operator
+            ascii_equiv = '.'
+        case (8706)  ! U+2202 partial differential
+            ascii_equiv = 'd'
+        case (8711)  ! U+2207 nabla
+            ascii_equiv = 'grad'
+        case default
+            codepoint_to_common_symbol = .false.
+        end select
+    end function codepoint_to_common_symbol
     
     logical function codepoint_to_lowercase_greek(codepoint, ascii_equiv)
         !! Convert lowercase Greek codepoint to ASCII name

--- a/test/test_unicode.f90
+++ b/test/test_unicode.f90
@@ -93,21 +93,21 @@ contains
 
         codepoint = 8706
         call unicode_codepoint_to_ascii(codepoint, ascii_output)
-        if (trim(ascii_output) /= 'U+2202') then
+        if (trim(ascii_output) /= 'd') then
             print *, 'FAIL: test_math_symbols - partial derivative'
             return
         end if
 
         codepoint = 8711
         call unicode_codepoint_to_ascii(codepoint, ascii_output)
-        if (trim(ascii_output) /= 'U+2207') then
+        if (trim(ascii_output) /= 'grad') then
             print *, 'FAIL: test_math_symbols - nabla'
             return
         end if
 
         codepoint = 177
         call unicode_codepoint_to_ascii(codepoint, ascii_output)
-        if (trim(ascii_output) /= 'U+00B1') then
+        if (trim(ascii_output) /= '+/-') then
             print *, 'FAIL: test_math_symbols - plus-minus'
             return
         end if


### PR DESCRIPTION
## Summary
Render mathtext (log ticks, Greek, sub/superscripts) and ASCII-safe transliterations properly in the ASCII backend. Addresses #1689, #1695, #1701, #1706, #1714 (partial), #1726, #1732, plus parts of #1710.

## Verification
\`\`\`
make build            # passes
make test-ci          # passes (datetime axis crash from short-circuit issue fixed)
\`\`\`

## Risk / Compatibility
Low. Behavior change is ASCII-only.