### PR TITLE
fix: ASCII backend: Unicode characters rendered as literal U+XXXX escape sequences (fixes #1695)

### DIFF
--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -58,7 +58,7 @@ contains
                 if (current_len > 0) then
                     start_idx = current_len
                     do while (start_idx > 1)
-                        byte = ichar(current_text(start_idx:start_idx))
+                        byte = iachar(current_text(start_idx:start_idx))
                         if (iand(byte, 192) /= 128) exit
                         start_idx = start_idx - 1
                     end do
@@ -85,7 +85,7 @@ contains
                 if (current_len > 0) then
                     start_idx = current_len
                     do while (start_idx > 1)
-                        byte = ichar(current_text(start_idx:start_idx))
+                        byte = iachar(current_text(start_idx:start_idx))
                         if (iand(byte, 192) /= 128) exit
                         start_idx = start_idx - 1
                     end do

--- a/src/utilities/text/fortplot_unicode.f90
+++ b/src/utilities/text/fortplot_unicode.f90
@@ -326,7 +326,7 @@ contains
         character(len=1), intent(in) :: char
         integer :: byte_val
         
-        byte_val = ichar(char)
+        byte_val = iachar(char)
         
         if (byte_val < 128) then
             ! ASCII (0xxxxxxx)
@@ -362,32 +362,32 @@ contains
         
         if (char_len == 1) then
             ! ASCII
-            utf8_to_codepoint = ichar(text(start_pos:start_pos))
+            utf8_to_codepoint = iachar(text(start_pos:start_pos))
         else if (char_len == 2) then
             ! 2-byte sequence
-            byte_val = ichar(text(start_pos:start_pos))
+            byte_val = iachar(text(start_pos:start_pos))
             codepoint = iand(byte_val, int(z'1F')) * 64
-            byte_val = ichar(text(start_pos+1:start_pos+1))
+            byte_val = iachar(text(start_pos+1:start_pos+1))
             codepoint = codepoint + iand(byte_val, int(z'3F'))
             utf8_to_codepoint = codepoint
         else if (char_len == 3) then
             ! 3-byte sequence
-            byte_val = ichar(text(start_pos:start_pos))
+            byte_val = iachar(text(start_pos:start_pos))
             codepoint = iand(byte_val, int(z'0F')) * 4096
-            byte_val = ichar(text(start_pos+1:start_pos+1))
+            byte_val = iachar(text(start_pos+1:start_pos+1))
             codepoint = codepoint + iand(byte_val, int(z'3F')) * 64
-            byte_val = ichar(text(start_pos+2:start_pos+2))
+            byte_val = iachar(text(start_pos+2:start_pos+2))
             codepoint = codepoint + iand(byte_val, int(z'3F'))
             utf8_to_codepoint = codepoint
         else if (char_len == 4) then
             ! 4-byte sequence
-            byte_val = ichar(text(start_pos:start_pos))
+            byte_val = iachar(text(start_pos:start_pos))
             codepoint = iand(byte_val, int(z'07')) * 262144
-            byte_val = ichar(text(start_pos+1:start_pos+1))
+            byte_val = iachar(text(start_pos+1:start_pos+1))
             codepoint = codepoint + iand(byte_val, int(z'3F')) * 4096
-            byte_val = ichar(text(start_pos+2:start_pos+2))
+            byte_val = iachar(text(start_pos+2:start_pos+2))
             codepoint = codepoint + iand(byte_val, int(z'3F')) * 64
-            byte_val = ichar(text(start_pos+3:start_pos+3))
+            byte_val = iachar(text(start_pos+3:start_pos+3))
             codepoint = codepoint + iand(byte_val, int(z'3F'))
             utf8_to_codepoint = codepoint
         else
@@ -447,7 +447,7 @@ contains
         
         ! Check continuation bytes
         do i = 1, seq_len - 1
-            byte_val = ichar(text(start_pos + i:start_pos + i))
+            byte_val = iachar(text(start_pos + i:start_pos + i))
             if (iand(byte_val, int(z'C0')) /= int(z'80')) then
                 return  ! Invalid continuation byte
             end if

--- a/test/test_unicode.f90
+++ b/test/test_unicode.f90
@@ -2,10 +2,10 @@ program test_unicode
     !! Comprehensive test suite for Unicode handling
     !! Consolidates: test_unicode_corruption_853, test_unicode_detection,
     !! test_unicode_issue_1138, test_unicode_superscript
-    use fortplot_unicode, only: unicode_codepoint_to_ascii, is_unicode_char, &
-                                check_utf8_sequence, utf8_char_length, &
-                                    utf8_to_codepoint, &
-                                is_greek_letter_codepoint, contains_unicode
+  use fortplot_unicode, only: unicode_codepoint_to_ascii, is_unicode_char, &
+                                 check_utf8_sequence, utf8_char_length, &
+                                     utf8_to_codepoint, escape_unicode_for_ascii, &
+                                 is_greek_letter_codepoint, contains_unicode
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot, only: figure, plot, title, xlabel, ylabel, savefig, &
                         add_plot, legend
@@ -30,6 +30,7 @@ program test_unicode
     call test_latex_uppercase_psi()
     call test_ascii_backend_handling()
     call test_superscript_rendering()
+    call test_no_u_escape_sequences()
 
     print *, ''
     print *, '=== Unicode Test Summary ==='
@@ -418,5 +419,94 @@ contains
         print *, '  PASS: test_superscript_rendering'
         passed_tests = passed_tests + 1
     end subroutine test_superscript_rendering
+
+    subroutine test_no_u_escape_sequences()
+        !! Regression test for issue #1695: Unicode chars must not render
+        !! as literal U+XXXX escape sequences in ASCII output.
+        character(len=200) :: input, output
+        character(len=:), allocatable :: output_dir
+        integer :: i, ios
+
+        total_tests = total_tests + 1
+
+        ! Test superscript 2 (U+00B2) - UTF-8: C2 B2
+        input = 'E = mc'//achar(194)//achar(178)
+        call escape_unicode_for_ascii(input, output)
+        if (index(output, 'U+') > 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - superscript 2'
+            return
+        end if
+        if (index(output, 'mc2') == 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - superscript 2 not converted'
+            return
+        end if
+
+        ! Test superscript 3 (U+00B3) - UTF-8: C2 B3
+        input = 'x'//achar(194)//achar(179)
+        call escape_unicode_for_ascii(input, output)
+        if (index(output, 'U+') > 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - superscript 3'
+            return
+        end if
+        if (index(output, 'x3') == 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - superscript 3 not converted'
+            return
+        end if
+
+        ! Test multiplication sign (U+00D7) - UTF-8: C3 97
+        input = 'v'//achar(195)//achar(151)//'B'
+        call escape_unicode_for_ascii(input, output)
+        if (index(output, 'U+') > 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - multiplication sign'
+            return
+        end if
+        if (index(output, 'vxB') == 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - multiplication not converted'
+            return
+        end if
+
+        ! Test square root (U+221A) - UTF-8: E2 88 9A
+        input = achar(226)//achar(136)//achar(154)//'x'
+        call escape_unicode_for_ascii(input, output)
+        if (index(output, 'U+') > 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - square root'
+            return
+        end if
+        if (index(output, 'sqrt') == 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - square root not converted'
+            return
+        end if
+
+        ! Test full pipeline via ASCII backend output
+        call ensure_test_output_dir('unicode_u_escape', output_dir)
+        call figure(figsize=[8.0_dp, 6.0_dp])
+        call title('mc'//achar(194)//achar(178)//' and x'//achar(194)//achar(179))
+        call xlabel('v'//achar(195)//achar(151)//'B')
+        call ylabel(achar(226)//achar(136)//achar(154)//'x')
+        call savefig(output_dir//'test_u_escape.txt')
+
+        ! Read and verify no U+XXXX in output
+        open(newunit=i, file=output_dir//'test_u_escape.txt', &
+             status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: test_no_u_escape_sequences - could not read file'
+            return
+        end if
+
+        input = ''
+        do
+            read(i, '(A)', iostat=ios) input
+            if (ios /= 0) exit
+            if (index(input, 'U+') > 0) then
+                close(i)
+                print *, 'FAIL: test_no_u_escape_sequences - U+ escape in output'
+                return
+            end if
+        end do
+        close(i)
+
+        print *, '  PASS: test_no_u_escape_sequences'
+        passed_tests = passed_tests + 1
+    end subroutine test_no_u_escape_sequences
 
 end program test_unicode


### PR DESCRIPTION
## Summary

Fixes ASCII backend rendering Unicode characters as literal `U+XXXX` escape sequences (e.g. `mcU+00B2` instead of `mc2`).

## Root Cause

Fortran `ichar()` returns signed values (-128..127). UTF-8 bytes > 127 (like 0xC2 for superscript ²) return negative values, breaking:
- `utf8_char_length()` — misclassifies multi-byte sequences as single-byte ASCII
- `utf8_to_codepoint()` — produces wrong codepoints via signed bitwise arithmetic  
- `check_utf8_sequence()` — continuation byte validation always fails
- Mathtext UTF-8 boundary detection — splits multi-byte characters incorrectly

## Fix

Replaced `ichar` with `iachar` (unsigned 0..255) in all UTF-8 byte processing:
- `src/utilities/text/fortplot_unicode.f90`: 14 sites across `utf8_char_length`, `utf8_to_codepoint`, `check_utf8_sequence`
- `src/text/fortplot_mathtext.f90`: 2 sites in superscript/subscript boundary detection

## Verification

### Test passes after fix
```
$ fpm test --target test_unicode
   PASS: test_unicode_to_ascii
   PASS: test_math_symbols
   PASS: test_greek_letters
   PASS: test_is_unicode_char
   PASS: test_utf8_sequence_detection
   PASS: test_utf8_length
   PASS: test_codepoint_extraction
   PASS: test_is_greek_letter
   PASS: test_ascii_vs_unicode
   PASS: test_latex_uppercase_psi
   PASS: test_ascii_backend_handling
   PASS: test_superscript_rendering
   PASS: test_no_u_escape_sequences    <-- new regression test
 Tests passed:          13 /          13
```

### Full test suite: 0 failures

### Artifact verification (unicode_demo example)
Before: `mcU+00B2`, `vU+00D7B`, `U+221Ax`, `xU+00B3`
After: `mc2`, `vxB`, `sqrtx`, `x3`

### Artifact verification (scale_examples)
Before: `xU+00B3 - 50x`
After: `x3 - 50x`