### PR TITLE
fix: errorbar_demo.md lists stale output filenames (fixes #1762)

### DIFF
--- a/doc/examples/errorbar_demo.md
+++ b/doc/examples/errorbar_demo.md
@@ -8,7 +8,7 @@ Source: [errorbar_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/e
 Demonstrates error bar plotting with both symmetric and asymmetric errors for scientific data visualization.
 
 - `errorbar_demo.f90` - Source code with comprehensive error bar examples
-- `errorbar_plot.png/pdf/txt` - Example outputs
+- Generated media in `output/example/fortran/errorbar_demo/`
 
 - **Symmetric error bars**: Single error value for both directions
 - **Asymmetric error bars**: Different upper and lower error bounds


### PR DESCRIPTION
## Summary

Corrected stale output filename `errorbar_plot.png/pdf/txt` in `doc/examples/errorbar_demo.md` to match actual generated media path.

## Verification

### Requirement: remove or correct the stale filename entry

**Before (line 11):**
```
- \`errorbar_plot.png/pdf/txt\` - Example outputs
```

**After (line 11):**
```
- Generated media in \`output/example/fortran/errorbar_demo/\`
```

The actual output files are `errorbar_asymmetric.png`, `errorbar_basic_x.png`, `errorbar_basic_y.png`, `errorbar_combined.png`, `errorbar_custom.png`, `errorbar_scientific.png` — none of which match the stale `errorbar_plot.*` pattern. The corrected entry now matches the existing "## Files" section (line 37-40) which already references the correct output directory.

### File changed
- `doc/examples/errorbar_demo.md` — 1 insertion, 1 deletion
