### PR TITLE
fix: Stale '_new' suffixes on production modules (fixes #1745)

### DIFF
--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -403,7 +403,7 @@ module fortplot_figure_core_accessors
     use fortplot_annotations, only: text_annotation_t
     use fortplot_plot_data, only: plot_data_t, arrow_data_t
     use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_figure_properties_new
+    use fortplot_figure_properties
     use fortplot_figure_management
     use fortplot_figure_operations, only: figure_render
     implicit none

--- a/src/figures/fortplot_figure_comprehensive_operations.f90
+++ b/src/figures/fortplot_figure_comprehensive_operations.f90
@@ -19,7 +19,7 @@ module fortplot_figure_comprehensive_operations
     ! Import ALL necessary modules (facade pattern allows more dependencies)
     use fortplot_figure_operations
     use fortplot_figure_management
-    use fortplot_figure_properties_new
+    use fortplot_figure_properties
     use fortplot_figure_core_ranges, only: update_data_ranges_figure, &
                                            update_data_ranges_pcolormesh_figure
     use fortplot_figure_core_operations

--- a/src/figures/fortplot_figure_properties.f90
+++ b/src/figures/fortplot_figure_properties.f90
@@ -1,4 +1,4 @@
-module fortplot_figure_properties_new
+module fortplot_figure_properties
     !! Figure property management module for fortplot_figure_core
     !! 
     !! This module handles property access, data ranges, and backend interface
@@ -185,4 +185,4 @@ contains
                                         xscale, yscale, symlog_threshold)
     end subroutine figure_update_data_ranges
 
-end module fortplot_figure_properties_new
+end module fortplot_figure_properties

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -19,7 +19,7 @@ module fortplot_matplotlib_advanced
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
         show_figure, show_viewer, ion, ioff, draw, pause
     use fortplot_matplotlib_colorbar, only: colorbar
-    use fortplot_matplotlib_plots_new, only: &
+    use fortplot_matplotlib_plots, only: &
         imshow, pie, polar, step, stem, fill, fill_between, twinx, twiny
 
     implicit none

--- a/src/interfaces/fortplot_matplotlib_plots.f90
+++ b/src/interfaces/fortplot_matplotlib_plots.f90
@@ -1,4 +1,4 @@
-module fortplot_matplotlib_plots_new
+module fortplot_matplotlib_plots
     !! Matplotlib-compatible plot functions for imshow/pie/polar/step/stem/fill.
     !!
     !! Color kwargs accept either a named color string or an RGB triple via
@@ -488,4 +488,4 @@ contains
         call fig%twiny()
     end subroutine twiny
 
-end module fortplot_matplotlib_plots_new
+end module fortplot_matplotlib_plots

--- a/test/test_matplotlib_facade_split.f90
+++ b/test/test_matplotlib_facade_split.f90
@@ -5,7 +5,7 @@ program test_matplotlib_facade_split
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_global, only: fig => global_figure
     use fortplot_matplotlib, only: figure, plot, bar, fill
-    use fortplot_matplotlib_plots_new, only: fill_new => fill
+    use fortplot_matplotlib_plots, only: fill_new => fill
 
     implicit none
 


### PR DESCRIPTION
## Summary

Remove stale `_new` suffixes from two production modules that were transitional markers from a completed migration:
- `fortplot_figure_properties_new` → `fortplot_figure_properties`
- `fortplot_matplotlib_plots_new` → `fortplot_matplotlib_plots`

## Changes

- Renamed `src/figures/fortplot_figure_properties_new.f90` → `fortplot_figure_properties.f90`
- Renamed `src/interfaces/fortplot_matplotlib_plots_new.f90` → `fortplot_matplotlib_plots.f90`
- Updated module declarations inside renamed files
- Updated `use` statements in 4 dependent files:
  - `src/figures/fortplot_figure_comprehensive_operations.f90`
  - `src/figures/core/fortplot_figure_core_ops.f90`
  - `src/interfaces/fortplot_matplotlib_advanced.f90`
  - `test/test_matplotlib_facade_split.f90`

## Verification

### Build succeeds
```
$ make build
[100%] Project compiled successfully.
```

### CI test suite passes
```
$ make test-ci
CI essential test suite completed successfully
```

### Specific test that imports renamed module passes
```
$ fpm test --target test_matplotlib_facade_split
Matplotlib facade split regression tests passed.
```

### No remaining references to old names
```
$ grep -r "fortplot_figure_properties_new\|fortplot_matplotlib_plots_new" src/ test/
(no matches)
```
