### PR TITLE
fix: Dead public API: fortplot_mathtext stubs return zero and suppress unused (fixes #1731)

### DIFF
--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -6,8 +6,7 @@ module fortplot_mathtext
     implicit none
 
     private
-    public :: mathtext_element_t, parse_mathtext, render_mathtext_elements
-    public :: calculate_mathtext_width, calculate_mathtext_height
+    public :: mathtext_element_t, parse_mathtext
     public :: ELEMENT_NORMAL, ELEMENT_SUPERSCRIPT, ELEMENT_SUBSCRIPT, ELEMENT_SQRT
 
     ! Mathematical text element types
@@ -296,66 +295,7 @@ contains
         element%element_type = element_type
         element%font_size_ratio = font_size_ratio
         element%vertical_offset = vertical_offset
-    end subroutine create_element
+   end subroutine create_element
 
-    function calculate_mathtext_width(elements, base_font_size) result(total_width)
-        !! Calculate total width of mathematical text elements
-        !! This function signature is used by text_rendering but implementation moved there
-        type(mathtext_element_t), intent(in) :: elements(:)
-        real(wp), intent(in) :: base_font_size
-        integer :: total_width
-
-        ! This is a placeholder - actual implementation is in text_rendering module
-        ! to avoid circular dependencies
-        total_width = 0
-
-        ! Suppress unused parameter warnings
-        associate(unused_elements => elements, unused_size => base_font_size)
-        end associate
-
-    end function calculate_mathtext_width
-
-    function calculate_mathtext_height(elements, base_font_size) result(total_height)
-        !! Calculate total height of mathematical text elements
-        !! This function signature is used by text_rendering but implementation moved there
-        type(mathtext_element_t), intent(in) :: elements(:)
-        real(wp), intent(in) :: base_font_size
-        integer :: total_height
-
-        ! This is a placeholder - actual implementation is in text_rendering module
-        ! to avoid circular dependencies
-        total_height = int(base_font_size)
-
-        ! Suppress unused parameter warnings
-        associate(unused_elements => elements, unused_size => base_font_size)
-        end associate
-
-    end function calculate_mathtext_height
-
-    subroutine render_mathtext_elements(image_data, width, height, x, y, elements, &
-                                       r, g, b, base_font_size)
-        !! Render mathematical text elements to image
-        !! This function signature is used by text_rendering but implementation moved there
-        integer(1), intent(inout) :: image_data(*)
-        integer, intent(in) :: width, height, x, y
-        type(mathtext_element_t), intent(in) :: elements(:)
-        integer(1), intent(in) :: r, g, b
-        real(wp), intent(in) :: base_font_size
-
-        ! This is a placeholder - actual implementation is in text_rendering module
-        ! to avoid circular dependencies
-
-        ! Suppress unused parameter warnings - avoid referencing assumed-size arrays
-        if (.false.) then
-            image_data(1) = image_data(1)  ! Reference array without bounds
-        end if
-        if (.false.) then
-            associate(unused_w => width, unused_h => height, &
-                     unused_x => x, unused_y => y, unused_elements => elements, &
-                     unused_r => r, unused_g => g, unused_b => b, unused_size => base_font_size)
-            end associate
-        end if
-
-    end subroutine render_mathtext_elements
 
 end module fortplot_mathtext


### PR DESCRIPTION
## Summary

Remove three dead public stub procedures from `fortplot_mathtext`:
- `calculate_mathtext_width` — returned 0, suppressed unused warnings
- `calculate_mathtext_height` — returned `int(base_font_size)`, suppressed unused warnings  
- `render_mathtext_elements` — no-op, suppressed unused warnings via `if (.false.)`

These had zero external callers. Real implementations exist as `_internal` variants in `fortplot_text_layout.f90` and `fortplot_raster_text_rendering.f90`.

## Changes

- Removed stubs from `public` declaration in `src/text/fortplot_mathtext.f90`
- Deleted three stub procedure bodies (62 lines removed, net -60 lines)
- Module shrunk from 361 to 301 lines

## Verification

### Build
```
$ fpm build
[100%] Project compiled successfully.
```

### Tests
```
$ fpm test 2>&1 | tail -5
Tests run: 6 | Passed: 6 | Failed: 0
Tests run: 4 | Passed: 4 | Failed: 0
Tests run: 12 | Passed: 12
```
All tests pass. No callers of removed procedures exist (verified via grep across `src/` and `test/`).
