### PR TITLE
fix: PNG backend: error bar whiskers clipped at axis boundary (fixes #1727)

### DIFF
--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -64,6 +64,11 @@ contains
         ! Apply small margin to prevent boundary clipping
         select type (bk => backend)
         class is (pdf_context)
+            call expand_data_range(x_min_transformed, x_max_transformed, &
+                                   x_min_adj, x_max_adj)
+            call expand_data_range(y_min_transformed, y_max_transformed, &
+                                   y_min_adj, y_max_adj)
+            call bk%set_coordinates(x_min_adj, x_max_adj, y_min_adj, y_max_adj)
         class is (raster_context)
             call expand_data_range(x_min_transformed, x_max_transformed, &
                                    x_min_adj, x_max_adj)

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -51,18 +51,20 @@ contains
     subroutine setup_coordinate_system(backend, x_min_transformed, x_max_transformed, &
                                        y_min_transformed, y_max_transformed)
         !! Setup the coordinate system for rendering
-        !! Adds a small margin to data ranges for the PDF backend to prevent
-        !! boundary data from being clipped by the plot frame stroke.
+        !! Adds a small margin to data ranges to prevent boundary data from
+        !! being clipped by the plot frame stroke.
         use fortplot_pdf, only: pdf_context
+        use fortplot_raster, only: raster_context
         class(plot_context), intent(inout) :: backend
         real(wp), intent(in) :: x_min_transformed, x_max_transformed
         real(wp), intent(in) :: y_min_transformed, y_max_transformed
 
         real(wp) :: x_min_adj, x_max_adj, y_min_adj, y_max_adj
 
-        ! Apply small margin for PDF backend to prevent boundary clipping
+        ! Apply small margin to prevent boundary clipping
         select type (bk => backend)
         class is (pdf_context)
+        class is (raster_context)
             call expand_data_range(x_min_transformed, x_max_transformed, &
                                    x_min_adj, x_max_adj)
             call expand_data_range(y_min_transformed, y_max_transformed, &


### PR DESCRIPTION
## Summary

Apply the 2% data-range margin expansion to raster (PNG) backends, matching existing PDF backend behavior. Previously only PDF backends received the margin in `setup_coordinate_system`, causing errorbar whiskers at axis boundaries to be clipped by the plot frame stroke.

## Changes

- `src/figures/fortplot_figure_rendering_pipeline.f90`: Added `raster_context` to the `class is` branch alongside `pdf_context` in `setup_coordinate_system`, so both backends get the `expand_data_range` margin.

## Verification

### Root cause
`setup_coordinate_system` at line 64-74 applied `expand_data_range` (2% margin) only to `pdf_context`. Raster backends used exact data range, so errorbar whiskers whose endpoint equals `y_max` mapped to the exact plot-area top edge, competing with the axes frame stroke.

### Test evidence
- Full test suite: `fpm test` — all tests pass, 0 failures
- Errorbar demo: `make example ARGS="errorbar_demo"` — produces `output/example/fortran/errorbar_demo/errorbar_scientific.png` successfully
- The 2% margin ensures whisker endpoints render inside the plot area rather than at the boundary pixel

### Before fix
```
class is (pdf_context)      ! margin applied
class default               ! no margin -> clipping
```

### After fix
```
class is (pdf_context)      ! margin applied
class is (raster_context)   ! margin applied
class default               ! fallback
```
