### PR TITLE
fix: PDF legend color swatches rendered with hatch patterns (fixes #1686)

### DIFF
--- a/src/ui/fortplot_legend.f90
+++ b/src/ui/fortplot_legend.f90
@@ -502,22 +502,17 @@ contains
         !! Draw filled white rectangle for legend background
         class(plot_context), intent(inout) :: backend
         real(wp), intent(in) :: x1, y1, x2, y2
-        
-        ! Draw filled rectangle by drawing horizontal lines
-        real(wp) :: y, dy
-        integer :: num_lines, i
-        
+
+        real(wp) :: x_quad(4), y_quad(4)
+
         ! Ensure legend background is rendered with solid style and white fill
         call backend%set_line_style('-')
         call backend%color(1.0_wp, 1.0_wp, 1.0_wp)
 
-        num_lines = 50  ! Number of horizontal lines to fill the box
-        dy = abs(y1 - y2) / real(num_lines, wp)
-        
-        do i = 0, num_lines
-            y = y1 - real(i, wp) * dy
-            call backend%line(x1, y, x2, y)
-        end do
+        ! Fill rectangle using fill_quad instead of hatch lines
+        x_quad = [x1, x2, x2, x1]
+        y_quad = [y1, y1, y2, y2]
+        call backend%fill_quad(x_quad, y_quad)
     end subroutine draw_legend_box
 
     subroutine draw_legend_border(backend, x1, y1, x2, y2)


### PR DESCRIPTION
## Summary

Replace the 50-line hatch fill in `draw_legend_box` with a proper `fill_quad` call. The legend background box was drawn using 50 horizontal lines, which rendered as visible parallel stroke artifacts in PDF vector output.

## Changes

- `src/ui/fortplot_legend.f90`: replaced 50-line hatch loop with single `backend%fill_quad()` call

## Verification

### Build
```
fpm build 2>&1 | tail -1
> [100%] Project compiled successfully.
```

### Tests
```
fpm test 2>&1 | grep "Failed:"
> Tests run: 6 | Passed: 6 | Failed: 0
> Tests run: 4 | Passed: 4 | Failed: 0
```

### Artifact verification
```
make verify-artifacts 2>&1 | tail -1
> Artifact verification passed.
```

### PDF stream analysis (stateful_sales.pdf)
- 79 `B` (fill+stroke) operators used for proper fills
- No hatch pattern in legend box region (verified via stream decomposition)
- Pie wedge arc lines at y=213.5 are legitimate wedge outlines, not hatch artifacts
