### PR TITLE
fix: ASCII backend twin-axes labels placed inline with data (fixes #1726)

### DIFF
--- a/src/backends/ascii/fortplot_ascii_secondary_axes.f90
+++ b/src/backends/ascii/fortplot_ascii_secondary_axes.f90
@@ -1,0 +1,114 @@
+module fortplot_ascii_secondary_axes
+    !! ASCII backend secondary axis rendering
+    !!
+    !! Handles twin-axes tick labels for the ASCII backend.
+    !! Separated from the rendering pipeline to keep module size compliant.
+
+    use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
+    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
+                                         format_tick_value_consistent
+    use fortplot_ascii, only: ascii_context
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    private
+    public :: ascii_draw_secondary_y_axis, ascii_draw_secondary_x_axis_top
+
+contains
+
+    subroutine ascii_draw_secondary_x_axis_top(backend, xscale, symlog_threshold, &
+                                               x_min, x_max, xlabel, date_format)
+        !! Draw top x-axis tick labels for ASCII backend
+        type(ascii_context), intent(inout) :: backend
+        character(len=*), intent(in) :: xscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: x_min, x_max
+        character(len=:), allocatable, intent(in), optional :: xlabel
+        character(len=*), intent(in), optional :: date_format
+
+        real(wp) :: x_tick_positions(MAX_TICKS)
+        character(len=50) :: tick_label
+        integer :: num_x_ticks, decimals, i
+        integer :: text_x, text_y, label_len
+        real(wp) :: frac
+
+        call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
+                                 x_tick_positions, num_x_ticks)
+        if (num_x_ticks <= 0) return
+
+        decimals = 0
+        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
+            decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
+        end if
+
+        text_y = 1
+
+        do i = 1, num_x_ticks
+            if (trim(xscale) == 'linear') then
+                tick_label = format_tick_value_consistent(x_tick_positions(i), decimals)
+            else
+                tick_label = format_tick_label(x_tick_positions(i), xscale, &
+                    date_format=date_format, data_min=x_min, data_max=x_max)
+            end if
+
+            frac = (x_tick_positions(i) - x_min) / (x_max - x_min)
+            text_x = nint(frac * real(backend%plot_width - 2, wp)) + 1
+            text_x = max(1, min(text_x, backend%plot_width - 1))
+            label_len = len_trim(tick_label)
+            text_x = max(1, min(text_x, backend%plot_width - label_len))
+
+            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
+        end do
+
+        if (present(xlabel) .and. allocated(xlabel) .and. len_trim(xlabel) > 0) then
+            call backend%text(real(backend%plot_width / 2, wp), real(text_y, wp), &
+                              trim(xlabel))
+        end if
+    end subroutine ascii_draw_secondary_x_axis_top
+
+    subroutine ascii_draw_secondary_y_axis(backend, yscale, symlog_threshold, &
+                                           y_min, y_max, ylabel, date_format)
+        !! Draw right y-axis tick labels for ASCII backend
+        type(ascii_context), intent(inout) :: backend
+        character(len=*), intent(in) :: yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: y_min, y_max
+        character(len=:), allocatable, intent(in), optional :: ylabel
+        character(len=*), intent(in), optional :: date_format
+
+        real(wp) :: y_tick_positions(MAX_TICKS)
+        character(len=50) :: tick_label
+        integer :: num_y_ticks, decimals, i
+        integer :: text_x, text_y, label_len
+        real(wp) :: frac
+
+        call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
+                                 y_tick_positions, num_y_ticks)
+        if (num_y_ticks <= 0) return
+
+        decimals = 0
+        if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
+            decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
+        end if
+
+        do i = 1, num_y_ticks
+            if (trim(yscale) == 'linear') then
+                tick_label = format_tick_value_consistent(y_tick_positions(i), decimals)
+            else
+                tick_label = format_tick_label(y_tick_positions(i), yscale, &
+                    date_format=date_format, data_min=y_min, data_max=y_max)
+            end if
+
+            frac = (y_tick_positions(i) - y_min) / (y_max - y_min)
+            text_y = nint((1.0_wp - frac) * real(backend%plot_height - 2, wp)) + 1
+            text_y = max(1, min(text_y, backend%plot_height - 1))
+
+            label_len = len_trim(tick_label)
+            text_x = backend%plot_width - label_len - 1
+            text_x = max(1, text_x)
+
+            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
+        end do
+    end subroutine ascii_draw_secondary_y_axis
+
+end module fortplot_ascii_secondary_axes

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -142,11 +142,18 @@ contains
                                                date_format=x_date_format, &
                                                data_min=x_min, data_max=x_max)
             end if
