### PR TITLE
fix: save_animation accepts .txt format for ASCII animation output (fixes #1718)

### DIFF
--- a/src/animation/fortplot_animation_pipeline.f90
+++ b/src/animation/fortplot_animation_pipeline.f90
@@ -17,23 +17,31 @@ module fortplot_animation_pipeline
 contains
 
     subroutine save_animation_full(anim, filename, fps, status)
-        use fortplot_animation_validation, only: is_supported_video_format
+        use fortplot_animation_validation, only: is_supported_video_format, get_file_extension
         use fortplot_utils, only: ensure_directory_exists
-        
+
         class(animation_t), intent(inout) :: anim
         character(len=*), intent(in) :: filename
         integer, intent(in), optional :: fps
         integer, intent(out), optional :: status
-        
+
         integer :: actual_fps, stat
-        
+        character(len=:), allocatable :: ext
+
         if (.not. is_supported_video_format(filename)) then
             if (present(status)) status = -3
             call log_error_with_remediation("Unsupported file format: " // trim(filename), &
-                                           "Change filename extension to .mp4, .avi, or .mkv")
+                                           "Change filename extension to .mp4, .avi, .mkv, or .txt")
             return
         end if
-        
+
+        ext = get_file_extension(filename)
+        if (ext == "txt") then
+            call save_ascii_animation(anim, filename, stat)
+            if (present(status)) status = stat
+            return
+        end if
+
         if (.not. check_ffmpeg_available()) then
             ! PNG sequence fallback when FFmpeg not available
             call log_warning("FFmpeg not found - falling back to PNG sequence")
@@ -41,17 +49,17 @@ contains
             if (present(status)) status = stat
             return
         end if
-        
+
         actual_fps = get_fps_or_default(fps)
         call ensure_directory_exists(filename)
         call save_animation_with_pipeline(anim, filename, actual_fps, stat)
-        
+
         ! If FFmpeg fails, fallback to PNG sequence
         if (stat /= 0) then
             call log_warning("FFmpeg animation failed - falling back to PNG sequence")
             call save_with_png_sequence_fallback(anim, filename, stat)
         end if
-        
+
         if (present(status)) status = stat
     end subroutine save_animation_full
 
@@ -77,10 +85,10 @@ contains
         class(animation_t), intent(inout) :: anim
         character(len=*), intent(in) :: filename
         integer, intent(out) :: status
-        
+
         character(len=:), allocatable :: base_name, pattern
         integer :: dot_pos
-        
+
         ! Extract base name from video filename
         dot_pos = index(filename, ".", back=.true.)
         if (dot_pos > 0) then
@@ -88,15 +96,100 @@ contains
         else
             base_name = filename
         end if
-        
+
         ! Create PNG sequence pattern
         pattern = base_name // "_frame_"
