### PR TITLE
refactor: eliminate DRY violation in set_xticks/set_yticks (fixes #1736)

### DIFF
--- a/src/figures/core/fortplot_figure_core_ticks.f90
+++ b/src/figures/core/fortplot_figure_core_ticks.f90
@@ -9,6 +9,155 @@ submodule (fortplot_figure_core) fortplot_figure_core_ticks
 
 contains
 
+    subroutine set_ticks_impl(self, axis, positions, labels)
+        !! Shared implementation for set_xticks and set_yticks
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: axis
+        real(wp), intent(in) :: positions(:)
+        character(len=*), intent(in), optional :: labels(:)
+
+        integer :: n, i
+
+        n = size(positions)
+        if (n == 0) then
+            select case (axis)
+            case (1)
+                call log_warning('set_xticks: empty positions array')
+            case (2)
+                call log_warning('set_yticks: empty positions array')
+            end select
+            return
+        end if
+
+        if (present(labels)) then
+            if (size(labels) /= n) then
+                select case (axis)
+                case (1)
+                    call log_error('set_xticks: labels array size must match positions')
+                case (2)
+                    call log_error('set_yticks: labels array size must match positions')
+                end select
+                return
+            end if
+        end if
+
+        select case (axis)
+        case (1)
+            if (allocated(self%state%custom_xtick_positions)) &
+                deallocate(self%state%custom_xtick_positions)
+            if (allocated(self%state%custom_xtick_labels)) &
+                deallocate(self%state%custom_xtick_labels)
+
+            allocate(self%state%custom_xtick_positions(n))
+            allocate(self%state%custom_xtick_labels(n))
+            self%state%custom_xtick_positions = positions
+
+            if (present(labels)) then
+                do i = 1, n
+                    self%state%custom_xtick_labels(i) = trim(labels(i))
+                end do
+            else
+                call auto_gen_labels(self%state%custom_xtick_labels, positions, n)
+            end if
+
+            self%state%custom_xticks_set = .true.
+        case (2)
+            if (allocated(self%state%custom_ytick_positions)) &
+                deallocate(self%state%custom_ytick_positions)
+            if (allocated(self%state%custom_ytick_labels)) &
+                deallocate(self%state%custom_ytick_labels)
+
+            allocate(self%state%custom_ytick_positions(n))
+            allocate(self%state%custom_ytick_labels(n))
+            self%state%custom_ytick_positions = positions
+
+            if (present(labels)) then
+                do i = 1, n
+                    self%state%custom_ytick_labels(i) = trim(labels(i))
+                end do
+            else
+                call auto_gen_labels(self%state%custom_ytick_labels, positions, n)
+            end if
+
+            self%state%custom_yticks_set = .true.
+        end select
+
+        self%state%rendered = .false.
+    end subroutine set_ticks_impl
+
+    subroutine set_tick_labels_impl(self, axis, labels)
+        !! Shared implementation for set_xtick_labels and set_ytick_labels
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: axis
+        character(len=*), intent(in) :: labels(:)
+
+        integer :: n, i
+
+        n = size(labels)
+        if (n == 0) then
+            select case (axis)
+            case (1)
+                call log_warning('set_xtick_labels: empty labels array')
+            case (2)
+                call log_warning('set_ytick_labels: empty labels array')
+            end select
+            return
+        end if
+
+        select case (axis)
+        case (1)
+            if (allocated(self%state%custom_xtick_labels)) &
+                deallocate(self%state%custom_xtick_labels)
+
+            allocate(self%state%custom_xtick_labels(n))
+            do i = 1, n
+                self%state%custom_xtick_labels(i) = trim(labels(i))
+            end do
+
+            if (.not. allocated(self%state%custom_xtick_positions)) then
+                allocate(self%state%custom_xtick_positions(n))
+                do i = 1, n
+                    self%state%custom_xtick_positions(i) = real(i, wp)
+                end do
+            end if
+
+            self%state%custom_xticks_set = .true.
+        case (2)
+            if (allocated(self%state%custom_ytick_labels)) &
+                deallocate(self%state%custom_ytick_labels)
+
+            allocate(self%state%custom_ytick_labels(n))
+            do i = 1, n
+                self%state%custom_ytick_labels(i) = trim(labels(i))
+            end do
+
+            if (.not. allocated(self%state%custom_ytick_positions)) then
+                allocate(self%state%custom_ytick_positions(n))
+                do i = 1, n
+                    self%state%custom_ytick_positions(i) = real(i, wp)
+                end do
+            end if
+
+            self%state%custom_yticks_set = .true.
+        end select
+
+        self%state%rendered = .false.
+    end subroutine set_tick_labels_impl
+
+    subroutine auto_gen_labels(labels_out, positions, n)
+        !! Generate numeric labels from tick positions
+        character(len=*), intent(out) :: labels_out(:)
+        real(wp), intent(in) :: positions(:)
+        integer, intent(in) :: n
+
+        integer :: i
+
+        do i = 1, n
+            write(labels_out(i), '(G12.5)') positions(i)
+            labels_out(i) = adjustl(labels_out(i))
+        end do
+    end subroutine auto_gen_labels
+
     module subroutine set_xticks(self, positions, labels)
         !! Set custom x-axis tick positions and optionally labels
         !! If only positions provided, numeric labels are auto-generated
@@ -17,45 +166,7 @@ contains
         real(wp), intent(in) :: positions(:)
         character(len=*), intent(in), optional :: labels(:)
 
-        integer :: n, i
-
-        n = size(positions)
-        if (n == 0) then
-            call log_warning('set_xticks: empty positions array')
-            return
-        end if
-
-        if (present(labels)) then
-            if (size(labels) /= n) then
-                call log_error('set_xticks: labels array size must match positions')
-                return
-            end if
-        end if
-
-        if (allocated(self%state%custom_xtick_positions)) &
-            deallocate(self%state%custom_xtick_positions)
-        if (allocated(self%state%custom_xtick_labels)) &
-            deallocate(self%state%custom_xtick_labels)
-
-        allocate(self%state%custom_xtick_positions(n))
-        allocate(self%state%custom_xtick_labels(n))
-
-        self%state%custom_xtick_positions = positions
-
-        if (present(labels)) then
-            do i = 1, n
-                self%state%custom_xtick_labels(i) = trim(labels(i))
-            end do
-        else
-            do i = 1, n
-                write(self%state%custom_xtick_labels(i), '(G12.5)') positions(i)
-                self%state%custom_xtick_labels(i) = &
-                    adjustl(self%state%custom_xtick_labels(i))
-            end do
-        end if
-
-        self%state%custom_xticks_set = .true.
-        self%state%rendered = .false.
+        call set_ticks_impl(self, 1, positions, labels)
     end subroutine set_xticks
 
     module subroutine set_yticks(self, positions, labels)
@@ -64,45 +175,7 @@ contains
         real(wp), intent(in) :: positions(:)
         character(len=*), intent(in), optional :: labels(:)
 
-        integer :: n, i
-
-        n = size(positions)
-        if (n == 0) then
-            call log_warning('set_yticks: empty positions array')
-            return
-        end if
-
-        if (present(labels)) then
-            if (size(labels) /= n) then
-                call log_error('set_yticks: labels array size must match positions')
-                return
-            end if
-        end if
-
-        if (allocated(self%state%custom_ytick_positions)) &
-            deallocate(self%state%custom_ytick_positions)
-        if (allocated(self%state%custom_ytick_labels)) &
-            deallocate(self%state%custom_ytick_labels)
-
-        allocate(self%state%custom_ytick_positions(n))
-        allocate(self%state%custom_ytick_labels(n))
-
-        self%state%custom_ytick_positions = positions
-
-        if (present(labels)) then
-            do i = 1, n
-                self%state%custom_ytick_labels(i) = trim(labels(i))
-            end do
-        else
-            do i = 1, n
-                write(self%state%custom_ytick_labels(i), '(G12.5)') positions(i)
-                self%state%custom_ytick_labels(i) = &
-                    adjustl(self%state%custom_ytick_labels(i))
-            end do
-        end if
-
-        self%state%custom_yticks_set = .true.
-        self%state%rendered = .false.
+        call set_ticks_impl(self, 2, positions, labels)
     end subroutine set_yticks
 
     module subroutine set_xtick_labels(self, labels)
@@ -111,32 +184,7 @@ contains
         class(figure_t), intent(inout) :: self
         character(len=*), intent(in) :: labels(:)
 
-        integer :: n, i
-
-        n = size(labels)
-        if (n == 0) then
-            call log_warning('set_xtick_labels: empty labels array')
-            return
-        end if
-
-        if (allocated(self%state%custom_xtick_labels)) &
-            deallocate(self%state%custom_xtick_labels)
-
-        allocate(self%state%custom_xtick_labels(n))
-
-        do i = 1, n
-            self%state%custom_xtick_labels(i) = trim(labels(i))
-        end do
-
-        if (.not. allocated(self%state%custom_xtick_positions)) then
-            allocate(self%state%custom_xtick_positions(n))
-            do i = 1, n
-                self%state%custom_xtick_positions(i) = real(i, wp)
-            end do
-        end if
-
-        self%state%custom_xticks_set = .true.
-        self%state%rendered = .false.
+        call set_tick_labels_impl(self, 1, labels)
     end subroutine set_xtick_labels
 
     module subroutine set_ytick_labels(self, labels)
@@ -144,32 +192,7 @@ contains
         class(figure_t), intent(inout) :: self
         character(len=*), intent(in) :: labels(:)
 
-        integer :: n, i
-
-        n = size(labels)
-        if (n == 0) then
-            call log_warning('set_ytick_labels: empty labels array')
-            return
-        end if
-
-        if (allocated(self%state%custom_ytick_labels)) &
-            deallocate(self%state%custom_ytick_labels)
-
-        allocate(self%state%custom_ytick_labels(n))
-
-        do i = 1, n
-            self%state%custom_ytick_labels(i) = trim(labels(i))
-        end do
-
-        if (.not. allocated(self%state%custom_ytick_positions)) then
-            allocate(self%state%custom_ytick_positions(n))
-            do i = 1, n
-                self%state%custom_ytick_positions(i) = real(i, wp)
-            end do
-        end if
-
-        self%state%custom_yticks_set = .true.
-        self%state%rendered = .false.
+        call set_tick_labels_impl(self, 2, labels)
     end subroutine set_ytick_labels
 
 end submodule fortplot_figure_core_ticks


### PR DESCRIPTION
## Summary

Consolidates four copy-paste duplicate subroutines in `fortplot_figure_core_ticks.f90` into two shared internal implementations parameterized by axis selector, eliminating drift risk and reducing maintenance burden.

## Changes

- `set_xticks`/`set_yticks` → shared `set_ticks_impl(self, axis, positions, labels)`
- `set_xtick_labels`/`set_ytick_labels` → shared `set_tick_labels_impl(self, axis, labels)`
- New `auto_gen_labels()` helper extracts the duplicated numeric label generation loop
- Public module subroutines remain unchanged (thin one-line delegates)

## Verification

### Tests pass

```
$ fpm test --target test_grouped_bar_ticks
Grouped Bar Tick Position Test Summary
Tests run: 4 | Passed: 4 | Failed: 0
ALL TESTS PASSED!

$ fpm test --target test_categorical_axis
Test 1: set_xticks with labels - PASS
Test 2: set_xtick_labels only - PASS
Test 3: set_yticks with labels - PASS
Test 4: Full categorical bar chart - PASS
Test 5: Weekly sales with days - PASS
All categorical axis tests completed successfully
```

Full test suite (`fpm test`) passes with no regressions.