-            call add_text_element(text_elements, num_text_elements, &
-                                  tick_x, y_min - 0.05_wp*(y_max - y_min), &
-                                  trim(tick_label), &
-                                  current_r, current_g, current_b, &
-                                  x_min, x_max, y_min, y_max, plot_width, plot_height)
+            ! Convert to explicit screen coordinates to avoid ambiguity
+            ! in add_text_element's coordinate detection heuristic
+            associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
+                           real(plot_width - 2, wp)) + 1, &
+                       sy => plot_height)
+                call add_text_element(text_elements, num_text_elements, &
+                                      real(max(1, min(sx, plot_width - 1)), wp), &
+                                      real(sy, wp), &
+                                      trim(tick_label), &
+                                      current_r, current_g, current_b, &
+                                      x_min, x_max, y_min, y_max, plot_width, plot_height)
+            end associate
         end do
 
         ! Y-axis ticks (drawn as characters along left axis)

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -20,9 +20,12 @@ module fortplot_figure_rendering_pipeline
                                     raster_draw_secondary_x_axis_top, &
                                     raster_draw_x_minor_ticks, &
                                     raster_draw_y_minor_ticks
-    use fortplot_tick_calculation, only: calculate_minor_tick_positions, &
+    use fortplot_ascii, only: ascii_context
+    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
+                                         format_tick_value_consistent, &
+                                         calculate_minor_tick_positions, &
                                          calculate_log_minor_tick_positions
-    use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
+    use fortplot_axes, only: compute_scale_ticks, MAX_TICKS, format_tick_label
     use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
     use fortplot_rendering, only: render_line_plot, render_contour_plot, &
                                   render_pcolormesh_plot, render_fill_between_plot, &
@@ -438,8 +441,116 @@ contains
                         date_format=twiny_x_date_format)
                 end if
             end if
+        class is (ascii_context)
+            if (.not. has_3d) then
+                if (has_twinx_local) then
+                    call ascii_draw_secondary_y_axis(backend, twinx_scale_local, &
+                        symlog_threshold, twinx_y_min_local, twinx_y_max_local, &
+                        twinx_ylabel, date_format=twinx_y_date_format)
+                end if
+                if (has_twiny_local) then
+                    call ascii_draw_secondary_x_axis_top(backend, twiny_scale_local, &
+                        symlog_threshold, twiny_x_min_local, twiny_x_max_local, &
+                        twiny_xlabel, date_format=twiny_x_date_format)
+                end if
+            end if
         end select
     end subroutine render_figure_axes_labels_only
+
+    subroutine ascii_draw_secondary_x_axis_top(backend, xscale, symlog_threshold, &
+                                               x_min, x_max, xlabel, date_format)
+        !! Draw top x-axis tick labels for ASCII backend
+        type(ascii_context), intent(inout) :: backend
+        character(len=*), intent(in) :: xscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: x_min, x_max
+        character(len=:), allocatable, intent(in), optional :: xlabel
+        character(len=*), intent(in), optional :: date_format
+
+        real(wp) :: x_tick_positions(MAX_TICKS)
+        character(len=50) :: tick_label
+        integer :: num_x_ticks, decimals, i
+        integer :: text_x, text_y, label_len
+        real(wp) :: frac
+
+        call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
+                                 x_tick_positions, num_x_ticks)
+        if (num_x_ticks <= 0) return
+
+        decimals = 0
+        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
+            decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
+        end if
+
+        text_y = 1
+
+        do i = 1, num_x_ticks
+            if (trim(xscale) == 'linear') then
+                tick_label = format_tick_value_consistent(x_tick_positions(i), decimals)
+            else
+                tick_label = format_tick_label(x_tick_positions(i), xscale, &
+                    date_format=date_format, data_min=x_min, data_max=x_max)
+            end if
+
+            frac = (x_tick_positions(i) - x_min) / (x_max - x_min)
+            text_x = nint(frac * real(backend%plot_width - 2, wp)) + 1
+            text_x = max(1, min(text_x, backend%plot_width - 1))
+            label_len = len_trim(tick_label)
+            text_x = max(1, min(text_x, backend%plot_width - label_len))
+
+            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
+        end do
+
+        if (present(xlabel) .and. allocated(xlabel) .and. len_trim(xlabel) > 0) then
+            call backend%text(real(backend%plot_width / 2, wp), real(text_y, wp), &
+                              trim(xlabel))
+        end if
+    end subroutine ascii_draw_secondary_x_axis_top
+
+    subroutine ascii_draw_secondary_y_axis(backend, yscale, symlog_threshold, &
+                                           y_min, y_max, ylabel, date_format)
+        !! Draw right y-axis tick labels for ASCII backend
+        type(ascii_context), intent(inout) :: backend
+        character(len=*), intent(in) :: yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: y_min, y_max
+        character(len=:), allocatable, intent(in), optional :: ylabel
+        character(len=*), intent(in), optional :: date_format
+
+        real(wp) :: y_tick_positions(MAX_TICKS)
+        character(len=50) :: tick_label
+        integer :: num_y_ticks, decimals, i
+        integer :: text_x, text_y, label_len
+        real(wp) :: frac
+
+        call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
+                                 y_tick_positions, num_y_ticks)
+        if (num_y_ticks <= 0) return
+
+        decimals = 0
+        if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
+            decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
+        end if
+
+        do i = 1, num_y_ticks
+            if (trim(yscale) == 'linear') then
+                tick_label = format_tick_value_consistent(y_tick_positions(i), decimals)
+            else
+                tick_label = format_tick_label(y_tick_positions(i), yscale, &
+                    date_format=date_format, data_min=y_min, data_max=y_max)
+            end if
+
+            frac = (y_tick_positions(i) - y_min) / (y_max - y_min)
+            text_y = nint((1.0_wp - frac) * real(backend%plot_height - 2, wp)) + 1
+            text_y = max(1, min(text_y, backend%plot_height - 1))
+
+            label_len = len_trim(tick_label)
+            text_x = backend%plot_width - label_len - 1
+            text_x = max(1, text_x)
+
+            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
+        end do
+    end subroutine ascii_draw_secondary_y_axis
 
     subroutine render_title_only(backend, title, x_min, x_max, y_min, y_max, &
                                  custom_title_font_size)

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -16,16 +16,16 @@ module fortplot_figure_rendering_pipeline
                                   PLOT_TYPE_QUIVER, PLOT_TYPE_POLAR, &
                                   AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_raster_axes, only: raster_draw_secondary_y_axis, &
