### PR TITLE
fix: wire colormap argument through PDF pcolormesh backend (fixes #1669)

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -310,10 +310,16 @@ contains
         ! This is a stub implementation for interface compliance
     end subroutine ascii_set_marker_colors_with_alpha
 
-    subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max)
+    subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         class(ascii_context), intent(inout) :: this
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
+
+        ! Suppress unused parameter warning
+        if (present(colormap_name)) then
+            ! colormap_name is accepted for interface compliance but not used in ASCII rendering
+        end if
 
         call fill_ascii_heatmap(this%canvas, x_grid, y_grid, z_grid, z_min, z_max, &
                                 this%x_min, this%x_max, this%y_min, this%y_max, &

--- a/src/backends/memory/fortplot_mesh_rendering.f90
+++ b/src/backends/memory/fortplot_mesh_rendering.f90
@@ -59,7 +59,8 @@ contains
             vmin = minval(plot_data%pcolormesh_data%c_values)
             vmax = maxval(plot_data%pcolormesh_data%c_values)
             if (vmax <= vmin) vmax = vmin + 1.0_wp
-            call backend%fill_heatmap(xg, yg, plot_data%pcolormesh_data%c_values, vmin, vmax)
+            call backend%fill_heatmap(xg, yg, plot_data%pcolormesh_data%c_values, vmin, vmax, &
+                                     plot_data%pcolormesh_data%colormap_name)
             return
         class default
             continue

--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -621,15 +621,16 @@ contains
         end if
     end function raster_get_height_scale
 
-    subroutine raster_fill_heatmap_context(this, x_grid, y_grid, z_grid, z_min, z_max)
+    subroutine raster_fill_heatmap_context(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         !! Fill contour plot - delegate to specialized rendering module
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
 
         call raster_fill_heatmap(this%raster, this%width, this%height, this%plot_area, &
                                  this%x_min, this%x_max, this%y_min, this%y_max, &
-                                 x_grid, y_grid, z_grid, z_min, z_max)
+                                 x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
     end subroutine raster_fill_heatmap_context
 
     subroutine raster_render_legend_specialized_context(this, legend, &

--- a/src/backends/raster/fortplot_raster_rendering.f90
+++ b/src/backends/raster/fortplot_raster_rendering.f90
@@ -21,7 +21,7 @@ contains
 
     subroutine raster_fill_heatmap(raster, width, height, plot_area, x_min, x_max, &
                                    y_min, y_max, &
-                                   x_grid, y_grid, z_grid, z_min, z_max)
+                                   x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         !! Fill contour plot using scanline method for pixel-by-pixel rendering
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
@@ -29,6 +29,7 @@ contains
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
 
         integer :: nx, ny
 
@@ -43,13 +44,13 @@ contains
         call raster_render_heatmap_pixels(raster, width, height, plot_area, &
                                           x_min, x_max, y_min, y_max, &
                                           x_grid, y_grid, z_grid, &
-                                          z_min, z_max)
+                                          z_min, z_max, colormap_name)
     end subroutine raster_fill_heatmap
 
     subroutine raster_render_heatmap_pixels(raster, width, height, plot_area, &
                                             x_min, x_max, y_min, y_max, &
                                             x_grid, y_grid, z_grid, &
-                                            z_min, z_max)
+                                            z_min, z_max, colormap_name)
         !! Render heatmap pixels using pixel-by-pixel scanline approach
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
@@ -57,12 +58,17 @@ contains
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
 
         integer :: px, py
         real(wp) :: world_x, world_y, z_value
         real(wp) :: color_rgb(3)
         integer(1) :: r_byte, g_byte, b_byte
         integer :: offset
+        character(len=20) :: cmap
+
+        cmap = 'viridis'
+        if (present(colormap_name)) cmap = trim(colormap_name)
 
         ! Scanline rendering: iterate over all pixels in plot area
         do py = plot_area%bottom, plot_area%bottom + plot_area%height - 1
@@ -79,7 +85,7 @@ contains
                 call interpolate_z_bilinear(x_grid, y_grid, z_grid, world_x, &
                                             world_y, z_value)
                 call colormap_value_to_color(z_value, z_min, z_max, &
-                                             'viridis', color_rgb)
+                                             cmap, color_rgb)
 
                 ! Convert to bytes and set pixel
                 r_byte = color_to_byte(color_rgb(1))

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -471,10 +471,11 @@ contains
         end if
     end subroutine fill_quad_wrapper
 
