### PR TITLE
fix: save_animation_demo writes output to animation/ instead of save_animation_demo/ (fixes #1720)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,10 @@ doc:
 		fi; \
 	done
 	# Ensure animation.mp4 explicitly present at expected locations (robust fallback)
-	if [ -f output/example/fortran/animation/animation.mp4 ]; then \
+	if [ -f output/example/fortran/save_animation_demo/animation.mp4 ]; then \
 		mkdir -p build/doc/page/media/examples/animation build/doc/media/examples/animation; \
-		cp output/example/fortran/animation/animation.mp4 build/doc/page/media/examples/animation/ 2>/dev/null || true; \
-		cp output/example/fortran/animation/animation.mp4 build/doc/media/examples/animation/ 2>/dev/null || true; \
+		cp output/example/fortran/save_animation_demo/animation.mp4 build/doc/page/media/examples/animation/ 2>/dev/null || true; \
+		cp output/example/fortran/save_animation_demo/animation.mp4 build/doc/media/examples/animation/ 2>/dev/null || true; \
 	fi
 
 
@@ -248,7 +248,7 @@ create_build_dirs:
 	@mkdir -p output/example/fortran/legend_demo
 	@mkdir -p output/example/fortran/legend_box_demo
 	@mkdir -p output/example/fortran/unicode_demo
-	@mkdir -p output/example/fortran/animation
+	@mkdir -p output/example/fortran/save_animation_demo
 	@mkdir -p output/example/fortran/annotation_demo
 	@mkdir -p output/example/fortran/histogram_demo
 	@mkdir -p output/example/fortran/subplot_demo

--- a/doc/examples/animation.md
+++ b/doc/examples/animation.md
@@ -10,7 +10,7 @@ Generate an MP4 animation from a sequence of frames.
 ## Files
 
 - `save_animation_demo.f90` - Source code
-- Generated media in `output/example/fortran/animation/`
+- Generated media in `output/example/fortran/save_animation_demo/`
 
 ## Running
 

--- a/example/fortran/animation/save_animation_demo.f90
+++ b/example/fortran/animation/save_animation_demo.f90
@@ -36,7 +36,7 @@ program save_animation_demo
     ! Save as MP4 video with 24 fps to GitHub Pages structure
     print *, "Saving animation as MP4..."
     call create_output_directory()
-    call save_animation_with_error_handling(anim, "output/example/fortran/animation/animation.mp4", 24)
+    call save_animation_with_error_handling(anim, "output/example/fortran/save_animation_demo/animation.mp4", 24)
     
 contains
 
@@ -88,9 +88,9 @@ contains
     subroutine create_output_directory()
         logical :: success
 
-        call create_directory_runtime("output/example/fortran/animation", success)
+        call create_directory_runtime("output/example/fortran/save_animation_demo", success)
         if (.not. success) then
-            print *, "WARNING: Could not create output/example/fortran/animation"
+            print *, "WARNING: Could not create output/example/fortran/save_animation_demo"
         end if
     end subroutine create_output_directory
     

--- a/test/test_animation_directory_creation.f90
+++ b/test/test_animation_directory_creation.f90
@@ -3,8 +3,8 @@ program test_animation_directory_creation
     use fortplot_file_operations, only: check_directory_exists
     implicit none
 
-    character(len=*), parameter :: out_file = 'output/example/fortran/animation/animation.mp4'
-    character(len=*), parameter :: out_dir  = 'output/example/fortran/animation'
+    character(len=*), parameter :: out_file = 'output/example/fortran/save_animation_demo/animation.mp4'
+    character(len=*), parameter :: out_dir  = 'output/example/fortran/save_animation_demo'
     logical :: exists
 
     print *, 'TEST: Animation output directory creation'


### PR DESCRIPTION
## Summary

Corrected the hardcoded output directory in `save_animation_demo.f90` from `output/example/fortran/animation/` to `output/example/fortran/save_animation_demo/` to match the convention used by all other examples.

### Changes
- `example/fortran/animation/save_animation_demo.f90`: updated output file path and directory creation
- `Makefile`: updated fallback copy path and `create_build_dirs` target
- `test/test_animation_directory_creation.f90`: updated expected paths
- `doc/examples/animation.md`: updated output directory reference

## Verification

### Test passes after fix
```
$ fpm test --target test_animation_directory_creation
 TEST: Animation output directory creation
 PASS: Directory exists for animation outputs: output/example/fortran/save_animation_demo
```

### Build succeeds
```
$ fpm build
[100%] Project compiled successfully.
```

### Output directory consistency
All other examples use `output/example/fortran/<example_name>/` as their output directory. This change aligns `save_animation_demo` with that convention.