### PR TITLE
Strengthen weak tests and relocate outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ CI_FPM_TEST_TARGETS += test_colormap_interpolation_regression
 CI_FPM_TEST_TARGETS += test_pdf_flate_content
 CI_FPM_TEST_TARGETS += test_pdf_coordinate_mapping_985
 CI_FPM_TEST_TARGETS += test_quad_fill_edges
+CI_FPM_TEST_TARGETS += test_svg_savefig
+CI_FPM_TEST_TARGETS += test_new_plot_types
+CI_FPM_TEST_TARGETS += test_ascii_animation_output
 
 .PHONY: all build example debug test clean help doc create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-with-evidence verify-size-compliance verify-complexity issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry git-prune verify-warnings
 
@@ -126,6 +129,12 @@ test-ci:
 	@$(TIMEOUT_PREFIX) ./scripts/test_pcolormesh_guard.sh || exit 1
 	@# Enforce directory item limits for src/* subfolders (Issue #914)
 	@$(TIMEOUT_PREFIX) python3 scripts/test_directory_organization_limits.py || exit 1
+	@# SVG end-to-end: stateful API through rendering pipeline to SVG file (Issue #1690)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_svg_savefig || exit 1
+	@# New plot types: imshow/step/stem/fill/fill_between/twinx/twiny behavioral smoke tests (Issue #1712)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_new_plot_types || exit 1
+	@# ASCII animation regression: frame clearing and file content (Issue #1699)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_ascii_animation_output || exit 1
 	@echo "CI essential test suite completed successfully"
 
 # Clean build artifacts

--- a/test/test_animation_clear_regression.f90
+++ b/test/test_animation_clear_regression.f90
@@ -15,7 +15,7 @@ program test_animation_clear_regression
     integer :: i, status, frame_idx
     integer(8) :: video_size
     logical :: ok, video_exists, fallback_ok
-    character(len=*), parameter :: output_stem = "test/output/test_animation_clear_regression"
+    character(len=*), parameter :: output_stem = "build/test/output/test_animation_clear_regression"
     character(len=*), parameter :: output_file = output_stem // ".mp4"
     character(len=64) :: frame_name
 
@@ -24,8 +24,8 @@ program test_animation_clear_regression
     end do
     y = gaussian_profile(0.6_wp)
 
-    call create_directory_runtime("test/output", ok)
-    if (.not. ok) error stop "failed to create test/output"
+    call create_directory_runtime("build/test/output", ok)
+    if (.not. ok) error stop "failed to create build/test/output"
 
     call figure(figsize=[6.0_wp, 3.0_wp])
     pfig => get_global_figure()

--- a/test/test_antialiasing_optimized.f90
+++ b/test/test_antialiasing_optimized.f90
@@ -4,14 +4,17 @@ program test_antialiasing_optimized
     
     use fortplot
     use fortplot_testing
+    use fortplot_system_runtime, only: create_directory_runtime
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
-    
+
     integer :: total_tests, passed_tests
+    logical :: dir_ok
     
     print *, "=== OPTIMIZED ANTIALIASING TEST SUITE ==="
     print *, "Testing rendering functionality without external dependencies"
     
+    call create_directory_runtime('build/test/output', dir_ok)
     total_tests = 0
     passed_tests = 0
     
@@ -45,7 +48,7 @@ contains
         print *, ""
         print *, "Test: Comprehensive rendering quality (all patterns)"
         
-        filename = 'test/output/aa_comprehensive.png'
+        filename = 'build/test/output/aa_comprehensive.png'
         
         ! Generate comprehensive test data covering all antialiasing scenarios:
         ! 1. Diagonal lines, 2. Curves, 3. High frequency, 4. Text, 5. Grid

--- a/test/test_ascii.f90
+++ b/test/test_ascii.f90
@@ -1,17 +1,24 @@
 program test_ascii
     !! Test program for ASCII terminal plotting functionality
     !!
-    !! This program tests the ASCII backend by creating sine and cosine
-    !! plots and displaying them in the terminal using character graphics.
-    
+    !! Creates sine and cosine plots, saves to a file, and verifies the
+    !! file content contains recognisable ASCII plot characters.
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure
-    use fortplot_system_runtime, only: is_windows
+    use fortplot_system_runtime, only: is_windows, create_directory_runtime
     implicit none
 
     real(wp), dimension(100) :: x, sx, cx
     type(figure_t) :: ascii_fig
     integer :: i
+    character(len=*), parameter :: outfile = 'build/test/output/ascii_smoke.txt'
+    logical :: dir_ok, file_exists
+    integer :: file_size, unit, ios, nlines
+    character(len=512) :: line
+    logical :: has_plot_chars
+
+    call create_directory_runtime('build/test/output', dir_ok)
 
     x = [(real(i, wp), i=0, size(x) - 1)]/5.0_wp
     sx = sin(x)
@@ -19,21 +26,52 @@ program test_ascii
 
     call ascii_fig%initialize(80, 24)
     call ascii_fig%set_title("Sine and Cosine Functions (ASCII)")
-
     call ascii_fig%add_plot(x, sx, label="sin(x)")
     call ascii_fig%add_plot(x, cx, label="cos(x)")
 
-    ! Skip show() on Windows to prevent MS Paint hanging in CI
-    ! Use blocking=.false. to avoid CI hang on all platforms
-    if (.not. is_windows()) then
-        call ascii_fig%show(blocking=.false.)
-    else
-        print *, "SKIPPED: show() on Windows (prevents CI hang)"
-        ! Test that we can save to file instead
-        call ascii_fig%savefig("test/output/test_ascii_output.txt")
+    call ascii_fig%savefig(outfile)
+
+    ! Verify the file was written
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, "FAIL: ASCII savefig did not create ", outfile
+        stop 1
+    end if
+    if (file_size <= 0) then
+        print *, "FAIL: ASCII output file is empty"
+        stop 1
+    end if
+    print *, "PASS: ASCII file created (", file_size, " bytes)"
+
+    ! Verify the file has plot content
+    nlines = 0
+    has_plot_chars = .false.
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, "FAIL: cannot read ", outfile
+        stop 1
+    end if
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        nlines = nlines + 1
+        if (index(line, '|') > 0 .or. index(line, '-') > 0 .or. &
+            index(line, '*') > 0 .or. index(line, '+') > 0) then
+            has_plot_chars = .true.
+        end if
+    end do
+    close(unit)
+
+    if (nlines < 5) then
+        print *, "FAIL: ASCII output too short (", nlines, " lines)"
+        stop 1
+    end if
+    if (.not. has_plot_chars) then
+        print *, "FAIL: ASCII output has no plot characters"
+        stop 1
     end if
 
-    print *, ""
+    print *, "PASS: ASCII content valid (", nlines, " lines)"
     print *, "ascii terminal plot created successfully!"
 
 end program test_ascii

--- a/test/test_ascii_animation_output.f90
+++ b/test/test_ascii_animation_output.f90
@@ -1,0 +1,100 @@
+program test_ascii_animation_output
+    !! Regression test for PR #1639: ASCII backend configurable canvas size
+    !! and animation frame clearing.
+    !!
+    !! Verifies:
+    !!   1. ASCII savefig writes a non-empty file with plot content.
+    !!   2. Re-rendering after set_ydata produces different output (frame
+    !!      clearing prevents ghosting from the previous render).
+    use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    type(figure_t) :: fig_a, fig_b
+    real(wp) :: x(5), y1(5), y2(5)
+    integer :: i
+    character(len=*), parameter :: frame1 = 'build/test/output/anim_frame1.txt'
+    character(len=*), parameter :: frame2 = 'build/test/output/anim_frame2.txt'
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    x  = [(real(i, wp), i = 1, 5)]
+    y1 = [1.0_wp, 2.0_wp, 3.0_wp, 2.0_wp, 1.0_wp]
+    y2 = [3.0_wp, 2.0_wp, 1.0_wp, 2.0_wp, 3.0_wp]
+
+    ! --- Test 1: savefig writes a non-empty ASCII file ---
+    call fig_a%initialize(40, 12)
+    call fig_a%add_plot(x, y1, label='frame1')
+    call fig_a%savefig(frame1)
+    call assert_file_nonempty(frame1, 'ASCII output frame1')
+
+    ! --- Test 2: re-rendering after set_ydata produces different content ---
+    ! The first render saves y1 data; after set_ydata(y2), a re-render should
+    ! clear the canvas so frame2 differs from frame1.
+    call fig_b%initialize(40, 12)
+    call fig_b%add_plot(x, y1, label='curve')
+    call fig_b%savefig(frame1)
+
+    call fig_b%set_ydata(1, y2)
+    call fig_b%set_rendered(.false.)
+    call fig_b%savefig(frame2)
+
+    call assert_file_nonempty(frame2, 'ASCII output frame2')
+    call assert_files_differ(frame1, frame2)
+
+    print *, 'All ASCII animation regression tests PASSED'
+
+contains
+
+    subroutine assert_file_nonempty(path, label)
+        character(len=*), intent(in) :: path, label
+        logical :: exists
+        integer :: sz
+
+        inquire(file=path, exist=exists, size=sz)
+        if (.not. exists) then
+            print *, 'FAIL: file not created: ', path
+            error stop 'ASCII savefig missing'
+        end if
+        if (sz <= 0) then
+            print *, 'FAIL: ASCII file is empty: ', path
+            error stop 'empty ASCII output'
+        end if
+        print *, 'PASS: ', label, ' created (', sz, ' bytes)'
+    end subroutine assert_file_nonempty
+
+    subroutine assert_files_differ(path_a, path_b)
+        character(len=*), intent(in) :: path_a, path_b
+        integer :: ua, ub, ios_a, ios_b
+        character(len=512) :: la, lb
+        integer :: diff_count, lines_checked
+
+        diff_count = 0
+        lines_checked = 0
+
+        open(newunit=ua, file=path_a, status='old', action='read', iostat=ios_a)
+        open(newunit=ub, file=path_b, status='old', action='read', iostat=ios_b)
+        if (ios_a /= 0 .or. ios_b /= 0) then
+            print *, 'FAIL: cannot open frames for comparison'
+            error stop 'cannot compare frames'
+        end if
+
+        do
+            read(ua, '(A)', iostat=ios_a) la
+            read(ub, '(A)', iostat=ios_b) lb
+            if (ios_a /= 0 .and. ios_b /= 0) exit
+            lines_checked = lines_checked + 1
+            if (la /= lb) diff_count = diff_count + 1
+        end do
+        close(ua)
+        close(ub)
+
+        if (diff_count == 0) then
+            print *, 'FAIL: frames are identical - ASCII canvas not cleared between renders'
+            error stop 'frame clearing regression'
+        end if
+        print *, 'PASS: frames differ (', diff_count, '/', lines_checked, ' lines changed)'
+    end subroutine assert_files_differ
+
+end program test_ascii_animation_output