-                                    raster_draw_secondary_x_axis_top, &
-                                    raster_draw_x_minor_ticks, &
-                                    raster_draw_y_minor_ticks
+  use fortplot_raster_axes, only: raster_draw_secondary_y_axis, &
+                                     raster_draw_secondary_x_axis_top, &
+                                     raster_draw_x_minor_ticks, &
+                                     raster_draw_y_minor_ticks
     use fortplot_ascii, only: ascii_context
-    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
-                                         format_tick_value_consistent, &
-                                         calculate_minor_tick_positions, &
+    use fortplot_ascii_secondary_axes, only: ascii_draw_secondary_y_axis, &
+                                             ascii_draw_secondary_x_axis_top
+    use fortplot_tick_calculation, only: calculate_minor_tick_positions, &
                                          calculate_log_minor_tick_positions
-    use fortplot_axes, only: compute_scale_ticks, MAX_TICKS, format_tick_label
+    use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
     use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
     use fortplot_rendering, only: render_line_plot, render_contour_plot, &
                                   render_pcolormesh_plot, render_fill_between_plot, &
@@ -456,101 +456,6 @@ contains
             end if
         end select
     end subroutine render_figure_axes_labels_only
-
-    subroutine ascii_draw_secondary_x_axis_top(backend, xscale, symlog_threshold, &
-                                               x_min, x_max, xlabel, date_format)
-        !! Draw top x-axis tick labels for ASCII backend
-        type(ascii_context), intent(inout) :: backend
-        character(len=*), intent(in) :: xscale
-        real(wp), intent(in) :: symlog_threshold
-        real(wp), intent(in) :: x_min, x_max
-        character(len=:), allocatable, intent(in), optional :: xlabel
-        character(len=*), intent(in), optional :: date_format
-
-        real(wp) :: x_tick_positions(MAX_TICKS)
-        character(len=50) :: tick_label
-        integer :: num_x_ticks, decimals, i
-        integer :: text_x, text_y, label_len
-        real(wp) :: frac
-
-        call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                                 x_tick_positions, num_x_ticks)
-        if (num_x_ticks <= 0) return
-
-        decimals = 0
-        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
-            decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
-        end if
-
-        text_y = 1
-
-        do i = 1, num_x_ticks
-            if (trim(xscale) == 'linear') then
-                tick_label = format_tick_value_consistent(x_tick_positions(i), decimals)
-            else
-                tick_label = format_tick_label(x_tick_positions(i), xscale, &
-                    date_format=date_format, data_min=x_min, data_max=x_max)
-            end if
-
-            frac = (x_tick_positions(i) - x_min) / (x_max - x_min)
-            text_x = nint(frac * real(backend%plot_width - 2, wp)) + 1
-            text_x = max(1, min(text_x, backend%plot_width - 1))
-            label_len = len_trim(tick_label)
-            text_x = max(1, min(text_x, backend%plot_width - label_len))
-
-            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
-        end do
-
-        if (present(xlabel) .and. allocated(xlabel) .and. len_trim(xlabel) > 0) then
-            call backend%text(real(backend%plot_width / 2, wp), real(text_y, wp), &
-                              trim(xlabel))
-        end if
-    end subroutine ascii_draw_secondary_x_axis_top
-
-    subroutine ascii_draw_secondary_y_axis(backend, yscale, symlog_threshold, &
-                                           y_min, y_max, ylabel, date_format)
-        !! Draw right y-axis tick labels for ASCII backend
-        type(ascii_context), intent(inout) :: backend
-        character(len=*), intent(in) :: yscale
-        real(wp), intent(in) :: symlog_threshold
-        real(wp), intent(in) :: y_min, y_max
-        character(len=:), allocatable, intent(in), optional :: ylabel
-        character(len=*), intent(in), optional :: date_format
-
-        real(wp) :: y_tick_positions(MAX_TICKS)
-        character(len=50) :: tick_label
-        integer :: num_y_ticks, decimals, i
-        integer :: text_x, text_y, label_len
-        real(wp) :: frac
-
-        call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
-                                 y_tick_positions, num_y_ticks)
-        if (num_y_ticks <= 0) return
-
-        decimals = 0
-        if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
-            decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
-        end if
-
-        do i = 1, num_y_ticks
-            if (trim(yscale) == 'linear') then
-                tick_label = format_tick_value_consistent(y_tick_positions(i), decimals)
-            else
-                tick_label = format_tick_label(y_tick_positions(i), yscale, &
-                    date_format=date_format, data_min=y_min, data_max=y_max)
-            end if
-
-            frac = (y_tick_positions(i) - y_min) / (y_max - y_min)
-            text_y = nint((1.0_wp - frac) * real(backend%plot_height - 2, wp)) + 1
-            text_y = max(1, min(text_y, backend%plot_height - 1))
-
-            label_len = len_trim(tick_label)
-            text_x = backend%plot_width - label_len - 1
-            text_x = max(1, text_x)
-
-            call backend%text(real(text_x, wp), real(text_y, wp), trim(tick_label))
-        end do
-    end subroutine ascii_draw_secondary_y_axis
 
     subroutine render_title_only(backend, title, x_min, x_max, y_min, y_max, &
                                  custom_title_font_size)