-        
+
         call log_info("Saving PNG sequence: " // pattern // "*.png")
         call anim%save_frame_sequence(pattern)
-        
+
         status = 0  ! PNG sequence always succeeds if frames can be generated
     end subroutine save_with_png_sequence_fallback
+
+    subroutine save_ascii_animation(anim, filename, status)
+        use fortplot_utils, only: ensure_directory_exists
+
+        class(animation_t), intent(inout) :: anim
+        character(len=*), intent(in) :: filename
+        integer, intent(out) :: status
+
+        integer :: frame_idx, tmp_unit, out_unit, ios
+        character(len=256) :: tmp_filename, err_msg
+        character(len=256) :: line
+        logical :: file_exists
+
+        if (.not. associated(anim%fig)) then
+            status = -1
+            call log_error_with_remediation("Animation figure not associated", &
+                                           "Set a figure on the animation before saving")
+            return
+        end if
+
+        call ensure_directory_exists(filename)
+
+        ! Create temporary file for individual frame output
+        tmp_filename = filename(1:index(filename, ".", back=.true.) - 1) // "_tmp_frame.txt"
+
+        ! Open output file for writing
+        open(newunit=out_unit, file=filename, status='replace', action='write', iostat=ios)
+        if (ios /= 0) then
+            status = -9
+            call log_error_with_remediation("Could not open output file: " // trim(filename), &
+                                           "Check directory permissions and disk space")
+            return
+        end if
+
+        do frame_idx = 1, anim%frames
+            ! Update figure for this frame
+            call anim%animate_func(frame_idx)
+
+            ! Reset rendered flag so figure re-renders
+            call anim%fig%set_rendered(.false.)
+
+            ! Save frame as ASCII to temporary file
+            call anim%fig%savefig_with_status(tmp_filename, ios)
+            if (ios /= 0) then
+                close(out_unit)
+                status = -10
+                write(err_msg, '(A,I0)') "Failed to render ASCII frame ", frame_idx
+                call log_error_with_remediation(err_msg, &
+                                               "Check figure data and ASCII backend")
+                return
+            end if
+
+            ! Write frame marker to output
+            write(out_unit, '(A,I0,A)') '=== Frame ', frame_idx, ' ==='
+
+            ! Read temporary file and write to output
+            open(newunit=tmp_unit, file=tmp_filename, status='old', action='read', iostat=ios)
+            if (ios /= 0) then
+                close(out_unit)
+                status = -11
+                call log_error_with_remediation("Could not read temporary frame file", &
+                                               "Temporary file may be corrupted")
+                return
+            end if
+
+            do
+                read(tmp_unit, '(A)', iostat=ios) line
+                if (ios /= 0) exit
+                write(out_unit, '(A)') trim(line)
+            end do
+            close(tmp_unit)
+        end do
+
+        close(out_unit)
+
+        ! Clean up temporary file
+        inquire(file=tmp_filename, exist=file_exists)
+        if (file_exists) then
+            open(newunit=tmp_unit, file=tmp_filename, status='old', iostat=ios)
+            if (ios == 0) close(tmp_unit, status='delete')
+        end if
+
+        status = 0
+        call log_info("ASCII animation saved to: " // trim(filename))
+    end subroutine save_ascii_animation
 
     subroutine save_animation_with_pipeline(anim, filename, fps, status)
         class(animation_t), intent(inout) :: anim

--- a/src/animation/fortplot_animation_validation.f90
+++ b/src/animation/fortplot_animation_validation.f90
@@ -35,7 +35,8 @@ contains
         extension = get_file_extension(filename)
         is_video = (extension == "mp4" .or. &
                    extension == "avi" .or. &
-                   extension == "mkv")
+                   extension == "mkv" .or. &
+                   extension == "txt")
     end function is_supported_video_format
 
     function validate_generated_video_enhanced(filename, file_size) result(is_valid)
@@ -90,18 +91,25 @@ contains
         integer, intent(in) :: file_size
         logical :: is_valid
         integer :: dummy_len
+        character(len=:), allocatable :: ext
+        integer :: min_size
+
+        ext = get_file_extension(filename)
+        min_size = MIN_VALID_VIDEO_SIZE
+        if (ext == "txt") min_size = 10
+
         dummy_len = len_trim(filename)
-        is_valid = (file_size > MIN_VALID_VIDEO_SIZE) .and. &
-                   (file_size < 2000000000)  ! Max 2GB reasonable limit
+        is_valid = (file_size > min_size) .and. &
+                   (file_size < 2000000000)
     end function validate_basic_file_properties
 
     function validate_format_specific_properties(filename) result(is_valid)
         character(len=*), intent(in) :: filename
         logical :: is_valid
         character(len=:), allocatable :: extension
-        
+
         extension = get_file_extension(filename)
-        
+
         select case (extension)
         case ("mp4")
             is_valid = validate_mp4_format(filename)
@@ -109,6 +117,8 @@ contains
             is_valid = validate_avi_format(filename)
         case ("mkv")
             is_valid = validate_mkv_format(filename)
+        case ("txt")
+            is_valid = validate_txt_format(filename)
         case default
             is_valid = .false.
         end select
@@ -117,10 +127,15 @@ contains
     function validate_video_structure(filename) result(is_valid)
         character(len=*), intent(in) :: filename
         logical :: is_valid
-        
-        ! Enhanced structure validation
-        is_valid = validate_video_header_format(filename) .and. &
-                   validate_container_structure(filename)
+        character(len=:), allocatable :: ext
+
+        ext = get_file_extension(filename)
+        if (ext == "txt") then
+            is_valid = .true.
+        else
+            is_valid = validate_video_header_format(filename) .and. &
+                       validate_container_structure(filename)
+        end if
     end function validate_video_structure
 
     function validate_content_integrity(filename) result(is_valid)
@@ -203,18 +218,38 @@ contains
         logical :: is_valid
         character(len=20) :: header
         integer :: file_unit, ios
-        
+
         is_valid = .false.
         open(newunit=file_unit, file=filename, access='stream', form='unformatted', iostat=ios)
         if (ios /= 0) return
-        
+
         read(file_unit, iostat=ios) header
         close(file_unit)
         if (ios /= 0) return
-        
+
         ! Matroska/MKV format validation (EBML header)
         is_valid = (header(1:1) == achar(26) .and. header(2:2) == achar(69))  ! EBML signature
     end function validate_mkv_format
+
+    function validate_txt_format(filename) result(is_valid)
+        character(len=*), intent(in) :: filename
+        logical :: is_valid
+        integer :: file_unit, ios
+        character(len=256) :: line
+
+        is_valid = .false.
+        open(newunit=file_unit, file=filename, status='old', iostat=ios)
+        if (ios /= 0) return
+
+        read(file_unit, '(A)', iostat=ios) line
+        if (ios /= 0) then
+            close(file_unit)
+            return
+        end if
+
+        is_valid = (index(line, '=== Frame') > 0)
+        close(file_unit)
+    end function validate_txt_format
 
     function validate_container_structure(filename) result(is_valid)
         character(len=*), intent(in) :: filename
@@ -329,7 +364,8 @@ contains
         
         has_ext = (index(filename, '.mp4') > 0 .or. &
                    index(filename, '.avi') > 0 .or. &
-                   index(filename, '.mkv') > 0)
+                   index(filename, '.mkv') > 0 .or. &
+                   index(filename, '.txt') > 0)
     end function has_video_extension
 
 end module fortplot_animation_validation

