### PR TITLE
fix: clamp ASCII text and arrows inside frame border (fixes #1706)

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -234,7 +234,7 @@ contains
             text_y = nint(y)
         end if
 
-        text_x = max(1, min(text_x, max(1, pw - processed_len + 1)))
+        text_x = max(2, min(text_x, max(2, pw - processed_len - 1)))
         text_y = max(1, min(text_y, ph))
 
         this%num_text_elements = this%num_text_elements + 1

--- a/src/backends/ascii/fortplot_ascii_drawing.f90
+++ b/src/backends/ascii/fortplot_ascii_drawing.f90
@@ -138,8 +138,8 @@ contains
         px = int((x - x_min) / (x_max - x_min) * real(width, wp))
         py = int((y - y_min) / (y_max - y_min) * real(height, wp))
 
-        ! Ensure coordinates are within bounds
-        if (px < 1 .or. px > width .or. py < 1 .or. py > height) return
+        ! Ensure coordinates stay inside the frame border (1-char margin)
+        if (px < 2 .or. px > width - 1 .or. py < 2 .or. py > height - 1) return
 
         ! Calculate angle for direction
         angle = atan2(dy, dx)

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -247,9 +247,9 @@ contains
             text_y = nint((y_max - y) / (y_max - y_min) * real(plot_height, wp))
         end if
 
-        ! Clamp to canvas bounds so the trailing character stays inside
-        ! the frame border (issue #1706).
-        text_x = max(1, min(text_x, max(1, plot_width - processed_len + 1)))
+        ! Clamp to canvas bounds so text stays inside the frame border
+        ! with 1-char margin on both sides (issue #1706).
+        text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
         text_y = max(1, min(text_y, plot_height))
 
         text = processed_text(1:processed_len)

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -292,10 +292,9 @@ contains
                 text_y = nint((y_max - y)/(y_max - y_min)*real(plot_height, wp))
             end if
 
-            ! Clamp to canvas bounds. Always keep the trailing character
-            ! inside the frame so the border ``|`` glyph is never pushed
-            ! off the right edge (issue #1706).
-            text_x = max(1, min(text_x, max(1, plot_width - processed_len + 1)))
+            ! Clamp to canvas bounds. Reserve margin on the right so text
+            ! never touches the border ``|`` glyph (issue #1706).
+            text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
             text_y = max(1, min(text_y, plot_height))
 
             text_elements(num_text_elements)%text = processed_text(1:processed_len)

--- a/src/backends/ascii/fortplot_ascii_utils.f90
+++ b/src/backends/ascii/fortplot_ascii_utils.f90
@@ -135,7 +135,7 @@ contains
                     conflict = .false.
                     do char_idx = 1, text_len
                         j = text_elements(i)%x + char_idx - 1
-                        if (j < 1 .or. j > plot_width) cycle
+                        if (j < 1 .or. j > plot_width - 1) cycle
                         if (canvas(candidate_y, j) /= ' ' .and. &
                             .not. is_graphics_character(canvas(candidate_y, j))) then
                             conflict = .true.
@@ -155,7 +155,7 @@ contains
                     conflict = .false.
                     do char_idx = 1, text_len
                         j = text_elements(i)%x + char_idx - 1
-                        if (j < 1 .or. j > plot_width) cycle
+                        if (j < 1 .or. j > plot_width - 1) cycle
                         if (canvas(candidate_y, j) /= ' ' .and. &
                             .not. is_graphics_character(canvas(candidate_y, j))) then
                             conflict = .true.
@@ -173,7 +173,7 @@ contains
             do char_idx = 1, text_len
                 j = text_elements(i)%x + char_idx - 1
 
-                if (j >= 1 .and. j <= plot_width .and. &
+                if (j >= 1 .and. j <= plot_width - 1 .and. &
                     current_y >= 1 .and. current_y <= plot_height) then
 
                     text_char = ascii_text(char_idx:char_idx)

--- a/test/test_ascii_text_overflow.f90
+++ b/test/test_ascii_text_overflow.f90
@@ -1,0 +1,102 @@
+program test_ascii_text_overflow
+    !! Regression test for issue #1706: ASCII text annotation overflow
+    !!
+    !! Verifies that text elements (legend entries, annotations, tick labels)
+    !! never overflow past the right frame border character.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    real(wp), dimension(100) :: x, y
+    integer :: i
+    character(len=*), parameter :: outfile = 'build/test/output/ascii_overflow_test.txt'
+    logical :: dir_ok, file_exists
+    integer :: file_size, unit, ios, nlines, overflow_count
+    character(len=512) :: line
+    character(len=1) :: char_before_border
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    ! Generate data that produces long legend labels
+    x = [(real(i, wp), i=0, size(x) - 1)] * 0.06_wp
+    y = sin(x) * exp(-x / 4.0_wp)
+
+    ! Create figure with long legend labels that could overflow
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call title("Overflow Test")
+    call plot(x, y, label="Damped sine: sin(x)e^-x/4", linestyle="-")
+    call plot(x, -y, label="Quadratic: 0.1(x-3)^2 - 0.3", linestyle=":")
+    call plot(x, y * 0.5_wp, label="Exponential: e^-x - 0.5", linestyle="--")
+
+    ! Add text near right edge to test clamping
+    call text(5.5_wp, 0.4_wp, "Right Edge", &
+              coord_type=COORD_DATA, font_size=10.0_wp)
+
+    call legend("upper right")
+    call savefig(outfile)
+
+    ! Verify file exists
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, "FAIL: ASCII output file not created"
+        stop 1
+    end if
+    if (file_size <= 0) then
+        print *, "FAIL: ASCII output file is empty"
+        stop 1
+    end if
+    print *, "PASS: ASCII file created (", file_size, " bytes)"
+
+    ! Check every line for overflow: no line should exceed frame width
+    ! Frame width = plot_width + 2 (left/right border)
+    nlines = 0
+    overflow_count = 0
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, "FAIL: Cannot open ASCII output file"
+        stop 1
+    end if
+
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios > 0) exit
+        nlines = nlines + 1
+        if (ios == -1 .and. len_trim(line) == 0) cycle
+
+        ! Frame lines start with +
+        if (index(line, '+') == 1) then
+            if (len_trim(line) > 82) then
+                overflow_count = overflow_count + 1
+                print *, "FAIL: Frame line", nlines, "overflows (", &
+                       len_trim(line), "chars)"
+            end if
+        else if (index(line, '|') == 1) then
+            ! Content lines: check for overflow
+            if (len_trim(line) > 82) then
+                overflow_count = overflow_count + 1
+                print *, "FAIL: Content line", nlines, "overflows (", &
+                       len_trim(line), "chars)"
+            end if
+            ! Check for arrow characters touching the right border
+            if (len_trim(line) >= 81) then
+                char_before_border = line(81:81)
+                if (char_before_border == '>' .or. char_before_border == '<') then
+                    overflow_count = overflow_count + 1
+                    print *, "FAIL: Arrow char at right border, line", nlines
+                end if
+            end if
+        end if
+    end do
+    close(unit)
+
+    if (overflow_count > 0) then
+        print *, "FAIL:", overflow_count, "overflow violations detected"
+        stop 1
+    end if
+
+    print *, "PASS: No text overflow detected (", nlines, " lines checked)"
+    print *, "PASS: Issue #1706 regression guard passed"
+
+end program test_ascii_text_overflow


### PR DESCRIPTION
## Summary

Text annotations, legend entries, and annotation arrows overflowed past the right `|` border character in ASCII backend output, corrupting the terminal frame.

### Root Causes

1. **Arrow drawing** (`annotate`): allowed placement at canvas column `width`, one past the safe margin used by data plotting. The `>` arrow character appeared at the rightmost canvas column.
2. **Text clamping inconsistency**: three code paths used different lower bounds (`max(1, ...)` vs `max(2, ...)`) for left-edge protection.
3. **Rendering boundary**: text rendering checks used `plot_width` instead of `plot_width - 1`, allowing text to reach the rightmost canvas column.

### Changes

- `fortplot_ascii_drawing.f90`: arrow bounds tightened to `px >= 2 && px <= width-1` (matching data plotting margins)
- `fortplot_ascii.f90` / `fortplot_ascii_primitives.f90` / `fortplot_ascii_text.f90`: unified text clamping to `max(2, ...)` on both sides
- `fortplot_ascii_utils.f90`: rendering boundary checks tightened to `plot_width - 1`
- New regression test `test_ascii_text_overflow.f90`

## Verification

### Requirement: legend/annotation text stays within border

**Command**: `make example ARGS="annotation_demo"` then check output
**Evidence**: all 32 plot lines are exactly 82 characters (80-column canvas + 2 borders); no `>` or `<` characters touch the border:
```
$ awk 'NR>=3 && NR<=34{if(length($0) != 82) print NR": "length($0)}' annotation_demo.txt
(no output — all lines correct)

$ grep '>|' annotation_demo.txt
(no output — no overflow)
```

### Requirement: annotation arrows stay within border

**Command**: same as above (annotation_demo uses `annotate()` with arrows)
**Evidence**: arrow characters (`>`, `<`, `^`, `v`, `/`, `\`) no longer appear at canvas column 80 (rightmost). The `>` that previously appeared at column 81 of output line 9 is gone:
```
Before: | 0.5                                         -- Quadratic: 0.1(x-3)^2 - 0.3    >|
After:  | 0.5                                         -- Quadratic: 0.1(x-3)^2 - 0.3     |
```

### Regression test

**Command**: `fpm test --target test_ascii_text_overflow`
**Output**:
```
 PASS: ASCII file created (        2704  bytes)
 PASS: No text overflow detected (          35  lines checked)
 PASS: Issue #1706 regression guard passed
```

### Existing ASCII tests

**Command**: `fpm test --target test_ascii && fpm test --target test_ascii_scrambling_fix_852 && fpm test --target test_errorbar_ascii_rendering`
**Output**: all pass.