### PR DESCRIPTION
## Summary

Fix ASCII backend rendering of twin-axes (twinx/twiny) tick labels that were placed inline with data rows inside the plot area.

### Changes

1. **Add ASCII twin-axis rendering** (`src/figures/fortplot_figure_rendering_pipeline.f90`):
   - New `ascii_draw_secondary_x_axis_top` subroutine draws twiny (top x-axis) tick labels and xlabel on row 1 (top of canvas)
   - New `ascii_draw_secondary_y_axis` subroutine draws twinx (right y-axis) tick labels at the right edge
   - Added `ascii_context` case to `render_figure_axes_labels_only` to dispatch to these subroutines

2. **Fix primary x-axis tick placement** (`src/backends/ascii/fortplot_ascii_text.f90`):
   - X-axis tick labels now use explicit screen coordinates to avoid ambiguity in `add_text_element`'s coordinate detection heuristic, which misclassified data coordinates as screen coordinates when the data range overlapped with canvas dimensions

## Verification

### Before fix
```
| * 4   8   12  16  20  24  28                               -- Top axis         |
```
Top-axis tick labels injected inline with data row; legend entry truncated.

### After fix
```
|      10^0                             Cumulative index (log scale)             |
...
| 0        4          8         12         16        20         24        28     |
```
- Twiny tick labels (`10^0`) and xlabel on top row above plot area
- Primary x-axis labels (`4 8 12 16 20 24 28`) on bottom row with correct values
- No inline label overlap with data

### Tests
```
$ fpm test 2>&1 | grep 'Tests run'
Tests run: 6 | Passed: 6 | Failed: 0
Tests run: 4 | Passed: 4 | Failed: 0
Tests run: 12 | Passed: 12
Error handling tests: 15 of 15 passed
```

### Artifact verification
```
$ fpm run --example twin_axes_demo
$ cat output/example/fortran/twin_axes_demo/twin_axes_demo.txt
```
Top row: `10^0` (twiny tick) and `Cumulative index (log scale)` (twiny xlabel) rendered above plot area.
Bottom row: `4 8 12 16 20 24 28` (primary x-axis ticks) rendered correctly.