### PR TITLE
fix: grouped bar chart ticks not centered at group positions (fixes #1708)

### DIFF
--- a/example/fortran/bar_chart_demo/bar_chart_demo.f90
+++ b/example/fortran/bar_chart_demo/bar_chart_demo.f90
@@ -4,7 +4,7 @@ program bar_chart_demo
     !! Includes categorical axis labels for bar charts (Issue #1458)
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-   use fortplot, only: figure, bar, barh, xlabel, ylabel, title, legend, set_xticks
+    use fortplot, only: figure, bar, barh, xlabel, ylabel, title, legend, set_xticks
     use fortplot, only: savefig_with_status, figure_t
     use fortplot_plotting_advanced, only: bar_impl
     use fortplot_errors, only: SUCCESS
@@ -114,10 +114,10 @@ contains
         call fig%set_title('Object API - grouped budget comparison')
         call fig%set_xlabel('Team')
         call fig%set_ylabel('Quarterly budget (M$)')
-      call bar_impl(fig, positions_baseline, baseline, width=0.32d0, &
-                       label='Baseline')
+        call bar_impl(fig, positions_baseline, baseline, width=0.32d0, &
+                      label='Baseline')
         call bar_impl(fig, positions_projected, projected, width=0.32d0, &
-                       label='Projected')
+                      label='Projected')
         call fig%set_xticks(centers, ['Team 1', 'Team 2', 'Team 3'])
         call fig%legend()
 

--- a/example/fortran/bar_chart_demo/bar_chart_demo.f90
+++ b/example/fortran/bar_chart_demo/bar_chart_demo.f90
@@ -4,7 +4,7 @@ program bar_chart_demo
     !! Includes categorical axis labels for bar charts (Issue #1458)
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use fortplot, only: figure, bar, barh, xlabel, ylabel, title, legend
+   use fortplot, only: figure, bar, barh, xlabel, ylabel, title, legend, set_xticks
     use fortplot, only: savefig_with_status, figure_t
     use fortplot_plotting_advanced, only: bar_impl
     use fortplot_errors, only: SUCCESS
@@ -38,6 +38,7 @@ contains
         call figure(figsize=[7.5d0, 5.0d0])
         call bar(positions_a, product_a, width=0.4d0, label='Product A')
         call bar(positions_b, product_b, width=0.4d0, label='Product B')
+        call set_xticks(centers, ['Q1', 'Q2', 'Q3', 'Q4'])
         call xlabel('Quarter')
         call ylabel('Revenue (million $)')
         call title('Stateful API - grouped bar chart')
@@ -113,10 +114,11 @@ contains
         call fig%set_title('Object API - grouped budget comparison')
         call fig%set_xlabel('Team')
         call fig%set_ylabel('Quarterly budget (M$)')
-        call bar_impl(fig, positions_baseline, baseline, width=0.32d0, &
-                      label='Baseline')
+      call bar_impl(fig, positions_baseline, baseline, width=0.32d0, &
+                       label='Baseline')
         call bar_impl(fig, positions_projected, projected, width=0.32d0, &
-                      label='Projected')
+                       label='Projected')
+        call fig%set_xticks(centers, ['Team 1', 'Team 2', 'Team 3'])
         call fig%legend()
 
         ok = .true.

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -98,27 +98,28 @@ module fortplot
     use fortplot_spec_json_parse, only: json_to_spec
 
     ! Matplotlib-compatible API (all pyplot-style functions)
-    use fortplot_matplotlib, only: plot, contour, contour_filled, contourf, &
-                                   pcolormesh, streamplot, quiver, add_quiver, &
-                                   hist, histogram, scatter, errorbar, boxplot, &
-                                   bar, barh, text, annotate, &
-                                   imshow, pie, polar, step, stem, &
-                                   fill, fill_between, twinx, twiny, colorbar, &
-                                   xlabel, ylabel, title, suptitle, legend, grid, &
-                                   savefig, savefig_with_status, figure, subplot, &
-                                   subplots, subplots_grid, &
-                                   add_plot, add_contour, add_contour_filled, &
-                                   add_contourf, &
-                                   add_pcolormesh, add_errorbar, &
-                                   add_3d_plot, add_surface, add_scatter, &
-                                   set_xscale, set_yscale, xscale, yscale, &
-                                   xlim, ylim, &
-                                   set_line_width, set_ydata, use_axis, &
-                                   get_active_axis, minorticks_on, &
-                                   axhline, axvline, hlines, vlines, &
-                                   show, show_viewer, &
-                                   ion, ioff, draw, pause, &
-                                   ensure_global_figure_initialized, get_global_figure
+   use fortplot_matplotlib, only: plot, contour, contour_filled, contourf, &
+                                    pcolormesh, streamplot, quiver, add_quiver, &
+                                    hist, histogram, scatter, errorbar, boxplot, &
+                                    bar, barh, text, annotate, &
+                                    imshow, pie, polar, step, stem, &
+                                    fill, fill_between, twinx, twiny, colorbar, &
+                                    xlabel, ylabel, title, suptitle, legend, grid, &
+                                    savefig, savefig_with_status, figure, subplot, &
+                                    subplots, subplots_grid, &
+                                    add_plot, add_contour, add_contour_filled, &
+                                    add_contourf, &
+                                    add_pcolormesh, add_errorbar, &
+                                    add_3d_plot, add_surface, add_scatter, &
+                                    set_xscale, set_yscale, xscale, yscale, &
+                                    xlim, ylim, &
+                                    set_line_width, set_ydata, use_axis, &
+                                    get_active_axis, minorticks_on, &
+                                    axhline, axvline, hlines, vlines, &
+                                    set_xticks, set_yticks, &
+                                    show, show_viewer, &
+                                    ion, ioff, draw, pause, &
+                                    ensure_global_figure_initialized, get_global_figure
 
     implicit none
     private
@@ -155,6 +156,7 @@ module fortplot
     public :: xlabel, ylabel, title, suptitle, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale, xscale, yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on
+    public :: set_xticks, set_yticks
     public :: savefig, savefig_with_status
 
     ! Extended plotting functions

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -98,7 +98,7 @@ module fortplot
     use fortplot_spec_json_parse, only: json_to_spec
 
     ! Matplotlib-compatible API (all pyplot-style functions)
-   use fortplot_matplotlib, only: plot, contour, contour_filled, contourf, &
+    use fortplot_matplotlib, only: plot, contour, contour_filled, contourf, &
                                     pcolormesh, streamplot, quiver, add_quiver, &
                                     hist, histogram, scatter, errorbar, boxplot, &
                                     bar, barh, text, annotate, &

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -19,7 +19,7 @@ module fortplot_matplotlib
         xlabel, ylabel, title, suptitle, legend, grid, &
         xlim, ylim, set_xscale, set_yscale, xscale, yscale, &
         set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, axis, &
-        tight_layout, axhline, axvline, hlines, vlines, &
+        tight_layout, axhline, axvline, hlines, vlines, set_xticks, set_yticks, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
         show, show_viewer, ion, ioff, draw, pause, &
         get_global_figure, ensure_global_figure_initialized
@@ -50,6 +50,7 @@ module fortplot_matplotlib
     public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, axis
     public :: tight_layout
     public :: axhline, axvline, hlines, vlines
+    public :: set_xticks, set_yticks
     public :: text, annotate
 
     ! Figure management functions

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -13,7 +13,7 @@ module fortplot_matplotlib_advanced
         xlabel, ylabel, title, suptitle, legend, grid, xlim, ylim, set_xscale, &
         set_yscale, xscale, yscale, set_line_width, set_ydata, use_axis, &
         get_active_axis, minorticks_on, axis, tight_layout, &
-        axhline, axvline, hlines, vlines
+        axhline, axvline, hlines, vlines, set_xticks, set_yticks
     use fortplot_matplotlib_session, only: &
         ensure_global_figure_initialized, get_global_figure, figure, subplot, &
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
@@ -41,6 +41,7 @@ module fortplot_matplotlib_advanced
     public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: minorticks_on, axis, tight_layout
     public :: axhline, axvline, hlines, vlines
+    public :: set_xticks, set_yticks
     public :: colorbar
 
     public :: figure, subplot, subplots, subplots_grid

--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -32,6 +32,8 @@ module fortplot_matplotlib_axes
     public :: axvline
     public :: hlines
     public :: vlines
+    public :: set_xticks
+    public :: set_yticks
 
     interface axis
         !! Set aspect ratio: axis('equal'), axis('auto'), or axis(2.0)
@@ -367,5 +369,31 @@ contains
         call fig%vlines(x, ymin=ymin, ymax=ymax, colors=colors, &
                         linestyles=linestyles, linewidth=linewidth, label=label)
     end subroutine vlines
+
+    subroutine set_xticks(positions, labels)
+        !! Set custom x-axis tick positions and optionally labels
+        real(wp), intent(in) :: positions(:)
+        character(len=*), intent(in), optional :: labels(:)
+
+        call ensure_fig_init()
+        if (present(labels)) then
+            call fig%set_xticks(positions, labels)
+        else
+            call fig%set_xticks(positions)
+        end if
+    end subroutine set_xticks
+
+    subroutine set_yticks(positions, labels)
+        !! Set custom y-axis tick positions and optionally labels
+        real(wp), intent(in) :: positions(:)
+        character(len=*), intent(in), optional :: labels(:)
+
+        call ensure_fig_init()
+        if (present(labels)) then
+            call fig%set_yticks(positions, labels)
+        else
+            call fig%set_yticks(positions)
+        end if
+    end subroutine set_yticks
 
 end module fortplot_matplotlib_axes

--- a/test/test_grouped_bar_ticks.f90
+++ b/test/test_grouped_bar_ticks.f90
@@ -1,0 +1,256 @@
+program test_grouped_bar_ticks
+    !! Tests for grouped bar chart tick positioning (Issue #1708)
+    !!
+    !! This test covers:
+    !! - Stateful set_xticks() sets custom tick positions and labels
+    !! - OO set_xticks() sets custom tick positions and labels
+    !! - Custom tick positions are stored correctly in figure state
+    !! - Grouped bar chart renders with correct tick positions
+    !! - set_yticks() stateful wrapper
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_plotting_advanced, only: bar_impl
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    integer :: test_count = 0
+    integer :: pass_count = 0
+    integer :: fail_count = 0
+    logical :: dir_ok
+
+    call create_directory_runtime('build/test/output', dir_ok)
+    print *, "=== GROUPED BAR TICK POSITION TESTS (Issue #1708) ==="
+
+    call test_stateful_set_xticks()
+    call test_oo_set_xticks()
+    call test_grouped_bar_with_ticks()
+    call test_set_yticks()
+    call print_test_summary()
+
+    if (fail_count > 0) stop 1
+
+contains
+
+    subroutine test_stateful_set_xticks()
+        !! Test stateful set_xticks via global figure pointer
+        real(wp) :: centers(4)
+        real(wp) :: positions_a(4)
+        real(wp) :: positions_b(4)
+        real(wp) :: values_a(4)
+        real(wp) :: values_b(4)
+        character(len=4) :: labels(4)
+        class(figure_t), pointer :: fig_ptr
+
+        call start_test("Stateful set_xticks stores positions and labels")
+
+        centers = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        positions_a = centers - 0.2_wp
+        positions_b = centers + 0.2_wp
+        values_a = [4.5_wp, 5.8_wp, 6.1_wp, 6.7_wp]
+        values_b = [3.2_wp, 4.6_wp, 5.4_wp, 6.0_wp]
+        labels = ['Q1  ', 'Q2  ', 'Q3  ', 'Q4  ']
+
+        call figure(figsize=[7.5_wp, 5.0_wp])
+        call bar(positions_a, values_a, width=0.4_wp, label='Product A')
+        call bar(positions_b, values_b, width=0.4_wp, label='Product B')
+        call set_xticks(centers, labels)
+
+        fig_ptr => get_global_figure()
+
+        call assert_true(fig_ptr%state%custom_xticks_set, &
+            "Custom x-ticks flag is set")
+        call assert_true(allocated(fig_ptr%state%custom_xtick_positions), &
+            "Custom x-tick positions allocated")
+        call assert_equal(real(size(fig_ptr%state%custom_xtick_positions), wp), &
+            4.0_wp, "Four tick positions stored")
+        call assert_equal(fig_ptr%state%custom_xtick_positions(1), &
+            1.0_wp, "First tick at center position 1")
+        call assert_equal(fig_ptr%state%custom_xtick_positions(4), &
+            4.0_wp, "Last tick at center position 4")
+        call assert_str_equal(trim(fig_ptr%state%custom_xtick_labels(1)), &
+            'Q1', "First label is Q1")
+        call assert_str_equal(trim(fig_ptr%state%custom_xtick_labels(4)), &
+            'Q4', "Last label is Q4")
+
+        call savefig('build/test/output/grouped_bar_stateful_ticks.png')
+
+        call end_test()
+    end subroutine test_stateful_set_xticks
+
+    subroutine test_oo_set_xticks()
+        !! Test OO set_xticks positions and labels are stored
+        type(figure_t) :: fig
+        real(wp) :: centers(3)
+        real(wp) :: positions_a(3)
+        real(wp) :: positions_b(3)
+        real(wp) :: values_a(3)
+        real(wp) :: values_b(3)
+        character(len=6) :: labels(3)
+
+        call start_test("OO set_xticks stores positions and labels")
+
+        centers = [1.0_wp, 2.0_wp, 3.0_wp]
+        positions_a = centers - 0.18_wp
+        positions_b = centers + 0.18_wp
+        values_a = [2.8_wp, 3.4_wp, 3.9_wp]
+        values_b = [3.5_wp, 3.8_wp, 4.6_wp]
+        labels = ['Team 1', 'Team 2', 'Team 3']
+
+        call fig%initialize()
+        call bar_impl(fig, positions_a, values_a, width=0.32_wp, label='A')
+        call bar_impl(fig, positions_b, values_b, width=0.32_wp, label='B')
+        call fig%set_xticks(centers, labels)
+
+        call assert_true(fig%state%custom_xticks_set, &
+            "Custom x-ticks flag is set")
+        call assert_true(allocated(fig%state%custom_xtick_positions), &
+            "Custom x-tick positions allocated")
+        call assert_equal(real(size(fig%state%custom_xtick_positions), wp), &
+            3.0_wp, "Three tick positions stored")
+        call assert_equal(fig%state%custom_xtick_positions(1), &
+            1.0_wp, "First tick at center position 1")
+        call assert_equal(fig%state%custom_xtick_positions(3), &
+            3.0_wp, "Last tick at center position 3")
+        call assert_str_equal(trim(fig%state%custom_xtick_labels(1)), &
+            'Team 1', "First label is Team 1")
+        call assert_str_equal(trim(fig%state%custom_xtick_labels(3)), &
+            'Team 3', "Last label is Team 3")
+
+        call fig%savefig('build/test/output/grouped_bar_oo_ticks.png')
+
+        call end_test()
+    end subroutine test_oo_set_xticks
+
+    subroutine test_grouped_bar_with_ticks()
+        !! End-to-end: grouped bar chart with explicit tick positions
+        !! Verifies bars render at offset positions but ticks at centers
+        type(figure_t) :: fig
+        real(wp) :: centers(4)
+        real(wp) :: positions_a(4)
+        real(wp) :: positions_b(4)
+        real(wp) :: values_a(4)
+        real(wp) :: values_b(4)
+        character(len=4) :: labels(4)
+
+        call start_test("Grouped bar chart with explicit tick positions")
+
+        centers = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        positions_a = centers - 0.2_wp
+        positions_b = centers + 0.2_wp
+        values_a = [4.5_wp, 5.8_wp, 6.1_wp, 6.7_wp]
+        values_b = [3.2_wp, 4.6_wp, 5.4_wp, 6.0_wp]
+        labels = ['Q1  ', 'Q2  ', 'Q3  ', 'Q4  ']
+
+        call fig%initialize(800, 600)
+        call bar_impl(fig, positions_a, values_a, width=0.4_wp, label='A')
+        call bar_impl(fig, positions_b, values_b, width=0.4_wp, label='B')
+        call fig%set_xticks(centers, labels)
+
+        call assert_true(fig%plot_count >= 2, "Two bar plots added")
+        call assert_true(fig%state%custom_xticks_set, "Ticks set to centers")
+        call assert_equal(fig%state%custom_xtick_positions(1), &
+            1.0_wp, "Tick 1 at center (not offset)")
+        call assert_equal(fig%state%custom_xtick_positions(2), &
+            2.0_wp, "Tick 2 at center (not offset)")
+
+        call fig%savefig('build/test/output/grouped_bar_explicit_ticks.png')
+
+        call end_test()
+    end subroutine test_grouped_bar_with_ticks
+
+    subroutine test_set_yticks()
+        !! Test stateful set_yticks stores positions and labels
+        class(figure_t), pointer :: fig_ptr
+        real(wp) :: yticks(3)
+        character(len=5) :: ylabels(3)
+
+        call start_test("Stateful set_yticks stores positions and labels")
+
+        call figure(figsize=[6.0_wp, 4.0_wp])
+        yticks = [0.0_wp, 5.0_wp, 10.0_wp]
+        ylabels = ['Low ', 'Mid ', 'High']
+
+        call bar([1.0_wp, 2.0_wp], [3.0_wp, 7.0_wp])
+        call set_yticks(yticks, ylabels)
+
+        fig_ptr => get_global_figure()
+
+        call assert_true(fig_ptr%state%custom_yticks_set, &
+            "Custom y-ticks flag set")
+        call assert_true(allocated(fig_ptr%state%custom_ytick_positions), &
+            "Custom y-tick positions allocated")
+        call assert_equal(real(size(fig_ptr%state%custom_ytick_positions), wp), &
+            3.0_wp, "Three y-tick positions stored")
+        call assert_str_equal(trim(fig_ptr%state%custom_ytick_labels(1)), &
+            'Low', "First y-label is Low")
+
+        call savefig('build/test/output/set_yticks.png')
+
+        call end_test()
+    end subroutine test_set_yticks
+
+    subroutine start_test(test_name)
+        character(len=*), intent(in) :: test_name
+        test_count = test_count + 1
+        write(*, '(A, I0, A, A)') 'Test ', test_count, ': ', test_name
+    end subroutine start_test
+
+    subroutine end_test()
+        pass_count = pass_count + 1
+        write(*, '(A)') '  PASS'
+        write(*, *)
+    end subroutine end_test
+
+    subroutine assert_equal(actual, expected, description)
+        real(wp), intent(in) :: actual, expected
+        character(len=*), intent(in) :: description
+
+        if (abs(actual - expected) < 1.0e-10_wp) then
+            print *, '  PASS: ', description
+        else
+            print *, '  FAIL: ', description, &
+                ' (expected ', expected, ', got ', actual, ')'
+            fail_count = fail_count + 1
+        end if
+    end subroutine assert_equal
+
+    subroutine assert_true(condition, description)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: description
+
+        if (condition) then
+            print *, '  PASS: ', description
+        else
+            print *, '  FAIL: ', description
+            fail_count = fail_count + 1
+        end if
+    end subroutine assert_true
+
+    subroutine assert_str_equal(actual, expected, description)
+        character(len=*), intent(in) :: actual, expected, description
+
+        if (trim(actual) == trim(expected)) then
+            print *, '  PASS: ', description
+        else
+            print *, '  FAIL: ', description, &
+                ' (expected "', trim(expected), '", got "', trim(actual), '")'
+            fail_count = fail_count + 1
+        end if
+    end subroutine assert_str_equal
+
+    subroutine print_test_summary()
+        write(*, '(A)') '============================================'
+        write(*, '(A)') 'Grouped Bar Tick Position Test Summary'
+        write(*, '(A, I0, A, I0, A, I0)') &
+            'Tests run: ', test_count, &
+            ' | Passed: ', pass_count, ' | Failed: ', fail_count
+        if (fail_count == 0) then
+            write(*, '(A)') 'ALL TESTS PASSED!'
+        else
+            write(*, '(A)') 'SOME TESTS FAILED!'
+        end if
+        write(*, '(A)') '============================================'
+    end subroutine print_test_summary
+
+end program test_grouped_bar_ticks

--- a/test/test_grouped_bar_ticks.f90
+++ b/test/test_grouped_bar_ticks.f90
@@ -17,6 +17,7 @@ program test_grouped_bar_ticks
     integer :: test_count = 0
     integer :: pass_count = 0
     integer :: fail_count = 0
+    integer :: test_fail_count = 0
     logical :: dir_ok
 
     call create_directory_runtime('build/test/output', dir_ok)
@@ -193,12 +194,17 @@ contains
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
+        test_fail_count = fail_count
         write(*, '(A, I0, A, A)') 'Test ', test_count, ': ', test_name
     end subroutine start_test
 
     subroutine end_test()
-        pass_count = pass_count + 1
-        write(*, '(A)') '  PASS'
+        if (fail_count == test_fail_count) then
+            pass_count = pass_count + 1
+            write(*, '(A)') '  PASS'
+        else
+            write(*, '(A)') '  FAIL'
+        end if
         write(*, *)
     end subroutine end_test
 


### PR DESCRIPTION
## Summary

Grouped bar charts rendered with auto-generated tick labels at every individual bar position (e.g. 0.8, 1.2, 1.8, 2.2, ...) instead of at group centers (1, 2, 3, 4) with categorical labels.

This PR adds `set_xticks`/`set_yticks` stateful API wrappers and updates the grouped bar chart demos to set explicit tick positions at group centers.

## Changes

- **`src/interfaces/fortplot_matplotlib_axes.f90`**: Add `set_xticks`/`set_yticks` stateful wrappers that delegate to the global figure
- **`src/interfaces/fortplot_matplotlib_advanced.f90`**: Re-export `set_xticks`/`set_yticks`
- **`src/interfaces/fortplot_matplotlib.f90`**: Re-export `set_xticks`/`set_yticks`
- **`src/core/fortplot.f90`**: Re-export `set_xticks`/`set_yticks` to public API
- **`example/fortran/bar_chart_demo/bar_chart_demo.f90`**: Use `set_xticks` with categorical labels (Q1-Q4, Team 1-3) in grouped demos
- **`test/test_grouped_bar_ticks.f90`**: Behavioral tests for stateful and OO tick positioning

## Verification

### Test passes after fix

```
$ fpm test --target test_grouped_bar_ticks
=== GROUPED BAR TICK POSITION TESTS (Issue #1708) ===
Test 1: Stateful set_xticks stores positions and labels
   PASS: Custom x-ticks flag is set
   PASS: Custom x-tick positions allocated
   PASS: Four tick positions stored
   PASS: First tick at center position 1
   PASS: Last tick at center position 4
   PASS: First label is Q1
   PASS: Last label is Q4
  PASS
...
Tests run: 4 | Passed: 4 | Failed: 0
ALL TESTS PASSED!
```

### Artifact verification

```
$ make verify-artifacts
...
Artifact verification passed.
```

### CI-fast test suite

```
$ make test-ci
...
CI essential test suite completed successfully
```

### Full test suite

```
$ make test
...
ALL TESTS PASSED (fpm test)
```

### Artifact evidence

`output/example/fortran/bar_chart_demo/stateful_grouped.txt` now shows tick labels at group centers:
```
|          Q1                 Q2                  Q3                 Q4          |
```

`output/example/fortran/bar_chart_demo/oo_grouped.txt` shows:
```
|            Team 1                     Team 2                     Team 3        |
```