### PR TITLE
fix: \sqrt{} command in legend text renders as literal text instead of symbol (fixes #1723)

### DIFF
--- a/src/utilities/text/fortplot_latex_parser.f90
+++ b/src/utilities/text/fortplot_latex_parser.f90
@@ -250,6 +250,13 @@ contains
                         i = cmd_end
                         cycle
                     end if
+
+                    ! Handle \sqrt{...} or \sqrt x -> Unicode radical + content
+                    if (trim(command) == 'sqrt') then
+                        call process_sqrt_block(input_text, cmd_end, n, pos, &
+                                                result_text, i)
+                        cycle
+                    end if
                 end if
                 ! If not a recognized command, fall through and copy the backslash
             end if
@@ -261,5 +268,95 @@ contains
 
         result_len = pos - 1
     end subroutine process_latex_in_text
+
+    recursive subroutine process_sqrt_block(input_text, after_cmd, n, out_pos, &
+                                            result_text, next_i)
+        !! Process \sqrt{...} or \sqrt x: output Unicode radical (U+221A) followed by
+        !! the content with LaTeX commands resolved. For braced form, strips outer braces.
+        !! For unbraced form, takes the next single character.
+        character(len=*), intent(in) :: input_text
+        integer, intent(in) :: after_cmd, n
+        integer, intent(inout) :: out_pos
+        character(len=*), intent(inout) :: result_text
+        integer, intent(out) :: next_i
+
+        character(len=4096) :: inner_raw, inner_processed
+        integer :: brace_depth, j, inner_end, inner_len, processed_len
+
+        ! Output Unicode radical symbol (U+221A = 8730, 3-byte UTF-8: E2 88 9A)
+        result_text(out_pos:out_pos) = achar(226)
+        result_text(out_pos+1:out_pos+1) = achar(136)
+        result_text(out_pos+2:out_pos+2) = achar(154)
+        out_pos = out_pos + 3
+
+        if (after_cmd > n) then
+            ! Nothing after \sqrt
+            next_i = after_cmd
+            return
+        end if
+
+        if (input_text(after_cmd:after_cmd) == '{') then
+            ! Braced form: \sqrt{...}
+            brace_depth = 1
+            j = after_cmd + 1
+            do while (j <= n .and. brace_depth > 0)
+                if (input_text(j:j) == '{') then
+                    brace_depth = brace_depth + 1
+                else if (input_text(j:j) == '}') then
+                    brace_depth = brace_depth - 1
+                    if (brace_depth == 0) then
+                        inner_end = j - 1
+                        exit
+                    end if
+                end if
+                j = j + 1
+            end do
+
+            if (brace_depth /= 0) then
+                ! No matching brace; treat as unbraced
+                inner_len = 1
+                if (after_cmd <= n) then
+                    inner_raw(1:1) = input_text(after_cmd:after_cmd)
+                else
+                    inner_len = 0
+                end if
+                call process_latex_in_text(inner_raw(1:inner_len), inner_processed, processed_len)
+                if (processed_len > 0) then
+                    result_text(out_pos:out_pos + processed_len - 1) = &
+                        inner_processed(1:processed_len)
+                    out_pos = out_pos + processed_len
+                end if
+                next_i = after_cmd + 1
+                return
+            end if
+
+            inner_len = inner_end - (after_cmd + 1) + 1
+            if (inner_len > 0 .and. inner_len <= len(inner_raw)) then
+                inner_raw(1:inner_len) = input_text(after_cmd + 1:inner_end)
+            else
+                inner_len = 0
+            end if
+
+            call process_latex_in_text(inner_raw(1:inner_len), inner_processed, processed_len)
+            if (processed_len > 0) then
+                result_text(out_pos:out_pos + processed_len - 1) = &
+                    inner_processed(1:processed_len)
+                out_pos = out_pos + processed_len
+            end if
+
+            next_i = j + 1
+        else
+            ! Unbraced form: \sqrt x -> radical + next char
+            inner_len = 1
+            inner_raw(1:1) = input_text(after_cmd:after_cmd)
+            call process_latex_in_text(inner_raw(1:inner_len), inner_processed, processed_len)
+            if (processed_len > 0) then
+                result_text(out_pos:out_pos + processed_len - 1) = &
+                    inner_processed(1:processed_len)
+                out_pos = out_pos + processed_len
+            end if
+            next_i = after_cmd + 1
+        end if
+    end subroutine process_sqrt_block
 
 end module fortplot_latex_parser

--- a/test/test_latex_sqrt_conversion.f90
+++ b/test/test_latex_sqrt_conversion.f90
@@ -1,0 +1,213 @@
+program test_latex_sqrt_conversion
+    !! Test that \sqrt{...} is converted to Unicode radical in process_latex_in_text
+    use fortplot_latex_parser
+    use fortplot_unicode
+    implicit none
+
+    call test_sqrt_basic()
+    call test_sqrt_with_nested_latex()
+    call test_sqrt_in_legend_label()
+    call test_sqrt_no_braces()
+    call test_sqrt_nested_braces()
+    call test_sqrt_empty_braces()
+
+    print *, "All sqrt conversion tests passed!"
+
+contains
+
+    subroutine test_sqrt_basic()
+        character(len=200) :: result_text
+        integer :: result_len, codepoint
+
+        call process_latex_in_text('\sqrt{x}', result_text, result_len)
+
+        if (result_len < 3) then
+            print *, 'FAIL: test_sqrt_basic - result too short'
+            stop 1
+        end if
+
+        ! First character should be Unicode radical (U+221A = 8730)
+        codepoint = utf8_to_codepoint(result_text, 1)
+        if (codepoint /= 8730) then
+            print *, 'FAIL: test_sqrt_basic - expected radical codepoint 8730, got', codepoint
+            stop 1
+        end if
+
+        ! Should not contain literal \sqrt
+        if (index(result_text(1:result_len), 'sqrt') /= 0) then
+            print *, 'FAIL: test_sqrt_basic - literal sqrt still present'
+            stop 1
+        end if
+
+        ! Check that 'x' appears in the result
+        if (index(result_text(1:result_len), 'x') == 0) then
+            print *, 'FAIL: test_sqrt_basic - x not found in result'
+            stop 1
+        end if
+
+        ! Result should be exactly radical + x (4 bytes, no stray braces)
+        if (result_len /= 4) then
+            print *, 'FAIL: test_sqrt_basic - expected 4 bytes, got', result_len
+            stop 1
+        end if
+
+        print *, 'test_sqrt_basic: PASSED'
+    end subroutine
+
+    subroutine test_sqrt_with_nested_latex()
+        character(len=4096) :: result_text
+        integer :: result_len, codepoint, pos
+
+        call process_latex_in_text('\sqrt{2\pi\sigma^2}', result_text, result_len)
+
+        if (result_len < 3) then
+            print *, 'FAIL: test_sqrt_with_nested_latex - result too short'
+            stop 1
+        end if
+
+        ! First character should be Unicode radical
+        codepoint = utf8_to_codepoint(result_text, 1)
+        if (codepoint /= 8730) then
+            print *, 'FAIL: test_sqrt_with_nested_latex - expected radical, got', codepoint
+            stop 1
+        end if
+
+        ! Inner content should have \pi and \sigma converted
+        if (index(result_text(1:result_len), '\pi') /= 0) then
+            print *, 'FAIL: test_sqrt_with_nested_latex - \pi not converted inside sqrt'
+            stop 1
+        end if
+
+        if (index(result_text(1:result_len), '\sigma') /= 0) then
+            print *, 'FAIL: test_sqrt_with_nested_latex - \sigma not converted inside sqrt'
+            stop 1
+        end if
+
+        ! Braces should be stripped
+        if (index(result_text(1:result_len), '{') /= 0) then
+            print *, 'FAIL: test_sqrt_with_nested_latex - braces not stripped'
+            stop 1
+        end if
+
+        print *, 'test_sqrt_with_nested_latex: PASSED'
+    end subroutine
+
+    subroutine test_sqrt_in_legend_label()
+        character(len=4096) :: result_text
+        integer :: result_len, codepoint
+
+        ! Simulate the exact label from the unicode_demo example
+        call process_latex_in_text( &
+            'Gaussian: \rho(\xi) = e^{-\xi^2/2\sigma^2}/\sqrt{2\pi\sigma^2}', &
+            result_text, result_len)
+
+        if (result_len < 10) then
+            print *, 'FAIL: test_sqrt_in_legend_label - result too short'
+            stop 1
+        end if
+
+        ! Should contain radical symbol
+        if (index(result_text(1:result_len), achar(226)//achar(136)//achar(154)) == 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - radical symbol not found'
+            stop 1
+        end if
+
+        ! Should NOT contain literal \sqrt
+        if (index(result_text(1:result_len), '\sqrt') /= 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - literal \sqrt still present'
+            stop 1
+        end if
+
+        ! Greek letters should be converted
+        if (index(result_text(1:result_len), '\rho') /= 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - \rho not converted'
+            stop 1
+        end if
+
+        if (index(result_text(1:result_len), '\xi') /= 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - \xi not converted'
+            stop 1
+        end if
+
+        if (index(result_text(1:result_len), '\sigma') /= 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - \sigma not converted'
+            stop 1
+        end if
+
+        if (index(result_text(1:result_len), '\pi') /= 0) then
+            print *, 'FAIL: test_sqrt_in_legend_label - \pi not converted'
+            stop 1
+        end if
+
+        print *, 'test_sqrt_in_legend_label: PASSED'
+    end subroutine
+
+    subroutine test_sqrt_no_braces()
+        character(len=200) :: result_text
+        integer :: result_len, codepoint
+
+        ! \sqrt without braces: should convert to radical + single next char
+        call process_latex_in_text('\sqrt x', result_text, result_len)
+
+        if (result_len < 3) then
+            print *, 'FAIL: test_sqrt_no_braces - result too short'
+            stop 1
+        end if
+
+        codepoint = utf8_to_codepoint(result_text, 1)
+        if (codepoint /= 8730) then
+            print *, 'FAIL: test_sqrt_no_braces - expected radical, got', codepoint
+            stop 1
+        end if
+
+        print *, 'test_sqrt_no_braces: PASSED'
+    end subroutine
+
+    subroutine test_sqrt_nested_braces()
+        character(len=4096) :: result_text
+        integer :: result_len, codepoint
+
+        ! \sqrt with nested braces
+        call process_latex_in_text('\sqrt{a_{b}}', result_text, result_len)
+
+        if (result_len < 3) then
+            print *, 'FAIL: test_sqrt_nested_braces - result too short'
+            stop 1
+        end if
+
+        codepoint = utf8_to_codepoint(result_text, 1)
+        if (codepoint /= 8730) then
+            print *, 'FAIL: test_sqrt_nested_braces - expected radical, got', codepoint
+            stop 1
+        end if
+
+        ! Inner braces should be preserved
+        if (index(result_text(1:result_len), '{') == 0) then
+            print *, 'FAIL: test_sqrt_nested_braces - inner braces stripped'
+            stop 1
+        end if
+
+        print *, 'test_sqrt_nested_braces: PASSED'
+    end subroutine
+
+    subroutine test_sqrt_empty_braces()
+        character(len=200) :: result_text
+        integer :: result_len, codepoint
+
+        call process_latex_in_text('\sqrt{}', result_text, result_len)
+
+        if (result_len < 3) then
+            print *, 'FAIL: test_sqrt_empty_braces - result too short'
+            stop 1
+        end if
+
+        codepoint = utf8_to_codepoint(result_text, 1)
+        if (codepoint /= 8730) then
+            print *, 'FAIL: test_sqrt_empty_braces - expected radical, got', codepoint
+            stop 1
+        end if
+
+        print *, 'test_sqrt_empty_braces: PASSED'
+    end subroutine
+
+end program test_latex_sqrt_conversion


### PR DESCRIPTION
## Summary

Fix `\sqrt{}` LaTeX command rendering as literal text in legend entries and other non-math-mode contexts.

**Root cause**: The `process_latex_in_text` function in `fortplot_latex_parser.f90` only handled Greek letter commands (`\alpha`, `\pi`, etc.). When it encountered `\sqrt`, the command was unrecognized and passed through literally as `\sqrt{...}`.

**Fix**: Added `\sqrt` handling to `process_latex_in_text` that:
- Converts `\sqrt{content}` to Unicode radical symbol √ (U+221A) + processed inner content (braces stripped)
- Handles `\sqrt x` (no braces) by taking the next single character
- Recursively processes inner content to resolve nested LaTeX commands (e.g., `\sqrt{2\pi\sigma^2}` → `√2πσ²`)
- Properly handles nested braces

## Changes

- `src/utilities/text/fortplot_latex_parser.f90`: Added `process_sqrt_block` recursive subroutine and `\sqrt` dispatch in `process_latex_in_text`
- `test/test_latex_sqrt_conversion.f90`: New test covering basic sqrt, nested LaTeX, legend label simulation, no-brace form, nested braces, and empty braces

## Verification

### Test passes after fix

```
$ fpm test --target test_latex_sqrt_conversion
 test_sqrt_basic: PASSED
 test_sqrt_with_nested_latex: PASSED
 test_sqrt_in_legend_label: PASSED
 test_sqrt_no_braces: PASSED
 test_sqrt_nested_braces: PASSED
 test_sqrt_empty_braces: PASSED
 All sqrt conversion tests passed!
```

### No regression in existing tests

```
$ fpm test --target test_latex_command_parser
 All LaTeX command parser tests passed!

$ fpm test --target test_latex_to_unicode_mapping
 All LaTeX to Unicode mapping tests passed!
```

Full test suite: all tests pass, zero failures.

### Artifact verification

unicode_demo example produces correct output:
- ASCII: `sqrt2pisigma2` (√ mapped to ASCII `sqrt` by backend, confirming conversion occurred)
- PDF: Greek letters and radical render correctly; no literal `\sqrt` in output
- Before fix: legend showed `\sqrt{2*pi*sigma^2}` as literal backslash-sqrt text