--- a/test/test_animation_txt_save.f90
+++ b/test/test_animation_txt_save.f90
@@ -1,0 +1,85 @@
+program test_animation_txt_save
+    !! Test that save_animation accepts .txt format and produces
+    !! a text file with === Frame N === delimiters.
+    use fortplot
+    use fortplot_animation
+    use fortplot_system_runtime, only: create_directory_runtime, delete_file_runtime
+    implicit none
+
+    integer, parameter :: nframes = 3
+    type(figure_t), pointer :: pfig
+    type(animation_t) :: anim
+    real(wp) :: x(32), y(32)
+    integer :: i, status
+    logical :: ok, exists
+    character(len=*), parameter :: outdir = "build/test/output/"
+    character(len=*), parameter :: outfile = "build/test/output/test_animation_txt_save.txt"
+    character(len=256) :: line
+    integer :: unit, ios, frame_count
+
+    do i = 1, size(x)
+        x(i) = real(i - 1, wp)
+        y(i) = sin(x(i) * 0.5_wp)
+    end do
+
+    call create_directory_runtime(outdir, ok)
+    if (.not. ok) error stop "failed to create output directory"
+
+    call figure(figsize=[6.0_wp, 4.0_wp])
+    pfig => get_global_figure()
+    call add_plot(x, y)
+    call title("Sine wave")
+    call xlabel("x")
+    call ylabel("sin(x)")
+
+    anim = FuncAnimation(update_sine, frames=nframes, interval=10, fig=pfig)
+    call save_animation(anim, outfile, status=status)
+
+    if (status /= 0) then
+        print *, "FAIL: save_animation returned status ", status
+        error stop "save_animation .txt failed with non-zero status"
+    end if
+
+    inquire(file=outfile, exist=exists)
+    if (.not. exists) then
+        print *, "FAIL: output file not created: ", outfile
+        error stop "save_animation .txt did not create output file"
+    end if
+
+    frame_count = 0
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, "FAIL: could not open output file for reading"
+        error stop "cannot open generated .txt file"
+    end if
+
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        if (index(line, '=== Frame') > 0) frame_count = frame_count + 1
+    end do
+    close(unit)
+
+    if (frame_count /= nframes) then
+        print *, "FAIL: expected ", nframes, " frames, got ", frame_count
+        error stop "frame count mismatch in .txt animation"
+    end if
+
+    call delete_file_runtime(outfile, ok)
+
+contains
+
+    subroutine update_sine(frame)
+        integer, intent(in) :: frame
+        real(wp) :: phase
+        phase = real(frame, wp) * 0.3_wp
+        y = sin(x * 0.5_wp + phase)
+        call pfig%clear()
+        call add_plot(x, y)
+        call title("Sine wave")
+        call xlabel("x")
+        call ylabel("sin(x)")
+        call pfig%set_rendered(.false.)
+    end subroutine update_sine
+
+end program test_animation_txt_save


### PR DESCRIPTION
## Summary

`save_animation` now accepts `.txt` extension to produce ASCII text animation files with `=== Frame N ===` delimiters, enabling terminal playback via `ascii_animation_player`.

### Changes
- **fortplot_animation_validation.f90**: Added `.txt` to supported formats, safe filename checks, and format-specific validation
- **fortplot_animation_pipeline.f90**: New `save_ascii_animation` subroutine that renders each animation frame as ASCII and writes to a single text file with frame markers
- **test/test_animation_txt_save.f90**: New test verifying `.txt` save produces correct frame count and format

## Verification

### Test passes
```
$ ./build/.../test_animation_txt_save
(no output — test exits 0, confirming all assertions pass)
```

### probability_animation_demo produces .txt output
```
$ ./build/.../probability_animation_demo
$ ls output/example/fortran/probability_animation_demo/
melting_gaussian.mp4  melting_gaussian.txt
$ grep -c "=== Frame" output/example/fortran/probability_animation_demo/melting_gaussian.txt
36
```

### CI-fast test suite passes
```
$ make test-ci
CI essential test suite completed successfully
```

### Requirement-by-requirement evidence
| Requirement | Evidence |
|---|---|
| `.txt` accepted by `save_animation` | `is_supported_video_format` returns `.true.` for `.txt`; demo saves `melting_gaussian.txt` without error |
| Frame delimiters present | `grep -c "=== Frame"` returns 36 (matches `nframes`) |
| Existing video formats unaffected | `melting_gaussian.mp4` produced alongside `.txt`; all CI tests pass |
| Validation handles `.txt` | `validate_txt_format` checks for `=== Frame` header; `validate_video_structure` skips binary checks for `.txt` |
