### PR TITLE
fix: Duplicate subroutine names across modules (fixes #1750)

### DIFF
--- a/src/figures/fortplot_figure_plot_management.f90
+++ b/src/figures/fortplot_figure_plot_management.f90
@@ -17,8 +17,8 @@ module fortplot_figure_plot_management
     implicit none
 
     private
-    public :: add_line_plot_data, add_contour_plot_data, add_colored_contour_plot_data
-    public :: add_surface_plot_data, add_pcolormesh_plot_data, &
+    public :: register_line_plot_data, add_contour_plot_data, add_colored_contour_plot_data
+    public :: add_surface_plot_data, register_pcolormesh_plot_data, &
               add_fill_between_plot_data
     public :: generate_default_contour_levels
     public :: setup_figure_legend, update_plot_ydata, validate_plot_data
@@ -100,7 +100,7 @@ contains
         end if
     end function next_plot_color
 
-    subroutine add_line_plot_data(plots, plot_count, max_plots, &
+    subroutine register_line_plot_data(plots, plot_count, max_plots, &
                                   x, y, label, linestyle, color, marker)
         !! Add line plot data to internal storage with edge case validation
         !! Fixed Issue #432: Added data validation for better user feedback
@@ -147,7 +147,7 @@ contains
                 plots(plot_count)%marker = marker
             end if
         end if
-    end subroutine add_line_plot_data
+    end subroutine register_line_plot_data
 
     subroutine add_fill_between_plot_data(plots, plot_count, max_plots, x, upper, &
                                           lower, mask, &
@@ -460,7 +460,7 @@ contains
         if (present(filled)) plots(plot_count)%surface_filled = filled
     end subroutine add_surface_plot_data
 
-    subroutine add_pcolormesh_plot_data(plots, plot_count, max_plots, &
+    subroutine register_pcolormesh_plot_data(plots, plot_count, max_plots, &
                                         x, y, c, colormap, vmin, vmax, &
                                         edgecolors, linewidths)
         !! Add pcolormesh plot data
@@ -539,7 +539,7 @@ contains
         if (present(linewidths)) then
             plots(plot_count)%pcolormesh_data%edge_width = linewidths
         end if
-    end subroutine add_pcolormesh_plot_data
+    end subroutine register_pcolormesh_plot_data
 
     subroutine generate_default_contour_levels(plot_data)
         !! Generate default contour levels

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -76,7 +76,7 @@ contains
         end if
         
         ! Add the plot data using focused module
-        call add_line_plot_data(plots, state%plot_count, state%max_plots, &
+        call register_line_plot_data(plots, state%plot_count, state%max_plots, &
                                x, y, label, ls, plot_color, &
                                marker=trim(parsed_marker))
     end subroutine figure_add_plot
@@ -136,7 +136,7 @@ contains
         real(wp), intent(in), optional :: edgecolors(3)
         real(wp), intent(in), optional :: linewidths
         
-        call add_pcolormesh_plot_data(plots, state%plot_count, state%max_plots, &
+        call register_pcolormesh_plot_data(plots, state%plot_count, state%max_plots, &
                                       x, y, c, colormap, vmin, vmax, edgecolors, &
                                       linewidths)
     end subroutine figure_add_pcolormesh


### PR DESCRIPTION
## Summary

Rename management-layer subroutines to eliminate name collisions between
`fortplot_figure_plot_management` and plotting modules:

- `add_line_plot_data` → `register_line_plot_data` (management layer)
- `add_pcolormesh_plot_data` → `register_pcolormesh_plot_data` (management layer)

The high-level entry points in `fortplot_2d_plots` and `fortplot_plot_contours`
retain the original names.

## Changes

- `src/figures/fortplot_figure_plot_management.f90`: renamed subroutines and public declarations
- `src/figures/fortplot_figure_plots.f90`: updated call sites

## Verification

- **Build**: `fpm build` compiles successfully (100%)
- **Tests**: `fpm test` — 910 PASS, 0 FAIL
- **Duplicate audit**: post-fix grep confirms `add_line_plot_data` and `add_pcolormesh_plot_data` each appear exactly once in the codebase. 23 other duplicate subroutine names remain (e.g. `add_3d_plot`, `render_line_plot`, `viridis_colormap`, `show_figure`, etc.) and are tracked for future consideration.