--- a/test/test_ascii_scrambling_fix_852.f90
+++ b/test/test_ascii_scrambling_fix_852.f90
@@ -1,98 +1,110 @@
 program test_ascii_scrambling_fix_852
-    !! Comprehensive test case for ASCII text scrambling fix (Issue #852)
-    !! Tests text rendering with improved layering system
+    !! Test case for ASCII text scrambling fix (Issue #852)
+    !! Verifies that text elements appear in the output without character corruption
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
+    logical :: all_passed, dir_ok
+
+    all_passed = .true.
+    call create_directory_runtime('build/test/output', dir_ok)
+
     print *, "=== ISSUE #852 ASCII TEXT SCRAMBLING FIX TEST ==="
-    print *, ""
-    print *, "ROOT CAUSE IDENTIFIED:"
-    print *, "- Text elements overlap on ASCII canvas"
-    print *, "- Original algorithm used density-based character overwriting"
-    print *, "- Letters from different text elements get mixed/scrambled"
-    print *, ""
-    print *, "FIX IMPLEMENTED:"
-    print *, "- Modified render_text_elements_to_canvas() in fortplot_ascii_utils.f90"
-    print *, "- Added is_graphics_character() function to distinguish plot vs text"
-    print *, "- Text now only overwrites spaces and plot graphics, not other text"
-    print *, ""
-    
-    ! Test Case 1: Original bug reproduction
-    print *, "Test 1: Original bug scenario reproduction"
+
+    ! Test 1: Title text must appear in output (regression guard)
     call figure(figsize=[8.0_wp, 6.0_wp])
     call plot([1.0_wp, 2.0_wp, 3.0_wp], [1.0_wp, 4.0_wp, 9.0_wp])
-    call title("ASCII Text Scrambling Issue #852")
-    
-    ! This was the problematic long text that caused scrambling
-    call text(1.5_wp, 6.0_wp, &
-        "This is extremely long text that should test ASCII rendering boundaries and clipping")
-    
-    call savefig("test/output/test_852_original_scenario.txt")
-    print *, "  Generated: test_852_original_scenario.txt"
-    print *, "  Expected: Clean text without character scrambling"
-    print *, ""
-    
-    ! Test Case 2: Overlapping text elements (reproduces collision)
-    print *, "Test 2: Overlapping text elements collision test"
+    call title("ScrambleTest852")
+    call savefig("build/test/output/test_852_original_scenario.txt")
+    call assert_txt_contains("build/test/output/test_852_original_scenario.txt", &
+                             "ScrambleTest852", "title appears in output", all_passed)
+    call assert_txt_has_plot_chars("build/test/output/test_852_original_scenario.txt", &
+                                   all_passed)
+
+    ! Test 2: Multiple text elements - file must be non-trivial
     call figure(figsize=[8.0_wp, 6.0_wp])
     call plot([1.0_wp, 2.0_wp, 3.0_wp], [1.0_wp, 2.0_wp, 3.0_wp])
-    call title("Text Collision Prevention Test")
-    
-    ! Add two overlapping text elements to test collision handling
-    call text(1.0_wp, 2.5_wp, "First Text Element")
-    call text(1.3_wp, 2.5_wp, "Second Overlapping Text")
-    
-    call savefig("test/output/test_852_text_collision.txt")
-    print *, "  Generated: test_852_text_collision.txt"
-    print *, "  Improved: Text should not scramble with new layering system"
-    print *, ""
-    
-    ! Test Case 3: Text over plot graphics
-    print *, "Test 3: Text annotation over plot graphics"
-    call figure(figsize=[8.0_wp, 6.0_wp])
-    call plot([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp], [1.0_wp, 4.0_wp, 2.0_wp, 5.0_wp])
-    call title("Text Over Graphics Test")
-    
-    ! Add text that overlaps with plot line graphics
-    call text(2.5_wp, 3.0_wp, "Annotation over plot line")
-    
-    call savefig("test/output/test_852_text_over_graphics.txt")
-    print *, "  Generated: test_852_text_over_graphics.txt" 
-    print *, "  Expected: Text should overwrite plot graphics (not scramble)"
-    print *, ""
-    
-    ! Test Case 4: Multiple text elements at different positions
-    print *, "Test 4: Multiple text elements positioning test"
-    call figure(figsize=[8.0_wp, 6.0_wp])
-    call plot([1.0_wp, 2.0_wp, 3.0_wp], [1.0_wp, 2.0_wp, 1.5_wp])
-    call title("Multiple Text Elements Test")
-    
-    call text(1.2_wp, 1.8_wp, "Label A")
-    call text(2.0_wp, 1.9_wp, "Label B") 
-    call text(2.8_wp, 1.7_wp, "Label C")
-    call text(1.5_wp, 1.3_wp, "Bottom Label")
-    
-    call savefig("test/output/test_852_multiple_text.txt")
-    print *, "  Generated: test_852_multiple_text.txt"
-    print *, "  Improved: All text labels should be clear and non-scrambled"
-    print *, ""
-    
-    print *, "=== FIX STATUS SUMMARY ==="
-    print *, "- Root cause identified: Density-based character overwriting"
-    print *, "- Mechanism understood: Text overlap causes character mixing"
-    print *, "- Partial fix implemented: Text layering system with proper priority"
-    print *, "- Changes: Modified render_text_elements_to_canvas() function"
-    print *, "- Added: is_graphics_character() function for character classification"
-    print *, "- Behavior: Text only overwrites spaces and plot graphics, not other text"
-    print *, "- Test suite: All existing tests pass (no regression)"
-    print *, ""
-    print *, "VERIFICATION INSTRUCTIONS:"
-    print *, "1. Check generated .txt files for text scrambling patterns"
-    print *, "2. Look for mixed characters like 'MaximumItPeak3Regi0n'"
-    print *, "3. Verify text annotations are readable and complete"
-    print *, "4. Compare with annotation_demo.txt to see improvement"
-    print *, ""
-    print *, "ISSUE #852 FIX IMPLEMENTATION COMPLETED"
-    
+    call title("MultiLabelTest")
+    call text(1.2_wp, 1.8_wp, "LabelA")
+    call text(2.0_wp, 1.9_wp, "LabelB")
+    call text(2.8_wp, 1.7_wp, "LabelC")
+    call savefig("build/test/output/test_852_multiple_text.txt")
+    call assert_txt_contains("build/test/output/test_852_multiple_text.txt", &
+                             "MultiLabelTest", "multi-label title visible", all_passed)
+    call assert_txt_has_plot_chars("build/test/output/test_852_multiple_text.txt", &
+                                   all_passed)
+
+    if (.not. all_passed) then
+        error stop "test_ascii_scrambling_fix_852: assertions failed"
+    end if
+    print *, "PASS: Issue #852 regression guards passed"
+
+contains
+
+    subroutine assert_txt_contains(path, needle, label, passed)
+        character(len=*), intent(in) :: path, needle, label
+        logical, intent(inout) :: passed
+        integer :: unit, ios
+        character(len=2048) :: line
+        logical :: found
+
+        found = .false.
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "FAIL (", label, "): cannot open ", path
+            passed = .false.
+            return
+        end if
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            if (index(line, needle) > 0) then
+                found = .true.
+                exit
+            end if
+        end do
+        close(unit)
+        if (.not. found) then
+            print *, "FAIL (", label, "): '", needle, "' not found in ", path
+            passed = .false.
+        else
+            print *, "PASS (", label, "): '", needle, "' found"
+        end if
+    end subroutine assert_txt_contains
+
+    subroutine assert_txt_has_plot_chars(path, passed)
+        character(len=*), intent(in) :: path
+        logical, intent(inout) :: passed
+        integer :: unit, ios, nlines
+        character(len=512) :: line
+        logical :: has_chars
+
+        nlines = 0
+        has_chars = .false.
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "FAIL: cannot open for plot-char check: ", path
+            passed = .false.
+            return
+        end if
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            nlines = nlines + 1
+            if (index(line, '|') > 0 .or. index(line, '-') > 0 .or. &
+                index(line, '*') > 0 .or. index(line, '+') > 0) then
+                has_chars = .true.
+            end if
+        end do
+        close(unit)
+        if (nlines < 5 .or. .not. has_chars) then
+            print *, "FAIL: ASCII canvas lacks plot content in ", path
+            passed = .false.
+        else
+            print *, "PASS: ASCII canvas has plot content (", nlines, " lines)"
+        end if
+    end subroutine assert_txt_has_plot_chars
+
 end program test_ascii_scrambling_fix_852

--- a/test/test_axes_labels_comprehensive.f90
+++ b/test/test_axes_labels_comprehensive.f90
@@ -1,20 +1,25 @@
 program test_axes_labels_comprehensive
     !! Comprehensive test for Issue #335: Missing axis labels and tick marks
     !! Tests that all axis text elements are properly rendered in both PNG and ASCII
-    
+
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(wp), dimension(6) :: x_data, y_linear, y_log
     integer :: i
-    
+    logical :: all_passed, dir_ok
+
+    all_passed = .true.
+    call create_directory_runtime('build/test/output', dir_ok)
+
     print *, "=== Comprehensive Axes Labels Test ==="
-    
+
     ! Generate test data
     x_data = [(real(i, wp), i = 1, 6)]
-    y_linear = x_data * 2.0_wp + 1.0_wp              ! Linear: 3, 5, 7, 9, 11, 13
-    y_log = exp(x_data * 0.5_wp)                     ! Exponential for log scale
-    
+    y_linear = x_data * 2.0_wp + 1.0_wp
+    y_log = exp(x_data * 0.5_wp)
+
     ! Test 1: Linear scale with all axis elements
     print *, "Testing linear scale with comprehensive axis labeling..."
     call figure()
@@ -22,9 +27,13 @@ program test_axes_labels_comprehensive
     call title('Linear Scale Test - All Elements')
     call xlabel('Input Values (x)')
     call ylabel('Linear Response (2x+1)')
-    call savefig("test/output/test_linear_axes_comprehensive.png")
-    call savefig("test/output/test_linear_axes_comprehensive.txt")
-    
+    call savefig("build/test/output/test_linear_axes_comprehensive.png")
+    call savefig("build/test/output/test_linear_axes_comprehensive.txt")
+    call assert_file_nonempty("build/test/output/test_linear_axes_comprehensive.png", &
+                              "linear PNG", all_passed)
+    call assert_txt_has_content("build/test/output/test_linear_axes_comprehensive.txt", &
+                                all_passed)
+
     ! Test 2: Log scale with proper formatting
     print *, "Testing log scale with scientific notation..."
     call figure()
@@ -33,22 +42,76 @@ program test_axes_labels_comprehensive
     call title('Log Scale Test - Scientific Labels')
     call xlabel('Input Index')
     call ylabel('Exponential Growth')
-    call savefig("test/output/test_log_axes_comprehensive.png")
-    call savefig("test/output/test_log_axes_comprehensive.txt")
-    
-    print *, ""
-    print *, "VERIFICATION CHECKLIST:"
-    print *, "========================"
-    print *, "For each output file, verify:"
-    print *, "1. Title text is visible at top"
-    print *, "2. X-axis label appears below plot"
-    print *, "3. Y-axis label appears left of plot"
-    print *, "4. Tick marks are visible on axes"
-    print *, "5. Tick labels show numerical values"
-    print *, "6. Log scale uses appropriate notation"
-    print *, ""
-    print *, "Files created:"
-    print *, "- test_linear_axes_comprehensive.png/txt"
-    print *, "- test_log_axes_comprehensive.png/txt"
-    
+    call savefig("build/test/output/test_log_axes_comprehensive.png")
+    call savefig("build/test/output/test_log_axes_comprehensive.txt")
+    call assert_file_nonempty("build/test/output/test_log_axes_comprehensive.png", &
+                              "log PNG", all_passed)
+    call assert_txt_has_content("build/test/output/test_log_axes_comprehensive.txt", &
+                                all_passed)
+
+    if (.not. all_passed) then
+        error stop "test_axes_labels_comprehensive: one or more assertions failed"
+    end if
+    print *, "All axis label tests PASSED"
+
+contains
+
+    subroutine assert_file_nonempty(path, label, passed)
+        character(len=*), intent(in) :: path, label
+        logical, intent(inout) :: passed
+        logical :: exists
+        integer :: sz
+        inquire(file=path, exist=exists, size=sz)
+        if (.not. exists) then
+            print *, "FAIL: ", label, " file not created: ", path
+            passed = .false.
+        else if (sz <= 0) then
+            print *, "FAIL: ", label, " file is empty"
+            passed = .false.
+        else
+            print *, "PASS: ", label, " written (", sz, " bytes)"
+        end if
+    end subroutine assert_file_nonempty
+
+    subroutine assert_txt_has_content(path, passed)
+        !! Verify the ASCII output file contains at least one line with
+        !! a plot-character (pipe, dash, asterisk, or digit for axis ticks)
+        character(len=*), intent(in) :: path
+        logical, intent(inout) :: passed
+        integer :: unit, ios, line_count
+        character(len=512) :: line
+        logical :: has_plot_chars
+
+        line_count = 0
+        has_plot_chars = .false.
+
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "FAIL: cannot open ASCII file: ", path
+            passed = .false.
+            return
+        end if
+
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            line_count = line_count + 1
+            if (index(line, '|') > 0 .or. index(line, '-') > 0 .or. &
+                index(line, '*') > 0 .or. index(line, '+') > 0) then
+                has_plot_chars = .true.
+            end if
+        end do
+        close(unit)
+
+        if (line_count < 5) then
+            print *, "FAIL: ASCII file too short (", line_count, " lines): ", path
+            passed = .false.
+        else if (.not. has_plot_chars) then
+            print *, "FAIL: ASCII file has no plot characters: ", path
+            passed = .false.
+        else
+            print *, "PASS: ASCII content present (", line_count, " lines with plot chars)"
+        end if
+    end subroutine assert_txt_has_content
+
 end program test_axes_labels_comprehensive

--- a/test/test_boxplot_comprehensive.f90
+++ b/test/test_boxplot_comprehensive.f90
@@ -5,8 +5,11 @@ program test_boxplot_comprehensive
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot, only: figure_t
     use fortplot_validation, only: validation_result_t, validate_file_exists, validate_file_size
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
+    logical :: dir_ok
 
+    call create_directory_runtime('build/test/output', dir_ok)
     call test_basic_boxplot()
     call test_outliers()
     call test_stats()
@@ -133,7 +136,7 @@ contains
         !! Verify boxplot rendering produces non-empty output (Issue #1327)
         type(figure_t) :: fig
         real(wp), dimension(10) :: data
-        character(len=*), parameter :: out_png = 'test/output/test_boxplot_1327.png'
+        character(len=*), parameter :: out_png = 'build/test/output/test_boxplot_1327.png'
         type(validation_result_t) :: val
         integer :: i
 

--- a/test/test_colorbar_stateful.f90
+++ b/test/test_colorbar_stateful.f90
@@ -11,11 +11,11 @@ program test_colorbar_stateful
     logical :: dir_ok
     real(wp) :: x(3), y(3)
     real(wp) :: z(2, 2)
-    character(len=*), parameter :: out_file = 'test/output/test_colorbar_stateful.png'
+    character(len=*), parameter :: out_file = 'build/test/output/test_colorbar_stateful.png'
 
-    call create_directory_runtime('test/output', dir_ok)
+    call create_directory_runtime('build/test/output', dir_ok)
     if (.not. dir_ok) then
-        write (error_unit, '(A)') 'Failed to create test/output directory'
+        write (error_unit, '(A)') 'Failed to create build/test/output directory'
         stop 1
     end if
 

--- a/test/test_edge_case_data_432.f90
+++ b/test/test_edge_case_data_432.f90
@@ -4,16 +4,18 @@ program test_edge_case_data_432
     
     use fortplot
     use iso_fortran_env, only: wp => real64
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     type(figure_t) :: fig
     real(wp), allocatable :: x_empty(:), y_empty(:)
     real(wp) :: x_single(1), y_single(1)
     real(wp) :: x_normal(5), y_normal(5)
-    logical :: test_passed
-    
+    logical :: test_passed, dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
     print *, "=== Testing Edge Case Data Handling (Issue #432) ==="
-    
+
     test_passed = .true.
     
     ! Test data
@@ -34,7 +36,7 @@ program test_edge_case_data_432
     call fig%set_title("Zero-size Array Test - PNG")
     call fig%set_xlabel("X axis")  
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_zero_arrays.png")
+    call fig%savefig("build/test/output/test_zero_arrays.png")
     
     ! Check that axes and labels are visible even with no data
     if (len_trim(fig%title) > 0 .and. len_trim(fig%xlabel) > 0) then
@@ -50,7 +52,7 @@ program test_edge_case_data_432
     call fig%set_title("Zero-size Array Test - ASCII")
     call fig%set_xlabel("X axis")
     call fig%set_ylabel("Y axis")  
-    call fig%savefig("test/output/test_zero_arrays.txt")
+    call fig%savefig("build/test/output/test_zero_arrays.txt")
     
     !---------------------------------------------------------------------
     ! Test 2: Single point handling
@@ -63,7 +65,7 @@ program test_edge_case_data_432
     call fig%set_title("Single Point Test - PNG")
     call fig%set_xlabel("X axis")
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_single_point.png")
+    call fig%savefig("build/test/output/test_single_point.png")
     
     ! ASCII backend  
     call fig%initialize(80, 24, 'ascii')
@@ -71,7 +73,7 @@ program test_edge_case_data_432
     call fig%set_title("Single Point Test - ASCII") 
     call fig%set_xlabel("X axis")
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_single_point.txt")
+    call fig%savefig("build/test/output/test_single_point.txt")
     
     !---------------------------------------------------------------------
     ! Test 3: Normal data (control test)
@@ -83,14 +85,14 @@ program test_edge_case_data_432
     call fig%set_title("Normal Data Test - PNG")
     call fig%set_xlabel("X axis")
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_normal_data.png")
+    call fig%savefig("build/test/output/test_normal_data.png")
     
     call fig%initialize(80, 24, 'ascii')
     call fig%add_plot(x_normal, y_normal, label="normal data")
     call fig%set_title("Normal Data Test - ASCII")
     call fig%set_xlabel("X axis") 
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_normal_data.txt")
+    call fig%savefig("build/test/output/test_normal_data.txt")
     
     !---------------------------------------------------------------------
     ! Test 4: Mixed edge cases
@@ -105,7 +107,7 @@ program test_edge_case_data_432
     call fig%set_title("Mixed Edge Cases Test")
     call fig%set_xlabel("X axis")
     call fig%set_ylabel("Y axis")
-    call fig%savefig("test/output/test_mixed_edge_cases.png")
+    call fig%savefig("build/test/output/test_mixed_edge_cases.png")
     
     !---------------------------------------------------------------------
     ! Summary

--- a/test/test_first_plot_rendering.f90
+++ b/test/test_first_plot_rendering.f90
@@ -2,25 +2,27 @@ program test_first_plot_rendering
     !! Test for Issue #355: First plot is empty
     !! Ensures that the first plot renders correctly with proper colors
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(wp), dimension(3) :: x = [1.0_wp, 2.0_wp, 3.0_wp]
     real(wp), dimension(3) :: y = [1.0_wp, 2.0_wp, 3.0_wp]
     character(len=1000) :: line
-    logical :: test_passed
+    logical :: test_passed, dir_ok
     integer :: unit, iostat, i
-    
+
+    call create_directory_runtime('build/test/output', dir_ok)
     print *, "Testing Issue #355: First plot rendering"
     
     ! Create a simple plot using procedural interface
     call figure()
     call plot(x, y, label='test')
     call title('Test First Plot')
-    call savefig("test/output/test_first_plot_355.txt")
+    call savefig("build/test/output/test_first_plot_355.txt")
     
     ! Check that the output contains plot characters (not just dots)
     test_passed = .false.
-    open(newunit=unit, file='test/output/test_first_plot_355.txt', status='old', action='read')
+    open(newunit=unit, file='build/test/output/test_first_plot_355.txt', status='old', action='read')
     
     ! Read through the file looking for plot characters
     do i = 1, 100
@@ -46,7 +48,7 @@ program test_first_plot_rendering
     end if
     
     ! Clean up - use secure file deletion instead of system command
-    open(newunit=unit, file='test/output/test_first_plot_355.txt', status='old', iostat=iostat)
+    open(newunit=unit, file='build/test/output/test_first_plot_355.txt', status='old', iostat=iostat)
     if (iostat == 0) then
         close(unit, status='delete')
     end if

--- a/test/test_issue_433_final.f90
+++ b/test/test_issue_433_final.f90
@@ -4,11 +4,14 @@ program test_issue_433_final
     
     use fortplot
     use iso_fortran_env, only: wp => real64
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(wp) :: x(3), y(3)
     real(wp) :: huge_val, tiny_val
-    
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
     print *, "=== Final Test: Issue #433 Reproduction ==="
     
     huge_val = huge(1.0_wp)
@@ -26,7 +29,7 @@ program test_issue_433_final
     call plot(x, y, label="limits")
     call title("Numeric Limits Test")
     call set_xscale("log")  ! Log scale should handle huge range
-    call savefig("test/output/numeric_limits_fixed.png")
+    call savefig("build/test/output/numeric_limits_fixed.png")
     
     print *, "PASS: Plot generated: numeric_limits_fixed.png"
     print *, "PASS: Should show proper plot with clamping info above"

--- a/test/test_issue_854_reproduction.f90
+++ b/test/test_issue_854_reproduction.f90
@@ -5,12 +5,15 @@
 !
 program test_issue_854_reproduction
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     use, intrinsic :: iso_fortran_env, only: wp => real64, output_unit
     implicit none
-    
+
     real(wp), parameter :: x(5) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
     real(wp), parameter :: y(5) = [1.0_wp, 4.0_wp, 2.0_wp, 8.0_wp, 3.0_wp]
+    logical :: dir_ok
     
+    call create_directory_runtime('build/test/output', dir_ok)
     write(output_unit, '(A)') "=== Issue #854 Reproduction Test ==="
     write(output_unit, '(A)') "Testing parameter validation warnings for invalid annotations"
     write(output_unit, '(A)') "across multiple backends (PNG, PDF, ASCII)"
@@ -54,15 +57,15 @@ program test_issue_854_reproduction
     
     ! Save to multiple formats - this should trigger the Issue #854 scenario
     write(output_unit, '(A)') "Saving to PNG format:"
-    call savefig("test/output/test_issue_854_reproduction.png")
+    call savefig("build/test/output/test_issue_854_reproduction.png")
     
     write(output_unit, '(A)') ""
     write(output_unit, '(A)') "Saving to PDF format:"
-    call savefig("test/output/test_issue_854_reproduction.pdf")
+    call savefig("build/test/output/test_issue_854_reproduction.pdf")
     
     write(output_unit, '(A)') ""
     write(output_unit, '(A)') "Saving to ASCII format:"
-    call savefig("test/output/test_issue_854_reproduction.txt")
+    call savefig("build/test/output/test_issue_854_reproduction.txt")
     
     write(output_unit, '(A)') ""
     write(output_unit, '(A)') "=== Issue #854 Test Results ==="

--- a/test/test_matplotlib_stubs.f90
+++ b/test/test_matplotlib_stubs.f90
@@ -1,115 +1,136 @@
 program test_matplotlib_stubs
-    !! Test that matplotlib stub implementations work correctly
+    !! Test that matplotlib stub implementations produce real output files
     use fortplot_matplotlib
     use fortplot_logging, only: log_info
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(8) :: x(10), y(10), data(100)
     integer :: i
-    logical :: test_passed
-    
+    logical :: all_passed, dir_ok
+
     ! Generate test data
     do i = 1, 10
         x(i) = real(i-1, 8)
         y(i) = real((i-1)**2, 8)
     end do
-    
+
     do i = 1, 100
         data(i) = real(i, 8) + 0.5d0 * sin(real(i, 8))
     end do
-    
-    test_passed = .true.
+
+    call create_directory_runtime('build/test/output', dir_ok)
+    all_passed = .true.
     call log_info("Testing matplotlib stub implementations...")
-    
-    ! Test scatter plot
-    call test_scatter()
-    
-    ! Test bar plot
-    call test_bar()
-    
-    ! Test horizontal bar plot
-    call test_barh()
-    
-    ! Test histogram
-    call test_hist()
-    
-    ! Test text annotation
-    call test_text()
-    
-    ! Test arrow annotation
-    call test_annotate()
-    
-    if (test_passed) then
-        call log_info("All tests passed!")
+
+    call test_scatter(all_passed)
+    call test_bar(all_passed)
+    call test_barh(all_passed)
+    call test_hist(all_passed)
+    call test_text(all_passed)
+    call test_annotate(all_passed)
+
+    if (all_passed) then
+        call log_info("All matplotlib stub tests passed!")
     else
-        call log_info("Some tests failed")
+        call log_info("Some matplotlib stub tests FAILED")
         stop 1
     end if
-    
+
 contains
 
-    subroutine test_scatter()
+    subroutine assert_file_written(path, label, passed)
+        character(len=*), intent(in) :: path, label
+        logical, intent(inout) :: passed
+        logical :: exists
+        integer :: sz
+
+        inquire(file=path, exist=exists, size=sz)
+        if (.not. exists) then
+            print *, "  FAIL: ", label, " - file not created: ", path
+            passed = .false.
+        else if (sz <= 0) then
+            print *, "  FAIL: ", label, " - file is empty: ", path
+            passed = .false.
+        else
+            print *, "  PASS: ", label, " (", sz, " bytes)"
+        end if
+    end subroutine assert_file_written
+
+    subroutine test_scatter(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing scatter plot...")
         call figure()
         call scatter(x, y, label="Test scatter")
         call title("Scatter Plot Test")
         call xlabel("X values")
         call ylabel("Y values")
-        call savefig("test/output/test_scatter.png")
-        call log_info("  scatter plot test complete")
+        call savefig("build/test/output/test_scatter_stubs.png")
+        call assert_file_written("build/test/output/test_scatter_stubs.png", &
+                                 "scatter", passed)
     end subroutine test_scatter
-    
-    subroutine test_bar()
+
+    subroutine test_bar(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing bar plot...")
         call figure()
         call bar(x, y, label="Test bars")
         call title("Bar Plot Test")
         call xlabel("Categories")
         call ylabel("Values")
-        call savefig("test/output/test_bar.png")
-        call log_info("  bar plot test complete")
+        call savefig("build/test/output/test_bar_stubs.png")
+        call assert_file_written("build/test/output/test_bar_stubs.png", &
+                                 "bar", passed)
     end subroutine test_bar
-    
-    subroutine test_barh()
+
+    subroutine test_barh(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing horizontal bar plot...")
         call figure()
         call barh(x, y, label="Test horizontal bars")
         call title("Horizontal Bar Plot Test")
         call xlabel("Values")
         call ylabel("Categories")
-        call savefig("test/output/test_barh.png")
-        call log_info("  horizontal bar plot test complete")
+        call savefig("build/test/output/test_barh_stubs.png")
+        call assert_file_written("build/test/output/test_barh_stubs.png", &
+                                 "barh", passed)
     end subroutine test_barh
-    
-    subroutine test_hist()
+
+    subroutine test_hist(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing histogram...")
         call figure()
         call hist(data, bins=20, label="Test histogram")
         call title("Histogram Test")
         call xlabel("Values")
         call ylabel("Frequency")
-        call savefig("test/output/test_hist.png")
-        call log_info("  histogram test complete")
+        call savefig("build/test/output/test_hist_stubs.png")
+        call assert_file_written("build/test/output/test_hist_stubs.png", &
+                                 "hist", passed)
     end subroutine test_hist
-    
-    subroutine test_text()
+
+    subroutine test_text(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing text annotation...")
         call figure()
         call plot(x, y)
         call text(5.0d0, 25.0d0, "Test annotation")
         call title("Text Annotation Test")
-        call savefig("test/output/test_text.png")
-        call log_info("  text annotation test complete")
+        call savefig("build/test/output/test_text_stubs.png")
+        call assert_file_written("build/test/output/test_text_stubs.png", &
+                                 "text", passed)
     end subroutine test_text
-    
-    subroutine test_annotate()
+
+    subroutine test_annotate(passed)
+        logical, intent(inout) :: passed
         call log_info("Testing arrow annotation...")
         call figure()
         call plot(x, y)
         call annotate("Peak", [5.0d0, 25.0d0], [3.0d0, 30.0d0])
         call title("Arrow Annotation Test")
-        call savefig("test/output/test_annotate.png")
-        call log_info("  arrow annotation test complete")
+        call savefig("build/test/output/test_annotate_stubs.png")
+        call assert_file_written("build/test/output/test_annotate_stubs.png", &
+                                 "annotate", passed)
     end subroutine test_annotate
-    
+
 end program test_matplotlib_stubs

--- a/test/test_mpeg_consolidated.f90
+++ b/test/test_mpeg_consolidated.f90
@@ -4,7 +4,8 @@ program test_mpeg_consolidated
     use fortplot
     use fortplot_animation
     use fortplot_pipe, only: check_ffmpeg_available
-    use fortplot_system_runtime, only: delete_file_runtime, is_windows
+    use fortplot_system_runtime, only: delete_file_runtime, is_windows, &
+                                       create_directory_runtime
     use iso_fortran_env, only: real64
     implicit none
 
@@ -12,7 +13,7 @@ program test_mpeg_consolidated
     real(real64), dimension(5) :: x, y
     character(len=256) :: ci_env
     integer :: status
-    logical :: in_ci, on_windows
+    logical :: in_ci, on_windows, dir_ok
     
     ! Skip on Windows CI - FFmpeg pipe issues
     on_windows = is_windows()
@@ -31,6 +32,7 @@ program test_mpeg_consolidated
         in_ci = (status == 0 .and. len_trim(ci_env) > 0)
     end if
 
+    call create_directory_runtime('build/test/output', dir_ok)
     print *, "=== CONSOLIDATED MPEG VALIDATION TESTS ==="
     
     if (.not. check_ffmpeg_available()) then
@@ -61,7 +63,7 @@ contains
         
         print *, "TEST: Basic MPEG Generation and Validation"
         
-        test_file = "consolidated_mpeg_test.mp4"
+        test_file = "build/test/output/consolidated_mpeg_test.mp4"
         
         call fig%initialize(width=320, height=240)  ! Small size for speed
         call fig%add_plot(x, y)

--- a/test/test_new_plot_types.f90
+++ b/test/test_new_plot_types.f90
@@ -1,0 +1,186 @@
+program test_new_plot_types
+    !! Behavioral smoke tests for imshow, step, stem, fill, fill_between,
+    !! twinx, twiny. Each sub-test verifies that:
+    !!  - the function accepts valid arguments without crashing
+    !!  - savefig produces a non-empty output file
+    use fortplot
+    use fortplot_matplotlib_session, only: get_global_figure
+    use fortplot_figure_core, only: figure_t
+    use fortplot_system_runtime, only: create_directory_runtime
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    logical :: all_passed, dir_ok
+
+    all_passed = .true.
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    call test_imshow(all_passed)
+    call test_step(all_passed)
+    call test_stem(all_passed)
+    call test_fill(all_passed)
+    call test_fill_between(all_passed)
+    call test_twinx(all_passed)
+    call test_twiny(all_passed)
+
+    if (.not. all_passed) then
+        error stop "test_new_plot_types: one or more smoke tests failed"
+    end if
+    print *, "All new plot type smoke tests PASSED"
+
+contains
+
+    subroutine assert_nonempty(path, label, passed)
+        character(len=*), intent(in) :: path, label
+        logical, intent(inout) :: passed
+        logical :: exists
+        integer :: sz
+        inquire(file=path, exist=exists, size=sz)
+        if (.not. exists) then
+            print *, "FAIL (", label, "): file not created: ", path
+            passed = .false.
+        else if (sz <= 0) then
+            print *, "FAIL (", label, "): file is empty"
+            passed = .false.
+        else
+            print *, "PASS (", label, "): ", sz, " bytes"
+        end if
+    end subroutine assert_nonempty
+
+    subroutine test_imshow(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: z(10, 10)
+        integer :: i, j
+        do i = 1, 10
+            do j = 1, 10
+                z(i, j) = sin(real(i, wp)) * cos(real(j, wp))
+            end do
+        end do
+        call figure()
+        call imshow(z)
+        call title('imshow smoke test')
+        call savefig('build/test/output/smoke_imshow.png')
+        call assert_nonempty('build/test/output/smoke_imshow.png', 'imshow', passed)
+    end subroutine test_imshow
+
+    subroutine test_step(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: x(8), y(8)
+        integer :: i
+        do i = 1, 8
+            x(i) = real(i, wp)
+            y(i) = mod(i, 3) * 1.0_wp
+        end do
+        call figure()
+        call step(x, y)
+        call title('step smoke test')
+        call savefig('build/test/output/smoke_step.png')
+        call assert_nonempty('build/test/output/smoke_step.png', 'step', passed)
+    end subroutine test_step
+
+    subroutine test_stem(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: x(6), y(6)
+        integer :: i
+        do i = 1, 6
+            x(i) = real(i, wp)
+            y(i) = sin(real(i, wp))
+        end do
+        call figure()
+        call stem(x, y)
+        call title('stem smoke test')
+        call savefig('build/test/output/smoke_stem.png')
+        call assert_nonempty('build/test/output/smoke_stem.png', 'stem', passed)
+    end subroutine test_stem
+
+    subroutine test_fill(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: x(5), y(5)
+        integer :: i
+        do i = 1, 5
+            x(i) = real(i, wp)
+            y(i) = real(i, wp) ** 2
+        end do
+        call figure()
+        call fill(x, y)
+        call title('fill smoke test')
+        call savefig('build/test/output/smoke_fill.png')
+        call assert_nonempty('build/test/output/smoke_fill.png', 'fill', passed)
+    end subroutine test_fill
+
+    subroutine test_fill_between(passed)
+        logical, intent(inout) :: passed
+        real(wp) :: x(10), y1(10), y2(10)
+        integer :: i
+        do i = 1, 10
+            x(i) = real(i, wp)
+            y1(i) = real(i, wp)
+            y2(i) = real(i, wp) * 0.5_wp
+        end do
+        call figure()
+        call fill_between(x, y1=y1, y2=y2)
+        call title('fill_between smoke test')
+        call savefig('build/test/output/smoke_fill_between.png')
+        call assert_nonempty('build/test/output/smoke_fill_between.png', 'fill_between', passed)
+    end subroutine test_fill_between
+
+    subroutine test_twinx(passed)
+        logical, intent(inout) :: passed
+        class(figure_t), pointer :: fig
+        real(wp) :: x(5), y1(5), y2(5)
+        integer :: i
+
+        do i = 1, 5
+            x(i) = real(i, wp)
+            y1(i) = real(i, wp)
+            y2(i) = 100.0_wp - real(i, wp) * 10.0_wp
+        end do
+        call figure()
+        call plot(x, y1, label='primary')
+        call twinx()
+        call plot(x, y2, label='secondary')
+        call savefig('build/test/output/smoke_twinx.png')
+        call assert_nonempty('build/test/output/smoke_twinx.png', 'twinx', passed)
+
+        fig => get_global_figure()
+        if (.not. associated(fig)) then
+            print *, "FAIL (twinx): global figure not associated"
+            passed = .false.
+        else if (.not. fig%state%has_twinx) then
+            print *, "FAIL (twinx): state%%has_twinx not set"
+            passed = .false.
+        else
+            print *, "PASS (twinx): state%%has_twinx set"
+        end if
+    end subroutine test_twinx
+
+    subroutine test_twiny(passed)
+        logical, intent(inout) :: passed
+        class(figure_t), pointer :: fig
+        real(wp) :: x(5), y(5)
+        integer :: i
+
+        do i = 1, 5
+            x(i) = real(i, wp)
+            y(i) = real(i, wp)
+        end do
+        call figure()
+        call plot(x, y, label='primary')
+        call twiny()
+        call plot(x * 2.0_wp, y, label='top axis')
+        call savefig('build/test/output/smoke_twiny.png')
+        call assert_nonempty('build/test/output/smoke_twiny.png', 'twiny', passed)
+
+        fig => get_global_figure()
+        if (.not. associated(fig)) then
+            print *, "FAIL (twiny): global figure not associated"
+            passed = .false.
+        else if (.not. fig%state%has_twiny) then
+            print *, "FAIL (twiny): state%%has_twiny not set"
+            passed = .false.
+        else
+            print *, "PASS (twiny): state%%has_twiny set"
+        end if
+    end subroutine test_twiny
+
+end program test_new_plot_types

--- a/test/test_no_error_stop.f90
+++ b/test/test_no_error_stop.f90
@@ -1,63 +1,126 @@
 program test_no_error_stop
-    !! Test that stub functions no longer call error_stop
+    !! Test that stub functions no longer call error_stop (issue #444)
+    !! Also verifies each function stores data (plot_count increments) and
+    !! the final render produces a non-empty file.
     use fortplot_matplotlib
+    use fortplot_matplotlib_session, only: get_global_figure
+    use fortplot_figure_core, only: figure_t
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(8) :: x(5), y(5), data(20)
     integer :: i
-    logical :: success
-    
+    logical :: all_passed, dir_ok
+    class(figure_t), pointer :: fig
+    integer :: expected_count
+    character(len=*), parameter :: outfile = 'build/test/output/test_no_error_stop.png'
+    logical :: file_exists
+    integer :: file_size
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
     ! Generate test data
     do i = 1, 5
         x(i) = real(i, 8)
         y(i) = real(i*i, 8)
     end do
-    
+
     do i = 1, 20
         data(i) = real(i, 8) + sin(real(i, 8))
     end do
-    
-    success = .true.
-    
-    ! Test each function that previously had error_stop
+
+    all_passed = .true.
+    expected_count = 0
+
+    ! Start fresh figure for this test
+    call figure()
+
+    ! bar() - should add a plot
     print *, "Testing bar()..."
     call bar(x, y)
     print *, "  bar() passed (no error_stop)"
-    
-    print *, "Testing barh()..."  
+    expected_count = expected_count + 1
+    fig => get_global_figure()
+    if (.not. associated(fig)) then
+        print *, "FAIL: global figure not associated after bar()"
+        all_passed = .false.
+    else if (fig%plot_count /= expected_count) then
+        print *, "FAIL: plot_count after bar() =", fig%plot_count, "; expected", expected_count
+        all_passed = .false.
+    else
+        print *, "PASS: plot_count =", fig%plot_count, " after bar()"
+    end if
+
+    ! barh()
+    print *, "Testing barh()..."
     call barh(x, y)
     print *, "  barh() passed (no error_stop)"
-    
-    print *, "Testing hist()..."
-    call hist(data)
-    print *, "  hist() passed (no error_stop)"
-    
-    print *, "Testing histogram()..."
-    call histogram(data)
-    print *, "  histogram() passed (no error_stop)"
-    
-    print *, "Testing boxplot()..."
-    call boxplot(data)
-    print *, "  boxplot() passed (no error_stop)"
-    
+    expected_count = expected_count + 1
+    fig => get_global_figure()
+    if (associated(fig) .and. fig%plot_count /= expected_count) then
+        print *, "FAIL: plot_count after barh() =", fig%plot_count, "; expected", expected_count
+        all_passed = .false.
+    else
+        print *, "PASS: plot_count =", fig%plot_count, " after barh()"
+    end if
+
+    ! scatter()
     print *, "Testing scatter()..."
     call scatter(x, y)
     print *, "  scatter() passed (no error_stop)"
-    
+    expected_count = expected_count + 1
+    fig => get_global_figure()
+    if (associated(fig) .and. fig%plot_count /= expected_count) then
+        print *, "FAIL: plot_count after scatter() =", fig%plot_count, "; expected", expected_count
+        all_passed = .false.
+    else
+        print *, "PASS: plot_count =", fig%plot_count, " after scatter()"
+    end if
+
+    ! These do not add a line plot but must not crash:
+    print *, "Testing hist()..."
+    call hist(data)
+    print *, "  hist() passed (no error_stop)"
+
+    print *, "Testing histogram()..."
+    call histogram(data)
+    print *, "  histogram() passed (no error_stop)"
+
+    print *, "Testing boxplot()..."
+    call boxplot(data)
+    print *, "  boxplot() passed (no error_stop)"
+
     print *, "Testing text()..."
     call text(2.5d0, 6.0d0, "Test")
     print *, "  text() passed (no error_stop)"
-    
+
     print *, "Testing annotate()..."
     call annotate("Arrow", [3.0d0, 9.0d0], [2.0d0, 10.0d0])
     print *, "  annotate() passed (no error_stop)"
-    
+
     print *, "Testing errorbar()..."
     call errorbar(x, y)
     print *, "  errorbar() passed (no error_stop)"
-    
+
+    ! Save and verify rendering pipeline accepts the accumulated data
+    call savefig(outfile)
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, "FAIL: savefig did not create output file"
+        all_passed = .false.
+    else if (file_size <= 0) then
+        print *, "FAIL: output file is empty"
+        all_passed = .false.
+    else
+        print *, "PASS: rendering pipeline accepted data (", file_size, " bytes)"
+    end if
+
+    if (.not. all_passed) then
+        error stop "test_no_error_stop: assertions failed"
+    end if
+
     print *, ""
-    print *, "SUCCESS: All previously stubbed functions work without error_stop!"
-    print *, "Issue #444 is resolved - no more crashes from stub implementations."
-    
+    print *, "SUCCESS: All previously stubbed functions work without error_stop."
+    print *, "Issue #444 is resolved and data is stored correctly."
+
 end program test_no_error_stop

--- a/test/test_pdf_flate_content.f90
+++ b/test/test_pdf_flate_content.f90
@@ -1,14 +1,17 @@
 program test_pdf_flate_content
     !! Verify that PDF content streams are Flate-compressed (/Filter /FlateDecode)
+    !! The compression uses a pure-Fortran zlib implementation, so this must work
+    !! on all platforms including Windows.
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    character(len=*), parameter :: fn = 'test/output/test_pdf_flate_content.pdf'
+    character(len=*), parameter :: fn = 'build/test/output/test_pdf_flate_content.pdf'
     integer :: unit, ios
     character(len=8192) :: buf
-    logical :: found
-    character(len=16) :: runner
-    integer :: rlen, rs
+    logical :: found, dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
 
     call figure()
     call plot([0.0_wp,1.0_wp],[0.0_wp,1.0_wp])
@@ -31,15 +34,8 @@ program test_pdf_flate_content
     close(unit)
 
     if (.not. found) then
-        ! In CI on Windows, PDF writer historically disabled compression; allow skip there.
-        call get_environment_variable('RUNNER_OS', runner, length=rlen, status=rs)
-        if (rs == 0 .and. rlen >= 7) then
-            if (runner(1:7) == 'Windows') then
-                print *, 'INFO: Windows runner uses uncompressed streams; skipping strict Flate check'
-                stop 0
-            end if
-        end if
         print *, 'FAIL: /Filter /FlateDecode not found in content stream'
+        print *, '      PDF compression must work on all platforms.'
         stop 2
     end if
     print *, 'PASS: PDF content stream is Flate-compressed'

--- a/test/test_pdf_io_error_handling.f90
+++ b/test/test_pdf_io_error_handling.f90
@@ -6,7 +6,7 @@ program test_pdf_io_error_handling
     implicit none
 
     type(pdf_context_core) :: ctx
-    character(len=*), parameter :: bad_path = 'test/output/does-not-exist/file.pdf'
+    character(len=*), parameter :: bad_path = 'build/test/output/does-not-exist/file.pdf'
     logical :: ok
 
     ! Initialize minimal context

--- a/test/test_pdf_unicode_sqrt.f90
+++ b/test/test_pdf_unicode_sqrt.f90
@@ -2,12 +2,16 @@ program test_pdf_unicode_sqrt
     use fortplot
     use test_pdf_utils, only: extract_pdf_stream_text
     use fortplot_validation, only: validation_result_t, validate_file_exists
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
     character(len=:), allocatable :: stream_text
     integer :: status
     type(validation_result_t) :: val
-    character(len=*), parameter :: outfile = 'test/output/test_pdf_sqrt.pdf'
+    character(len=*), parameter :: outfile = 'build/test/output/test_pdf_sqrt.pdf'
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
 
     call figure()
     call plot([0.0d0, 1.0d0], [0.0d0, 1.0d0])

--- a/test/test_pdf_unicode_uppercase.f90
+++ b/test/test_pdf_unicode_uppercase.f90
@@ -2,13 +2,16 @@ program test_pdf_unicode_uppercase
     !! Verify PDF renders uppercase Greek letters (e.g., \Psi) via Symbol font
     use fortplot
     use test_pdf_utils, only: extract_pdf_stream_text
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
-    character(len=*), parameter :: out_pdf = 'test/output/test_pdf_unicode_uppercase.pdf'
+    character(len=*), parameter :: out_pdf = 'build/test/output/test_pdf_unicode_uppercase.pdf'
+    logical :: dir_ok
     character(len=:), allocatable :: stream_text
     integer :: status
     logical :: has_symbol_font, has_upper_psi, has_upper_theta, has_upper_omega
 
+    call create_directory_runtime('build/test/output', dir_ok)
     call figure()
     call title('Uppercase: $\Psi$ test')
     call xlabel('Theta $\Theta$ and Omega $\Omega$')

--- a/test/test_public_api.f90
+++ b/test/test_public_api.f90
@@ -1,10 +1,16 @@
 program test_public_api
     !! Test program for the public fortplot API
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
     real(wp), dimension(100) :: x, y
     integer :: i
+    character(len=*), parameter :: outfile = 'build/test/output/simple_plot.png'
+    logical :: file_exists, dir_ok
+    integer :: file_size
+
+    call create_directory_runtime('build/test/output', dir_ok)
 
     ! Generate test data
     x = [(real(i, wp), i=0, size(x) - 1)]/10.0_wp
@@ -16,8 +22,18 @@ program test_public_api
     call title('Simple Plot Test')
     call xlabel('x')
     call ylabel('y')
-    call savefig('test/output/simple_plot.png')
-    
-    print *, "Public API test completed - simple_plot.png created"
+    call savefig(outfile)
+
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, "FAIL: savefig did not create ", outfile
+        stop 1
+    end if
+    if (file_size <= 0) then
+        print *, "FAIL: output file is empty"
+        stop 1
+    end if
+
+    print *, "PASS: public API test - PNG written (", file_size, " bytes)"
 
 end program test_public_api

--- a/test/test_scientific_workflow.f90
+++ b/test/test_scientific_workflow.f90
@@ -4,11 +4,14 @@ program test_scientific_workflow
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
-    
+
     real(wp), parameter :: pi = 3.14159265359_wp
     type(figure_t) :: fig
-    
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
     write(*,*) '=== SCIENTIFIC WORKFLOW TESTING ==='
     
     call test_measurement_distribution()
@@ -43,7 +46,7 @@ contains
         call fig%set_xlabel('Measured Value')
         call fig%set_ylabel('Probability Density')
         call fig%legend()
-        call fig%savefig("test/output/scientific_measurements.png")
+        call fig%savefig("build/test/output/scientific_measurements.png")
         write(*,*) '  PASS: Measurement distribution analysis complete'
         
     end subroutine test_measurement_distribution
@@ -70,7 +73,7 @@ contains
         call fig%set_xlabel('Computed Value')
         call fig%set_ylabel('Frequency')
         call fig%legend()
-        call fig%savefig("test/output/scientific_simulation.png")
+        call fig%savefig("build/test/output/scientific_simulation.png")
         write(*,*) '  PASS: Simulation result analysis complete'
         
     end subroutine test_simulation_results
@@ -100,7 +103,7 @@ contains
         call fig%set_xlabel('Response Variable')
         call fig%set_ylabel('Probability Density')
         call fig%legend()
-        call fig%savefig("test/output/scientific_comparison.png")
+        call fig%savefig("build/test/output/scientific_comparison.png")
         write(*,*) '  PASS: Comparative analysis complete'
         
     end subroutine test_comparative_analysis
@@ -127,8 +130,8 @@ contains
         call fig%set_xlabel('Parameter X (units)')
         call fig%set_ylabel('Probability Density (1/units)')
         call fig%legend()
-        call fig%savefig("test/output/scientific_publication.png")
-        call fig%savefig("test/output/scientific_publication.pdf")
+        call fig%savefig("build/test/output/scientific_publication.png")
+        call fig%savefig("build/test/output/scientific_publication.pdf")
         write(*,*) '  PASS: Publication-quality output complete'
         
     end subroutine test_publication_quality

--- a/test/test_set_aspect_rendering.f90
+++ b/test/test_set_aspect_rendering.f90
@@ -1,5 +1,6 @@
 program test_set_aspect_rendering
     use fortplot_figure, only: figure_t
+    use fortplot_system_runtime, only: create_directory_runtime
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -7,7 +8,9 @@ program test_set_aspect_rendering
     real(wp), allocatable :: theta(:), x(:), y(:)
     type(figure_t) :: fig
     integer :: i, n, status
+    logical :: dir_ok
 
+    call create_directory_runtime('build/test/output', dir_ok)
     n = 100
     allocate(theta(n), x(n), y(n))
     do i = 1, n
@@ -22,7 +25,7 @@ program test_set_aspect_rendering
     call fig%set_xlabel('X')
     call fig%set_ylabel('Y')
     call fig%set_aspect('equal')
-    call fig%savefig_with_status('test/output/test_aspect_equal.png', status)
+    call fig%savefig_with_status('build/test/output/test_aspect_equal.png', status)
 
     if (status /= 0) then
         print *, "FAIL: Could not save equal aspect PNG"
@@ -35,7 +38,7 @@ program test_set_aspect_rendering
     call fig%set_xlabel('X')
     call fig%set_ylabel('Y')
     call fig%set_aspect('auto')
-    call fig%savefig_with_status('test/output/test_aspect_auto.png', status)
+    call fig%savefig_with_status('build/test/output/test_aspect_auto.png', status)
 
     if (status /= 0) then
         print *, "FAIL: Could not save auto aspect PNG"
@@ -48,7 +51,7 @@ program test_set_aspect_rendering
     call fig%set_xlabel('X')
     call fig%set_ylabel('Y')
     call fig%set_aspect(2.0_wp)
-    call fig%savefig_with_status('test/output/test_aspect_numeric.png', status)
+    call fig%savefig_with_status('build/test/output/test_aspect_numeric.png', status)
 
     if (status /= 0) then
         print *, "FAIL: Could not save numeric aspect PNG"
@@ -56,6 +59,6 @@ program test_set_aspect_rendering
     end if
 
     print *, "All set_aspect rendering tests passed!"
-    print *, "Visual outputs saved to test/output/test_aspect_*.png"
+    print *, "Visual outputs saved to build/test/output/test_aspect_*.png"
 
 end program test_set_aspect_rendering

--- a/test/test_silent_output.f90
+++ b/test/test_silent_output.f90
@@ -1,27 +1,31 @@
 program test_silent_output
     !! Test program to verify silent output works in production
     !! Should demonstrate zero output when set to silent level
-    
+
     use fortplot, only: figure, plot, savefig, set_log_level, LOG_LEVEL_SILENT
-    
+    use fortplot_system_runtime, only: create_directory_runtime
+
     implicit none
     real(8) :: x(10), y(10)
     integer :: i
-    
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
     ! Set to silent mode - no console output should occur
     call set_log_level(LOG_LEVEL_SILENT)
-    
+
     ! Generate test data
     do i = 1, 10
         x(i) = real(i-1, 8)
         y(i) = sin(x(i))
     end do
-    
+
     ! Create plot - should produce no console output
     call figure(figsize=[4.0d0, 3.0d0])
     call plot(x, y)
-    call savefig('test/output/silent_test.png')
-    
+    call savefig('build/test/output/silent_test.png')
+
     ! This print should still work (it's not going through logging)
     print *, "Silent test completed - output saved"
 

--- a/test/test_stacked_bar_charts.f90
+++ b/test/test_stacked_bar_charts.f90
@@ -10,12 +10,15 @@ program test_stacked_bar_charts
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot
     use fortplot_plotting_advanced, only: bar_impl, barh_impl
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
     integer :: test_count = 0
     integer :: pass_count = 0
     integer :: fail_count = 0
+    logical :: dir_ok
 
+    call create_directory_runtime('build/test/output', dir_ok)
     print *, "=== STACKED BAR CHART TESTS (Issue #1460) ==="
 
     call test_stacked_vertical_bars()
@@ -53,8 +56,8 @@ contains
         call fig%set_xlabel('Categories')
         call fig%set_ylabel('Values')
 
-        call fig%savefig('test/output/stacked_vertical_bars.png')
-        print *, '  Output: test/output/stacked_vertical_bars.png'
+        call fig%savefig('build/test/output/stacked_vertical_bars.png')
+        print *, '  Output: build/test/output/stacked_vertical_bars.png'
 
         call end_test()
     end subroutine test_stacked_vertical_bars
@@ -84,8 +87,8 @@ contains
         call fig%set_xlabel('Values')
         call fig%set_ylabel('Categories')
 
-        call fig%savefig('test/output/stacked_horizontal_bars.png')
-        print *, '  Output: test/output/stacked_horizontal_bars.png'
+        call fig%savefig('build/test/output/stacked_horizontal_bars.png')
+        print *, '  Output: build/test/output/stacked_horizontal_bars.png'
 
         call end_test()
     end subroutine test_stacked_horizontal_bars
@@ -134,8 +137,8 @@ contains
         call xlabel('Categories')
         call ylabel('Values')
 
-        call savefig('test/output/stacked_bars_stateful.png')
-        print *, '  Output: test/output/stacked_bars_stateful.png'
+        call savefig('build/test/output/stacked_bars_stateful.png')
+        print *, '  Output: build/test/output/stacked_bars_stateful.png'
 
         call end_test()
     end subroutine test_stacked_bar_stateful

--- a/test/test_svg_savefig.f90
+++ b/test/test_svg_savefig.f90
@@ -1,0 +1,84 @@
+program test_svg_savefig
+    !! End-to-end test for SVG backend via the high-level savefig("x.svg") path.
+    !! Exercises the full pipeline: stateful API -> get_backend_from_filename ->
+    !! rendering pipeline -> SVG backend adapter.
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    character(len=*), parameter :: outfile = 'build/test/output/test_svg_savefig.svg'
+    logical :: file_exists, dir_ok
+    integer :: file_size, unit, ios
+    character(len=1024) :: line
+    logical :: has_svg_open, has_svg_close, has_path_or_line
+    real(wp) :: x(10), y(10)
+    integer :: i
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    do i = 1, 10
+        x(i) = real(i, wp)
+        y(i) = real(i, wp) ** 2
+    end do
+
+    call figure()
+    call plot(x, y, label='x^2')
+    call title('SVG savefig smoke test')
+    call xlabel('x')
+    call ylabel('y')
+    call savefig(outfile)
+
+    ! Assert file was created
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, 'FAIL: SVG file not created: ', outfile
+        stop 1
+    end if
+    if (file_size <= 0) then
+        print *, 'FAIL: SVG file is empty'
+        stop 1
+    end if
+    print *, 'PASS: SVG file created (', file_size, ' bytes)'
+
+    ! Assert well-formed SVG content
+    has_svg_open = .false.
+    has_svg_close = .false.
+    has_path_or_line = .false.
+
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open SVG file for reading'
+        stop 1
+    end if
+    do while (ios == 0)
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        if (index(line, '<svg') > 0) has_svg_open = .true.
+        if (index(line, '</svg>') > 0) has_svg_close = .true.
+        if (index(line, '<path') > 0 .or. index(line, '<line') > 0) &
+            has_path_or_line = .true.
+    end do
+    close(unit)
+
+    if (.not. has_svg_open) then
+        print *, 'FAIL: <svg opening tag not found'
+        stop 1
+    end if
+    print *, 'PASS: <svg opening tag present'
+
+    if (.not. has_svg_close) then
+        print *, 'FAIL: </svg> closing tag not found'
+        stop 1
+    end if
+    print *, 'PASS: </svg> closing tag present'
+
+    if (.not. has_path_or_line) then
+        print *, 'FAIL: no <path or <line element found (no plot data rendered)'
+        stop 1
+    end if
+    print *, 'PASS: plot data element (<path or <line) present'
+
+    print *, 'All SVG savefig end-to-end tests PASSED'
+
+end program test_svg_savefig

--- a/test/test_tick_vs_axis_labels.f90
+++ b/test/test_tick_vs_axis_labels.f90
@@ -1,72 +1,82 @@
 program test_tick_vs_axis_labels
-    !! TDD test: Define correct positioning for tick labels vs axis labels
-    !! Based on matplotlib analysis: plot at x=80-576, y=58-427
+    !! Test that calculate_plot_area produces sane plot area geometry for
+    !! a standard 640x480 canvas with default matplotlib margins.
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
-    
+
     type(plot_margins_t) :: margins
     type(plot_area_t) :: plot_area
     integer, parameter :: CANVAS_WIDTH = 640
     integer, parameter :: CANVAS_HEIGHT = 480
-    
-    ! Expected positioning based on matplotlib analysis
-    integer, parameter :: EXPECTED_Y_TICK_SPACING = 19  ! Y-tick labels 19px from plot left
-    integer, parameter :: EXPECTED_Y_AXIS_SPACING = 98  ! Y-axis label 98px from plot left
-    integer, parameter :: EXPECTED_X_TICK_SPACING = 15  ! X-tick labels ~15px below plot
-    integer, parameter :: EXPECTED_X_AXIS_SPACING = 50  ! X-axis label ~50px below plot
-    
+    logical :: passed
+
+    passed = .true.
     margins = plot_margins_t()
     call calculate_plot_area(CANVAS_WIDTH, CANVAS_HEIGHT, margins, plot_area)
-    
+
     print *, "=== Tick vs Axis Label Positioning Test ==="
-    print *, "Plot area: x=", plot_area%left, "-", plot_area%left + plot_area%width, &
-             " y=", plot_area%bottom, "-", plot_area%bottom + plot_area%height
-    print *, ""
-    
-    ! Test X-axis positioning
-    print *, "X-AXIS POSITIONING:"
-    print *, "Plot bottom edge:", plot_area%bottom + plot_area%height
-    
-    print *, "X-tick labels should be at Y =", plot_area%bottom + plot_area%height + EXPECTED_X_TICK_SPACING
-    print *, "  (", EXPECTED_X_TICK_SPACING, "pixels below plot bottom)"
-    
-    print *, "X-axis label should be at Y =", plot_area%bottom + plot_area%height + EXPECTED_X_AXIS_SPACING  
-    print *, "  (", EXPECTED_X_AXIS_SPACING, "pixels below plot bottom)"
-    print *, "  Gap between tick labels and axis label:", EXPECTED_X_AXIS_SPACING - EXPECTED_X_TICK_SPACING, "pixels"
-    print *, ""
-    
-    ! Test Y-axis positioning  
-    print *, "Y-AXIS POSITIONING:"
-    print *, "Plot left edge:", plot_area%left
-    
-    print *, "Y-tick labels should end at X =", plot_area%left - EXPECTED_Y_TICK_SPACING
-    print *, "  (", EXPECTED_Y_TICK_SPACING, "pixels left of plot)"
-    
-    print *, "Y-axis label should end at X =", plot_area%left - EXPECTED_Y_AXIS_SPACING
-    print *, "  (", EXPECTED_Y_AXIS_SPACING, "pixels left of plot)"  
-    print *, "  Gap between tick labels and axis label:", EXPECTED_Y_AXIS_SPACING - EXPECTED_Y_TICK_SPACING, "pixels"
-    print *, ""
-    
-    ! Text anchor considerations
-    print *, "TEXT ANCHOR CONSIDERATIONS:"
-    print *, "PNG render_text_to_image(x,y,text):"
-    print *, "  - (x,y) is likely top-left corner of text"
-    print *, "  - For centered text: x = center_pos - text_width/2"
-    print *, "  - For right-aligned text: x = right_pos - text_width"
-    print *, ""
-    
-    print *, "PDF text positioning:"
-    print *, "  - (x,y) is text baseline, left edge"
-    print *, "  - For centered text: x = center_pos - text_width/2" 
-    print *, "  - For right-aligned text: x = right_pos - text_width"
-    print *, ""
-    
-    print *, "FAILING TESTS (to be fixed):"
-    print *, "1. Separate tick label positioning from axis label positioning"
-    print *, "2. Fix Y-tick label right-alignment to end exactly at plot_left - 19px"
-    print *, "3. Fix X-tick label center-alignment below plot"
-    print *, "4. Fix Y-axis label positioning to be 98px left of plot"
-    print *, "5. Fix X-axis label positioning to be 50px below plot"
-    
+    print *, "Plot area: left=", plot_area%left, " bottom=", plot_area%bottom, &
+             " width=", plot_area%width, " height=", plot_area%height
+
+    ! Plot left edge must be > 0 (room for y-tick and y-axis labels)
+    if (plot_area%left <= 0) then
+        print *, "FAIL: plot_area%left must be > 0, got", plot_area%left
+        passed = .false.
+    else
+        print *, "PASS: plot_area%left =", plot_area%left, " > 0"
+    end if
+
+    ! Plot bottom edge must be > 0 (room for x-tick and x-axis labels)
+    if (plot_area%bottom <= 0) then
+        print *, "FAIL: plot_area%bottom must be > 0, got", plot_area%bottom
+        passed = .false.
+    else
+        print *, "PASS: plot_area%bottom =", plot_area%bottom, " > 0"
+    end if
+
+    ! Width must be positive and fit within canvas
+    if (plot_area%width <= 0) then
+        print *, "FAIL: plot_area%width must be > 0, got", plot_area%width
+        passed = .false.
+    else if (plot_area%left + plot_area%width > CANVAS_WIDTH) then
+        print *, "FAIL: plot right edge exceeds canvas width"
+        passed = .false.
+    else
+        print *, "PASS: plot_area%width =", plot_area%width
+    end if
+
+    ! Height must be positive and fit within canvas
+    if (plot_area%height <= 0) then
+        print *, "FAIL: plot_area%height must be > 0, got", plot_area%height
+        passed = .false.
+    else if (plot_area%bottom + plot_area%height > CANVAS_HEIGHT) then
+        print *, "FAIL: plot bottom edge + height exceeds canvas height"
+        passed = .false.
+    else
+        print *, "PASS: plot_area%height =", plot_area%height
+    end if
+
+    ! Left margin must leave at least 40px for tick+axis labels (realistic minimum)
+    if (plot_area%left < 40) then
+        print *, "FAIL: left margin too narrow for tick+axis labels, got", plot_area%left
+        passed = .false.
+    else
+        print *, "PASS: left margin", plot_area%left, ">= 40px (room for tick+axis labels)"
+    end if
+
+    ! Bottom margin must leave at least 30px for tick+axis labels
+    if (plot_area%bottom < 30) then
+        print *, "FAIL: bottom margin too narrow for tick+axis labels, got", plot_area%bottom
+        passed = .false.
+    else
+        print *, "PASS: bottom margin", plot_area%bottom, ">= 30px (room for tick+axis labels)"
+    end if
+
+    if (.not. passed) then
+        error stop "test_tick_vs_axis_labels: one or more assertions failed"
+    end if
+
+    print *, "All tick vs axis label positioning assertions passed."
+
 end program test_tick_vs_axis_labels

--- a/test/test_tight_layout.f90
+++ b/test/test_tight_layout.f90
@@ -3,10 +3,13 @@ program test_tight_layout
     use fortplot, only: figure_t
     use fortplot_matplotlib, only: figure, subplots, subplot, plot, title, xlabel, &
                                    ylabel, suptitle, tight_layout, savefig
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
-    logical :: all_passed
+    logical :: all_passed, dir_ok
     all_passed = .true.
+
+    call create_directory_runtime('build/test/output', dir_ok)
 
     print *, 'Running tight_layout tests...'
 
@@ -90,6 +93,10 @@ contains
     subroutine test_tight_layout_stateful_basic(passed)
         logical, intent(inout) :: passed
         real(wp), dimension(5) :: x, y
+        character(len=*), parameter :: outfile = &
+            'build/test/output/test_tight_layout_stateful.png'
+        logical :: file_exists
+        integer :: file_size
 
         print *, 'Testing: tight_layout stateful interface'
 
@@ -102,15 +109,28 @@ contains
         call xlabel('X')
         call ylabel('Y')
         call tight_layout()
-        call savefig('/tmp/test_tight_layout_stateful.png')
+        call savefig(outfile)
 
-        print *, '  PASS: stateful tight_layout executed without error'
+        inquire(file=outfile, exist=file_exists, size=file_size)
+        if (.not. file_exists) then
+            print *, '  FAIL: savefig did not create ', outfile
+            passed = .false.
+        else if (file_size <= 0) then
+            print *, '  FAIL: savefig wrote empty file'
+            passed = .false.
+        else
+            print *, '  PASS: stateful tight_layout output written (', file_size, ' bytes)'
+        end if
     end subroutine test_tight_layout_stateful_basic
 
     subroutine test_tight_layout_with_subplots(passed)
         logical, intent(inout) :: passed
         type(figure_t) :: fig
         real(wp), dimension(5) :: x, y1, y2, y3, y4
+        character(len=*), parameter :: outfile = &
+            'build/test/output/test_tight_layout_subplots.png'
+        logical :: file_exists
+        integer :: file_size
 
         print *, 'Testing: tight_layout with subplots'
 
@@ -153,8 +173,17 @@ contains
             passed = .false.
         end if
 
-        call fig%savefig('/tmp/test_tight_layout_subplots.png')
-        print *, '  PASS: saved subplot figure with tight_layout'
+        call fig%savefig(outfile)
+        inquire(file=outfile, exist=file_exists, size=file_size)
+        if (.not. file_exists) then
+            print *, '  FAIL: savefig did not create ', outfile
+            passed = .false.
+        else if (file_size <= 0) then
+            print *, '  FAIL: savefig wrote empty file'
+            passed = .false.
+        else
+            print *, '  PASS: subplot tight_layout output written (', file_size, ' bytes)'
+        end if
     end subroutine test_tight_layout_with_subplots
 
 end program test_tight_layout


### PR DESCRIPTION
## Summary
Adds real assertions to previously tautological tests, relocates outputs under build/test/output, registers the ASCII animation test that existed but was never run, and adds end-to-end SVG + stateless-API smoke tests. Addresses #1672, #1674, #1675, #1679, #1682, #1685, #1690, #1692, #1699, #1707, #1712, #1715.

## Verification
\`\`\`
make build            # passes
make test-ci          # passes
\`\`\`

## Risk / Compatibility
Test-only changes plus Makefile/fpm.toml test registration.