### PR TITLE
fix: add descriptive message to error stop in build_extended_steps (#1743)

### DIFF
--- a/src/utilities/ticks/fortplot_contour_level_calculation.f90
+++ b/src/utilities/ticks/fortplot_contour_level_calculation.f90
@@ -104,7 +104,7 @@ contains
 
         n = size(steps)
         if (size(extended) /= 2*n) then
-            error stop
+            error stop 'build_extended_steps: extended array must have size 2*size(steps)'
         end if
 
         do i = 1, n - 1


### PR DESCRIPTION
## Summary

- Fixes #1743: bare `error stop` in `build_extended_steps` provided no diagnostic context when contract was violated
- Replaces bare `error stop` with `error stop 'build_extended_steps: extended array must have size 2*size(steps)'`
- Maintains abort behavior for unrecoverable contract violations while improving developer diagnostics

## Verification

### Build
```
$ make build
[... compiled successfully ...]
```

### Tests
Full test suite executed with all relevant tests passing.