### PR TITLE
fix: add 5% margin to bar chart axis ranges to prevent boundary clipping (fixes #1748, fixes #1696)

### DIFF
--- a/src/figures/fortplot_figure_data_ranges.f90
+++ b/src/figures/fortplot_figure_data_ranges.f90
@@ -439,12 +439,14 @@ contains
 
         integer :: n, i
         real(wp), parameter :: DEFAULT_BAR_WIDTH = 0.8_wp
+        real(wp), parameter :: BAR_MARGIN = 0.05_wp
         real(wp) :: half_width, effective_width
         real(wp) :: x_min_bar, x_max_bar
         real(wp) :: y_min_bar, y_max_bar
         real(wp) :: left_edge, right_edge
         real(wp) :: lower_edge, upper_edge
         real(wp) :: base_val, top_val
+        real(wp) :: range_x, range_y
 
         if (.not. allocated(plot%bar_x)) return
         if (.not. allocated(plot%bar_heights)) return
@@ -489,6 +491,18 @@ contains
             y_min_bar = min(y_min_bar, lower_edge)
             y_max_bar = max(y_max_bar, upper_edge)
         end do
+
+        ! Apply margin to bar ranges so bars are not clipped at axis boundaries
+        range_x = x_max_bar - x_min_bar
+        range_y = y_max_bar - y_min_bar
+        if (range_x > 0.0_wp) then
+            x_min_bar = x_min_bar - BAR_MARGIN * range_x
+            x_max_bar = x_max_bar + BAR_MARGIN * range_x
+        end if
+        if (range_y > 0.0_wp) then
+            y_min_bar = y_min_bar - BAR_MARGIN * range_y
+            y_max_bar = y_max_bar + BAR_MARGIN * range_y
+        end if
 
         if (first_plot) then
             x_min_data = x_min_bar

--- a/test/test_stacked_bar_charts.f90
+++ b/test/test_stacked_bar_charts.f90
@@ -24,6 +24,7 @@ program test_stacked_bar_charts
     call test_stacked_vertical_bars()
     call test_stacked_horizontal_bars()
     call test_stacked_bar_ranges()
+    call test_bar_chart_margin()
     call test_stacked_bar_stateful()
     call print_test_summary()
 
@@ -113,6 +114,43 @@ contains
 
         call end_test()
     end subroutine test_stacked_bar_ranges
+
+    subroutine test_bar_chart_margin()
+        !! Verify bar chart axis ranges include margin so bars are not clipped (Issues #1748, #1696)
+        type(figure_t) :: fig
+        real(wp) :: x(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        real(wp) :: heights(4) = [4.5_wp, 5.8_wp, 6.1_wp, 6.7_wp]
+
+        call start_test("Bar chart y-axis margin prevents clipping")
+
+        call fig%initialize(640, 480)
+
+        call bar_impl(fig, x, heights)
+
+        ! Y-max should exceed the tallest bar (6.7) with margin
+        ! Exact max bar top = 6.7, margin = 5% of range (0 to 6.7) = 0.335
+        ! So y_max should be >= 6.7 + 0.335 = 7.035
+        call assert_true(fig%state%y_max >= 7.0_wp, &
+                         "Y-max exceeds tallest bar height with margin")
+
+        call end_test()
+
+        call start_test("Bar chart x-axis margin prevents rightmost bar clipping")
+
+        call fig%initialize(640, 480)
+
+        ! Bar centers at 1.0, 2.0, 3.0 with width 0.8
+        ! Rightmost bar right edge = 3.0 + 0.4 = 3.4
+        ! Leftmost bar left edge = 1.0 - 0.4 = 0.6
+        ! Range = 2.8, margin = 5% * 2.8 = 0.14
+        ! x_max should be >= 3.4 + 0.14 = 3.54
+        call bar_impl(fig, [1.0_wp, 2.0_wp, 3.0_wp], [5.0_wp, 8.0_wp, 6.0_wp], width=0.8_wp)
+
+        call assert_true(fig%state%x_max >= 3.5_wp, &
+                         "X-max extends past rightmost bar edge with margin")
+
+        call end_test()
+    end subroutine test_bar_chart_margin
 
     subroutine test_stacked_bar_stateful()
         real(wp) :: x(3) = [1.0_wp, 2.0_wp, 3.0_wp]


### PR DESCRIPTION
## Summary

- Bar chart axis ranges were computed as exact min/max of bar edges with no margin/padding
- This caused tallest bars to be clipped at the y-axis top boundary (Issue #1748)
- This caused rightmost bars to be clipped at the x-axis right boundary (Issue #1696)
- Fix: Add 5% percentage-based margin on each side of bar chart axis ranges

## Changes

- `src/figures/fortplot_figure_data_ranges.f90`: Added `BAR_MARGIN = 0.05_wp` constant and margin application logic in `process_bar_plot_ranges`
- `test/test_stacked_bar_charts.f90`: Added `test_bar_chart_margin` with two assertions verifying y-axis and x-axis margins

## Verification

### Test passes
```
$ fpm test --target test_stacked_bar_charts
Test 4: Bar chart y-axis margin prevents clipping
  PASS: Y-max exceeds tallest bar height with margin
Test 5: Bar chart x-axis margin prevents rightmost bar clipping
  PASS: X-max extends past rightmost bar edge with margin
ALL TESTS PASSED!
```

### Full CI test suite
```
$ make test-ci
CI essential test suite completed successfully
EXIT_CODE=0
```

### Artifact verification
```
$ make verify-artifacts
Artifact verification passed.
```