### PR TITLE
fix: convert_power_of_ten outputs empty string for 10^0 instead of 1 (fixes #1809)

### DIFF
--- a/src/backends/ascii/fortplot_ascii_mathtext.f90
+++ b/src/backends/ascii/fortplot_ascii_mathtext.f90
@@ -162,6 +162,7 @@ contains
                                 if (has_minus) then
                                     j = j + 1; output(j:j) = '-'
                                 end if
+                                j = j + 1; output(j:j) = '1'
                             else
                                 if (has_minus) then
                                     j = j + 1; output(j:j) = '-'

--- a/test/test_mathtext_power_of_ten.f90
+++ b/test/test_mathtext_power_of_ten.f90
@@ -1,0 +1,47 @@
+program test_mathtext_power_of_ten
+    !! Regression test for issue #1809: convert_power_of_ten outputs empty
+    !! string for 10^0 instead of 1.
+
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
+    implicit none
+
+    character(len=64) :: out
+    integer :: olen
+    integer :: fail_count
+
+    fail_count = 0
+
+    call check("$10^{0}$", "1", fail_count)
+    call check("$-10^{0}$", "-1", fail_count)
+    call check("$10^{3}$", "1e3", fail_count)
+    call check("$-10^{3}$", "-1e3", fail_count)
+    call check("$10^{-2}$", "1e-2", fail_count)
+    call check("$10^{00}$", "1", fail_count)
+    call check("$x10^{0}y$", "x1y", fail_count)
+    call check("$10^{10}$", "1e10", fail_count)
+
+    if (fail_count > 0) then
+        print *, "FAIL:", fail_count, "assertion(s) failed"
+        stop 1
+    end if
+
+    print *, "PASS: all sanitize_ascii_text mathtext cases correct"
+
+contains
+
+    subroutine check(input, expected, fails)
+        character(len=*), intent(in) :: input, expected
+        integer, intent(inout) :: fails
+
+        call sanitize_ascii_text(input, out, olen)
+        if (out(1:olen) /= expected) then
+            fails = fails + 1
+            print *, "FAIL: sanitize('" // trim(input) // &
+                     "') = '" // out(1:olen) // "', expected '" // &
+                     trim(expected) // "'"
+        else
+            print *, "PASS: '" // trim(input) // "' -> '" // out(1:olen) // "'"
+        end if
+    end subroutine check
+
+end program test_mathtext_power_of_ten


### PR DESCRIPTION
## Summary

Fix `convert_power_of_ten` in `src/backends/ascii/fortplot_ascii_mathtext.f90` which produced an empty string for `10^0` and just `-` for `-10^0`. Both now correctly output `1` and `-1`.

### Root cause
The `is_zero_exp` branch at line 161 stripped the exponent but only emitted a minus sign when `has_minus` was true, and emitted nothing otherwise. Missing `output(j:j) = '1'` in both cases.

### Fix
Added `j = j + 1; output(j:j) = '1'` in the `is_zero_exp` branch after the optional minus sign.

## Verification

### Test passes after fix
```
$ fpm test --target test_mathtext_power_of_ten
 PASS: '$10^{0}$' -> '1'
 PASS: '$-10^{0}$' -> '-1'
 PASS: '$10^{3}$' -> '1e3'
 PASS: '$-10^{3}$' -> '-1e3'
 PASS: '$10^{-2}$' -> '1e-2'
 PASS: '$10^{00}$' -> '1'
 PASS: '$x10^{0}y$' -> 'x1y'
 PASS: '$10^{10}$' -> '1e10'
 PASS: all sanitize_ascii_text mathtext cases correct
```

### Existing ASCII test still passes
```
$ fpm test --target test_ascii
 PASS: ASCII file created (        2216  bytes)
 PASS: ASCII content valid (          28  lines)
 ascii terminal plot created successfully!
```

### Requirement mapping
| Issue requirement | Evidence |
|---|---|
| `10^0` produces empty output (should be `1`) | Test `'$10^{0}$' -> '1'` passes |
| `-10^0` produces just `-` (should be `-1`) | Test `'$-10^{0}$' -> '-1'` passes |