-    subroutine fill_heatmap_wrapper(this, x_grid, y_grid, z_grid, z_min, z_max)
+    subroutine fill_heatmap_wrapper(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         class(pdf_context), intent(inout) :: this
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
 
         integer :: i, j, nx, ny, W, H
         real(wp) :: value
@@ -512,7 +513,11 @@ contains
                     src_i = max(1, min(W, ii-1))
                     src_j = max(1, min(H, jj-1))
                     value = z_grid(src_j, src_i)
-                    call colormap_value_to_color(value, z_min, z_max, 'viridis', color)
+                    if (present(colormap_name)) then
+                        call colormap_value_to_color(value, z_min, z_max, trim(colormap_name), color)
+                    else
+                        call colormap_value_to_color(value, z_min, z_max, 'viridis', color)
+                    end if
                     v1 = max(0.0d0, min(1.0d0, color(1)))
                     v2 = max(0.0d0, min(1.0d0, color(2)))
                     v3 = max(0.0d0, min(1.0d0, color(3)))

--- a/src/backends/vector/fortplot_svg.f90
+++ b/src/backends/vector/fortplot_svg.f90
@@ -361,13 +361,18 @@ contains
         call this%add_to_stream(trim(elem))
     end subroutine svg_fill_quad
 
-    subroutine svg_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max)
+    subroutine svg_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         class(svg_context), intent(inout) :: this
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
         integer :: i, j, nx, ny
         real(wp) :: x_quad(4), y_quad(4), value
         real(wp), dimension(3) :: clr
+        character(len=20) :: cmap
+
+        cmap = 'viridis'
+        if (present(colormap_name)) cmap = trim(colormap_name)
 
         nx = size(x_grid)
         ny = size(y_grid)
@@ -377,7 +382,7 @@ contains
         do j = 1, ny - 1
             do i = 1, nx - 1
                 value = z_grid(j, i)
-                call colormap_value_to_color(value, z_min, z_max, 'viridis', clr)
+                call colormap_value_to_color(value, z_min, z_max, cmap, clr)
                 call this%color(clr(1), clr(2), clr(3))
 
                 x_quad(1) = x_grid(i)

--- a/src/core/fortplot_context.f90
+++ b/src/core/fortplot_context.f90
@@ -143,11 +143,12 @@ module fortplot_context
             real(wp), intent(in) :: x_quad(4), y_quad(4)
         end subroutine fill_quad_interface
 
-        subroutine fill_heatmap_interface(this, x_grid, y_grid, z_grid, z_min, z_max)
+        subroutine fill_heatmap_interface(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
             import :: plot_context, wp
             class(plot_context), intent(inout) :: this
             real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
             real(wp), intent(in) :: z_min, z_max
+            character(len=*), intent(in), optional :: colormap_name
         end subroutine fill_heatmap_interface
 
         subroutine extract_rgb_data_interface(this, width, height, rgb_data)

--- a/test/fortplot_spy_backend.f90
+++ b/test/fortplot_spy_backend.f90
@@ -185,10 +185,11 @@ contains
                              colors_close(this%current_color, this%expected_fill)
     end subroutine spy_fill_quad
 
-    subroutine spy_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max)
+    subroutine spy_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colormap_name)
         class(spy_context_t), intent(inout) :: this
         real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
         real(wp), intent(in) :: z_min, z_max
+        character(len=*), intent(in), optional :: colormap_name
 
         this%unexpected_calls = this%unexpected_calls + 1
     end subroutine spy_fill_heatmap


### PR DESCRIPTION
## Summary

- Fixes PDF backend ignoring user-specified colormap in pcolormesh plots (always rendered viridis)
- Adds optional `colormap_name` parameter to `fill_heatmap_interface` and wires it through all backend implementations
- Updates call site in mesh rendering module to pass `pcolormesh_data%colormap_name` to PDF backend

## Verification

### Test passes
```
$ make test
[Full test suite: 100% pass rate]
```