### PR TITLE
fix: ASCII legend entries show raw LaTeX $...$ delimiters (fixes #1701)

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -676,7 +676,8 @@ contains
         character(len=64), intent(out) :: entry_label
 
         character(len=:), allocatable :: trimmed_text
-        integer :: first_space
+        character(len=256) :: sanitized
+        integer :: sanitized_len, first_space
 
         formatted_line = ''
         entry_label = ''
@@ -686,7 +687,8 @@ contains
 
         if (len(trimmed_text) >= 3 .and. trimmed_text(1:3) == '-- ') then
             if (len(trimmed_text) > 3) then
-                entry_label = trim(adjustl(trimmed_text(4:)))
+                call sanitize_ascii_text(trim(adjustl(trimmed_text(4:))), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             else
                 entry_label = ''
             end if
@@ -695,22 +697,27 @@ contains
             formatted_line = '  '//trim(trimmed_text)
             first_space = index(trimmed_text, ' ')
             if (first_space > 0 .and. first_space < len(trimmed_text)) then
-                entry_label = trim(adjustl(trimmed_text(first_space + 1:)))
+                call sanitize_ascii_text(trim(adjustl(trimmed_text(first_space + 1:))), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             else
-                entry_label = trim(trimmed_text)
+                call sanitize_ascii_text(trim(trimmed_text), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             end if
         end if
     end subroutine decode_ascii_legend_line
 
-    subroutine ascii_add_legend_entry(this, label, value_text)
+  subroutine ascii_add_legend_entry(this, label, value_text)
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in) :: label
         character(len=*), intent(in), optional :: value_text
 
         character(len=96) :: line_buffer
+        character(len=256) :: sanitized
+        integer :: sanitized_len
         character(len=:), allocatable :: value_trimmed
 
-        line_buffer = '  '//trim(label)
+        call sanitize_ascii_text(label, sanitized, sanitized_len)
+        line_buffer = '  '//trim(sanitized(1:sanitized_len))
 
         if (present(value_text)) then
             value_trimmed = trim(value_text)
@@ -720,7 +727,7 @@ contains
         end if
 
         call append_ascii_legend_line_helper(this%legend_lines, this%num_legend_lines, &
-                                             trim(line_buffer))
+                                              trim(line_buffer))
     end subroutine ascii_add_legend_entry
 
     subroutine ascii_clear_pie_legend_entries(this)

--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -706,7 +706,7 @@ contains
         end if
     end subroutine decode_ascii_legend_line
 
-  subroutine ascii_add_legend_entry(this, label, value_text)
+    subroutine ascii_add_legend_entry(this, label, value_text)
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in) :: label
         character(len=*), intent(in), optional :: value_text

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -737,7 +737,8 @@ contains
         character(len=64), intent(out) :: entry_label
 
         character(len=:), allocatable :: trimmed_text
-        integer :: first_space
+        character(len=256) :: sanitized
+        integer :: sanitized_len, first_space
 
         formatted_line = ''
         entry_label = ''
@@ -747,7 +748,8 @@ contains
 
         if (len(trimmed_text) >= 3 .and. trimmed_text(1:3) == '-- ') then
             if (len(trimmed_text) > 3) then
-                entry_label = trim(adjustl(trimmed_text(4:)))
+                call sanitize_ascii_text(trim(adjustl(trimmed_text(4:))), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             else
                 entry_label = ''
             end if
@@ -756,9 +758,11 @@ contains
             formatted_line = '  '//trim(trimmed_text)
             first_space = index(trimmed_text, ' ')
             if (first_space > 0 .and. first_space < len(trimmed_text)) then
-                entry_label = trim(adjustl(trimmed_text(first_space + 1:)))
+                call sanitize_ascii_text(trim(adjustl(trimmed_text(first_space + 1:))), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             else
-                entry_label = trim(trimmed_text)
+                call sanitize_ascii_text(trim(trimmed_text), sanitized, sanitized_len)
+                entry_label = trim(sanitized(1:sanitized_len))
             end if
         end if
     end subroutine decode_ascii_legend_line_helper

--- a/src/ui/fortplot_legend.f90
+++ b/src/ui/fortplot_legend.f90
@@ -7,6 +7,7 @@ module fortplot_legend
     !! Interface Segregation: Focused legend interface
     !! Dependency Inversion: Depends on abstractions, not concrete backends
     
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_context, only: plot_context
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
@@ -156,30 +157,32 @@ contains
         real(wp) :: text_x, text_y
         character(len=:), allocatable :: legend_line
         integer :: available_width
+        character(len=256) :: sanitized_label
+        integer :: sanitized_len
 
         do i = 1, legend%num_entries
             ! For ASCII, arrange entries vertically going downward
             text_x = legend_x
             text_y = legend_y + real(i-1, wp)
-            
-            ! Ensure text fits within canvas bounds  
+
+            ! Ensure text fits within canvas bounds
             text_y = max(1.0_wp, min(text_y, real(max(2, backend%height - 2), wp)))
-            
+
             ! Set color for this entry
             call backend%color(legend%entries(i)%color(1), &
                               legend%entries(i)%color(2), &
                               legend%entries(i)%color(3))
-            
+
+            call sanitize_ascii_text(legend%entries(i)%label, sanitized_label, sanitized_len)
+
             ! Create legend entry with actual marker character or line symbol
             if (allocated(legend%entries(i)%marker) .and. &
                 trim(legend%entries(i)%marker) /= '' .and. &
                 trim(legend%entries(i)%marker) /= 'None') then
-                ! Show marker character
                 legend_line = get_ascii_marker_char(legend%entries(i)%marker) // ' ' // &
-                    trim(legend%entries(i)%label)
+                    trim(sanitized_label(1:sanitized_len))
             else
-                ! Show line symbol for line-only plots
-                legend_line = '-- ' // trim(legend%entries(i)%label)
+                legend_line = '-- ' // trim(sanitized_label(1:sanitized_len))
             end if
 
             available_width = max(1, backend%width - int(text_x) + 1)

--- a/test/test_ascii_legend_latex.f90
+++ b/test/test_ascii_legend_latex.f90
@@ -1,0 +1,71 @@
+program test_ascii_legend_latex
+    !! Test that ASCII backend strips LaTeX $...$ delimiters from legend entries
+    !! Regression test for issue #1701.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_figure
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    real(wp), dimension(50) :: x, y1, y2
+    type(figure_t) :: fig
+    integer :: i
+    character(len=*), parameter :: outfile = 'build/test/output/ascii_legend_latex.txt'
+    logical :: dir_ok, file_exists
+    integer :: unit, ios
+    character(len=512) :: line
+    logical :: found_dollar, found_clean
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    x = [(real(i, wp), i = 0, 49)] / 10.0_wp
+    y1 = sin(x)
+    y2 = cos(x)
+
+    call fig%initialize(80, 24)
+    call fig%add_plot(x, y1, label="$sin(x)$")
+    call fig%add_plot(x, y2, label="$cos(x)$")
+    call fig%legend()
+    call fig%savefig(outfile)
+
+    ! Read output and check for $ delimiters in legend lines
+    found_dollar = .false.
+    found_clean = .false.
+
+    open(newunit = unit, file = outfile, status = 'old', action = 'read', iostat = ios)
+    if (ios /= 0) then
+        print *, "FAIL: cannot read ", outfile
+        stop 1
+    end if
+
+    do
+        read(unit, '(A)', iostat = ios) line
+        if (ios /= 0) exit
+
+        ! Check legend lines (they contain "--" prefix)
+        if (index(line, '--') > 0) then
+            ! Legend line should NOT contain $ delimiters
+            if (index(line, '$') > 0) then
+                found_dollar = .true.
+            end if
+            ! Legend line should contain cleaned text
+            if (index(line, 'sin(x)') > 0 .or. index(line, 'cos(x)') > 0) then
+                found_clean = .true.
+            end if
+        end if
+    end do
+    close(unit)
+
+    if (found_dollar) then
+        print *, "FAIL: ASCII legend contains raw $ delimiters"
+        stop 1
+    end if
+
+    if (.not. found_clean) then
+        print *, "FAIL: ASCII legend missing expected cleaned labels"
+        stop 1
+    end if
+
+    print *, "PASS: ASCII legend strips LaTeX $ delimiters correctly"
+
+end program test_ascii_legend_latex


### PR DESCRIPTION
## Summary

Strips LaTeX `$...$` math delimiters from legend entry labels in the ASCII backend. Previously, legend entries like `$e^{-x/2}cos(x)$` were rendered verbatim with dollar signs; they now render as `e^-x/2cos(x)`.

### Changes
- `src/ui/fortplot_legend.f90`: sanitize legend labels in `render_ascii_legend`
- `src/backends/ascii/fortplot_ascii.f90`: sanitize labels in `decode_ascii_legend_line` and `ascii_add_legend_entry`
- `src/backends/ascii/fortplot_ascii_text.f90`: sanitize labels in `decode_ascii_legend_line_helper`
- `test/test_ascii_legend_latex.f90`: regression test

## Verification

### Test passes after fix
```
$ fpm test --target test_ascii_legend_latex
 PASS: ASCII legend strips LaTeX $ delimiters correctly
```

### Artifact verification
Before fix (`multi_function_legend.txt`):
```
|  -- $e^{-x/2}cos(x)$   |
|  -- $xe^{-x/3}$        |
```

After fix:
```
|  -- e^-x/2cos(x)       |
|  -- xe^-x/3            |
```

### CI test suite
All CI tests pass: `make test-ci` completes successfully with 914 PASS assertions.