### PR TITLE
fix: Polar default theta offset is pi/2, matplotlib default is 0 (fixes #1742)

### DIFF
--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -944,7 +944,7 @@ contains
         radius = min(x_max - x_min, y_max - y_min)*0.45_wp
 
         ! Get polar configuration from state
-        theta_offset = 1.5707963267948966_wp  ! pi/2
+        theta_offset = 0.0_wp  ! 0 deg at east (matplotlib)
         clockwise = .false.
         if (present(state)) then
             theta_offset = state%polar_theta_offset

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -154,7 +154,7 @@ module fortplot_figure_initialization
         integer :: polar_theta_gridlines = 12   ! Default: 30-degree intervals
         integer :: polar_r_gridlines = 5        ! Default: 5 radial circles
         logical :: polar_theta_direction_cw = .false.  ! Counter-clockwise default
-        real(wp) :: polar_theta_offset = 1.5707963267948966_wp  ! pi/2 = 90deg (top)
+        real(wp) :: polar_theta_offset = 0.0_wp  ! 0 deg at east (matplotlib)
     end type figure_state_t
 
 contains
@@ -360,7 +360,7 @@ contains
         state%polar_theta_gridlines = 12
         state%polar_r_gridlines = 5
         state%polar_theta_direction_cw = .false.
-        state%polar_theta_offset = 1.5707963267948966_wp
+        state%polar_theta_offset = 0.0_wp
     end subroutine reset_state_for_initialization
 
     subroutine reset_figure_state(state)
@@ -457,7 +457,7 @@ contains
         state%polar_theta_gridlines = 12
         state%polar_r_gridlines = 5
         state%polar_theta_direction_cw = .false.
-        state%polar_theta_offset = 1.5707963267948966_wp
+        state%polar_theta_offset = 0.0_wp
     end subroutine reset_figure_state
 
     subroutine ensure_figure_storage(plots, state)

--- a/src/utilities/fortplot_polar.f90
+++ b/src/utilities/fortplot_polar.f90
@@ -24,7 +24,7 @@ contains
         !! Convert single polar coordinate to Cartesian
         !! theta: angle in radians
         !! r: radius
-        !! theta_offset: angular offset (default: pi/2 = 90 deg, 0 at top)
+        !! theta_offset: angular offset (default: 0, 0 at east)
         !! clockwise: if true, angles increase clockwise
         real(wp), intent(in) :: theta, r
         real(wp), intent(out) :: x, y
@@ -34,7 +34,7 @@ contains
         real(wp) :: effective_theta, offset
         logical :: cw
 
-        offset = 0.5_wp*PI  ! Default: 0 deg at top (mathematical convention)
+        offset = 0.0_wp  ! Default: 0 deg at east (matplotlib convention)
         if (present(theta_offset)) offset = theta_offset
 
         cw = .false.

--- a/test/test_polar_theta_offset.f90
+++ b/test/test_polar_theta_offset.f90
@@ -1,0 +1,132 @@
+program test_polar_theta_offset
+    !! Verify polar_to_cartesian uses theta_offset=0 by default (matplotlib compat)
+    !! Issue #1742: polar default theta_offset was pi/2 (0 at top) instead of 0 (0 at east)
+    use fortplot_polar, only: polar_to_cartesian, PI, TWO_PI
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    real(wp) :: x, y
+    real(wp), parameter :: tol = 1.0e-10_wp
+    integer :: test_count = 0, passed_count = 0
+    logical :: all_pass = .true.
+
+    call test_default_offset_zero()
+    call test_pi_over_two()
+    call test_pi()
+    call test_three_pi_over_two()
+    call test_custom_offset()
+
+    write(*, '(/A)') '=== Test Summary ==='
+    write(*, '(A, I0, A, I0)') 'Passed: ', passed_count, ' / ', test_count
+
+    if (all_pass) then
+        write(*, '(A)') 'PASS: All tests PASSED'
+    else
+        write(*, '(A)') 'FAIL: Some tests FAILED'
+        error stop 1
+    end if
+
+contains
+
+    subroutine test_default_offset_zero()
+        !! (theta=0, r=1) with default offset => (1, 0) i.e. east
+        real(wp) :: dx, dy
+
+        call polar_to_cartesian(0.0_wp, 1.0_wp, x, y)
+
+        dx = abs(x - 1.0_wp)
+        dy = abs(y - 0.0_wp)
+
+        test_count = test_count + 1
+        if (dx < tol .and. dy < tol) then
+            passed_count = passed_count + 1
+            write(*, '(A)') 'PASS: theta=0, r=1 => (1, 0) [east]'
+        else
+            all_pass = .false.
+            write(*, '(A, F12.6, A, F12.6, A)') &
+                'FAIL: theta=0, r=1 => (', x, ', ', y, ') expected (1, 0)'
+        end if
+    end subroutine
+
+    subroutine test_pi_over_two()
+        !! (theta=pi/2, r=1) with default offset => (0, 1) i.e. north
+        real(wp) :: dx, dy
+
+        call polar_to_cartesian(0.5_wp*PI, 1.0_wp, x, y)
+
+        dx = abs(x - 0.0_wp)
+        dy = abs(y - 1.0_wp)
+
+        test_count = test_count + 1
+        if (dx < tol .and. dy < tol) then
+            passed_count = passed_count + 1
+            write(*, '(A)') 'PASS: theta=pi/2, r=1 => (0, 1) [north]'
+        else
+            all_pass = .false.
+            write(*, '(A, F12.6, A, F12.6, A)') &
+                'FAIL: theta=pi/2, r=1 => (', x, ', ', y, ') expected (0, 1)'
+        end if
+    end subroutine
+
+    subroutine test_pi()
+        !! (theta=pi, r=1) => (-1, 0) i.e. west
+        real(wp) :: dx, dy
+
+        call polar_to_cartesian(PI, 1.0_wp, x, y)
+
+        dx = abs(x - (-1.0_wp))
+        dy = abs(y - 0.0_wp)
+
+        test_count = test_count + 1
+        if (dx < tol .and. dy < tol) then
+            passed_count = passed_count + 1
+            write(*, '(A)') 'PASS: theta=pi, r=1 => (-1, 0) [west]'
+        else
+            all_pass = .false.
+            write(*, '(A, F12.6, A, F12.6, A)') &
+                'FAIL: theta=pi, r=1 => (', x, ', ', y, ') expected (-1, 0)'
+        end if
+    end subroutine
+
+    subroutine test_three_pi_over_two()
+        !! (theta=3pi/2, r=1) => (0, -1) i.e. south
+        real(wp) :: dx, dy
+
+        call polar_to_cartesian(1.5_wp*PI, 1.0_wp, x, y)
+
+        dx = abs(x - 0.0_wp)
+        dy = abs(y - (-1.0_wp))
+
+        test_count = test_count + 1
+        if (dx < tol .and. dy < tol) then
+            passed_count = passed_count + 1
+            write(*, '(A)') 'PASS: theta=3pi/2, r=1 => (0, -1) [south]'
+        else
+            all_pass = .false.
+            write(*, '(A, F12.6, A, F12.6, A)') &
+                'FAIL: theta=3pi/2, r=1 => (', x, ', ', y, ') expected (0, -1)'
+        end if
+    end subroutine
+
+    subroutine test_custom_offset()
+        !! Explicit theta_offset=pi/2 gives old behavior: theta=0 => (0, 1)
+        real(wp) :: dx, dy
+
+        call polar_to_cartesian(0.0_wp, 1.0_wp, x, y, &
+                                theta_offset=0.5_wp*PI)
+
+        dx = abs(x - 0.0_wp)
+        dy = abs(y - 1.0_wp)
+
+        test_count = test_count + 1
+        if (dx < tol .and. dy < tol) then
+            passed_count = passed_count + 1
+            write(*, '(A)') 'PASS: custom offset=pi/2, theta=0 => (0, 1) [top]'
+        else
+            all_pass = .false.
+            write(*, '(A, F12.6, A, F12.6, A)') &
+                'FAIL: custom offset=pi/2, theta=0 => (', x, ', ', y, ') expected (0, 1)'
+        end if
+    end subroutine
+
+end program test_polar_theta_offset


### PR DESCRIPTION
## Summary
- Change default `polar_theta_offset` from `pi/2` (theta=0 at top/north) to `0` (theta=0 at east/right) to match matplotlib polar projection defaults
- Eliminates 90-degree CCW rotation mismatch when porting polar plots from matplotlib

## Changes
- `src/utilities/fortplot_polar.f90`: default `offset` from `0.5*PI` to `0.0`
- `src/figures/management/fortplot_figure_initialization.f90`: default `polar_theta_offset` from `pi/2` to `0` in type declaration and two reset subroutines
- `test/test_polar_theta_offset.f90`: new test verifying matplotlib-compatible defaults and backward-compatible custom offset

## Verification

### Test passes after fix
```
$ fpm test --target test_polar_theta_offset
PASS: theta=0, r=1 => (1, 0) [east]
PASS: theta=pi/2, r=1 => (0, 1) [north]
PASS: theta=pi, r=1 => (-1, 0) [west]
PASS: theta=3pi/2, r=1 => (0, -1) [south]
PASS: custom offset=pi/2, theta=0 => (0, 1) [top]

=== Test Summary ===
Passed: 5 / 5
PASS: All tests PASSED
```

### CI-fast test suite passes
```
$ make test-ci
...
CI essential test suite completed successfully
```

### Existing polar tests pass
```
$ fpm test --target test_matplotlib_new_functions
PASS: polar() function works

$ fpm test --target test_pyplot_legacy_order
PASS: Pyplot positional wrappers remain OO-compatible
```

## Risk / Compatibility
Low. Behavior change affects polar plots only. Users relying on the old default can restore it via `theta_offset=pi/2`.