### PR TITLE
fix: Inconsistent diagnostics: print * used instead of fortplot_logging (fixes #1739)

### DIFF
--- a/src/documentation/fortplot_documentation.f90
+++ b/src/documentation/fortplot_documentation.f90
@@ -2,6 +2,7 @@ module fortplot_documentation
     !! Consolidated documentation generation module combining core utilities,
     !! processing logic, and output generation
     use fortplot_directory_listing, only: list_directory_entries
+    use fortplot_logging, only: log_warning
     use fortplot_doc_utils, only: &
         build_file_path, check_file_exists, file_exists, get_file_extension, &
         lowercase_string, replace_extension, title_case
@@ -92,7 +93,7 @@ contains
 
         open(newunit=input_unit, file=input_file, status='old', action='read', iostat=ios)
         if (ios /= 0) then
-            print *, 'Warning: Could not open input file: ', trim(input_file)
+            call log_warning('Could not open input file: ' // trim(input_file))
             return
         end if
 

--- a/src/figures/fortplot_figure_data_ranges.f90
+++ b/src/figures/fortplot_figure_data_ranges.f90
@@ -1,6 +1,7 @@
 module fortplot_figure_data_ranges
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_scales, only: apply_scale_transform, clamp_extreme_log_range
+    use fortplot_logging, only: log_debug
    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE, &
                                    PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
                                    PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
@@ -616,6 +617,7 @@ contains
         real(wp), intent(in) :: symlog_threshold
         
         real(wp) :: x_clamped_min, x_clamped_max, y_clamped_min, y_clamped_max
+        character(len=256) :: msg
         
         ! Apply user-specified limits or use calculated data ranges
         if (.not. xlim_set) then
@@ -633,9 +635,11 @@ contains
             call clamp_extreme_log_range(x_min, x_max, x_clamped_min, x_clamped_max)
             if (abs(x_clamped_min - x_min) > 1.0e-10_wp .or. &
                 abs(x_clamped_max - x_max) > 1.0e-10_wp) then
-                print *, "Info: X-axis range clamped for log scale visualization"
-                print *, "      Original:", x_min, "to", x_max
-                print *, "      Clamped: ", x_clamped_min, "to", x_clamped_max
+                write(msg, '(A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
+                    'X-axis range clamped for log scale visualization; ', &
+                    'original=', x_min, ' to ', x_max, &
+                    '; clamped=', x_clamped_min, ' to ', x_clamped_max
+                call log_debug(trim(adjustl(msg)))
             end if
             x_min = x_clamped_min
             x_max = x_clamped_max
@@ -645,9 +649,11 @@ contains
             call clamp_extreme_log_range(y_min, y_max, y_clamped_min, y_clamped_max)
             if (abs(y_clamped_min - y_min) > 1.0e-10_wp .or. &
                 abs(y_clamped_max - y_max) > 1.0e-10_wp) then
-                print *, "Info: Y-axis range clamped for log scale visualization"
-                print *, "      Original:", y_min, "to", y_max
-                print *, "      Clamped: ", y_clamped_min, "to", y_clamped_max
+                write(msg, '(A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
+                    'Y-axis range clamped for log scale visualization; ', &
+                    'original=', y_min, ' to ', y_max, &
+                    '; clamped=', y_clamped_min, ' to ', y_clamped_max
+                call log_debug(trim(adjustl(msg)))
             end if
             y_min = y_clamped_min
             y_max = y_clamped_max

--- a/src/figures/fortplot_figure_data_ranges.f90
+++ b/src/figures/fortplot_figure_data_ranges.f90
@@ -635,7 +635,7 @@ contains
             call clamp_extreme_log_range(x_min, x_max, x_clamped_min, x_clamped_max)
             if (abs(x_clamped_min - x_min) > 1.0e-10_wp .or. &
                 abs(x_clamped_max - x_max) > 1.0e-10_wp) then
-                write(msg, '(A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
+                write(msg, '(A,A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
                     'X-axis range clamped for log scale visualization; ', &
                     'original=', x_min, ' to ', x_max, &
                     '; clamped=', x_clamped_min, ' to ', x_clamped_max
@@ -649,7 +649,7 @@ contains
             call clamp_extreme_log_range(y_min, y_max, y_clamped_min, y_clamped_max)
             if (abs(y_clamped_min - y_min) > 1.0e-10_wp .or. &
                 abs(y_clamped_max - y_max) > 1.0e-10_wp) then
-                write(msg, '(A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
+                write(msg, '(A,A,F12.4,A,F12.4,A,F12.4,A,F12.4)') &
                     'Y-axis range clamped for log scale visualization; ', &
                     'original=', y_min, ' to ', y_max, &
                     '; clamped=', y_clamped_min, ' to ', y_clamped_max

--- a/src/figures/plot_types/fortplot_figure_boxplot.f90
+++ b/src/figures/plot_types/fortplot_figure_boxplot.f90
@@ -7,6 +7,7 @@ module fortplot_figure_boxplot
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_BOXPLOT
     use fortplot_utils_sort, only: sort_array
+    use fortplot_logging, only: log_warning
     implicit none
     
     private
@@ -41,7 +42,7 @@ contains
         ! Check plot count
         plot_count = plot_count + 1
         if (plot_count > max_plots) then
-            print *, "WARNING: Maximum number of plots exceeded"
+            call log_warning('Maximum number of plots exceeded')
             plot_count = max_plots
             return
         end if

--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -12,6 +12,7 @@ module fortplot_utils
     use fortplot_ascii, only: create_ascii_canvas
     use fortplot_svg, only: create_svg_canvas
     use fortplot_constants, only: MAX_SAFE_PIXELS
+    use fortplot_logging, only: log_warning
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
@@ -85,9 +86,7 @@ contains
             ! Allow up to MAX_SAFE_PIXELS (matches matplotlib figure limits)
             if (width > MAX_SAFE_PIXELS .or. height > MAX_SAFE_PIXELS .or. &
                 width <= 0 .or. height <= 0) then
-                print *, "WARNING: PNG backend dimensions invalid or too large:", &
-                    width, "x", height
-                print *, "Falling back to PDF backend for this file"
+                call log_warning('PNG backend dimensions invalid or too large; falling back to PDF backend')
                 allocate(backend, source=create_pdf_canvas( &
                     min(max(width, 800), 1920), min(max(height, 600), 1080)))
             else

--- a/src/utilities/validation/fortplot_validation_context.f90
+++ b/src/utilities/validation/fortplot_validation_context.f90
@@ -7,6 +7,7 @@
 ! Issue #871: Thread-safe validation context system
 !
 module fortplot_validation_context
+    use fortplot_logging, only: log_warning, log_error
     implicit none
     private
     
@@ -77,9 +78,9 @@ contains
         emit = should_emit_warning(warning_key)
         if (emit) then
             if (present(context)) then
-                print *, "Warning [", trim(context), "]: ", trim(message)
+                call log_warning('[' // trim(context) // '] ' // trim(message))
             else
-                print *, "Warning: ", trim(message)
+                call log_warning(trim(message))
             end if
         end if
     end subroutine validation_warning
@@ -93,9 +94,9 @@ contains
         if (current_warning_mode == WARNING_MODE_SILENT) return
         
         if (present(context)) then
-            print *, "Error [", trim(context), "]: ", trim(message)
+            call log_error('[' // trim(context) // '] ' // trim(message))
         else
-            print *, "Error: ", trim(message)
+            call log_error(trim(message))
         end if
     end subroutine validation_error
     
@@ -149,11 +150,11 @@ contains
         if (ctx%warning_mode == WARNING_MODE_SILENT .or. ctx%suppress_output) return
         
         if (present(context_param)) then
-            print *, "Error [", trim(context_param), "]: ", trim(message)
+            call log_error('[' // trim(context_param) // '] ' // trim(message))
         else if (len_trim(ctx%context_name) > 0) then
-            print *, "Error [", trim(ctx%context_name), "]: ", trim(message)
+            call log_error('[' // trim(ctx%context_name) // '] ' // trim(message))
         else
-            print *, "Error: ", trim(message)
+            call log_error(trim(message))
         end if
     end subroutine validation_error_with_context
     


### PR DESCRIPTION
## Summary

Replace 17 scattered `print *` statements with proper `fortplot_logging` calls across 5 source files, enabling consistent formatting, verbosity control, and redirection via `FORTPLOT_LOG_LEVEL` and `FORTPLOT_SUPPRESS_WARNINGS`.

## Changes

| File | Before | After |
|------|--------|-------|
| `fortplot_figure_data_ranges.f90` | 6 `print *` (log-axis clamping) | `log_debug` |
| `fortplot_figure_boxplot.f90` | 1 `print *` (max plots) | `log_warning` |
| `fortplot_utils.f90` | 2 `print *` (PNG dimension fallback) | `log_warning` |
| `fortplot_validation_context.f90` | 7 `print *` (validation msgs) | `log_warning`/`log_error` |
| `fortplot_documentation.f90` | 1 `print *` (file open failure) | `log_warning` |

Legitimate exceptions left in place:
- `fortplot_logging.f90` lines 63/83/91/99: logging backend itself
- `fortplot_windows_performance.f90` lines 118-123: explicit debug-dump routine
- `fortplot_windows_test_helper.f90` line 94: CI-specific skip marker

## Verification

### Build passes
```
$ fpm build
[100%] Project compiled successfully.
```

### CI test suite passes
```
$ make test-ci
CI essential test suite completed successfully
```

### Remaining print * count verified
```
$ grep -rn "print \*" src/ --include="*.f90" | wc -l
11
```
(Down from 28; 11 remaining are all legitimate exceptions)
