### PR TITLE
fix: PNG backend: markers at data range boundary clipped by plot border (fixes #1683)

### DIFF
--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -47,7 +47,7 @@ module fortplot_figure_rendering_pipeline
     public :: render_figure_axes_labels_only, render_title_only
     public :: render_polar_axes
 
-    real(wp), parameter :: PDF_DATA_RANGE_MARGIN = 0.05_wp
+    real(wp), parameter :: DATA_RANGE_MARGIN = 0.05_wp
 
 contains
 
@@ -85,7 +85,7 @@ contains
     end subroutine setup_coordinate_system
 
     subroutine expand_data_range(data_min, data_max, expanded_min, expanded_max)
-        !! Expand a data range by PDF_DATA_RANGE_MARGIN (5%) on each side,
+        !! Expand a data range by DATA_RANGE_MARGIN (5%) on each side,
         !! keeping the range center fixed. Prevents markers at exact boundaries
         !! from being clipped by the plot frame stroke.
         real(wp), intent(in) :: data_min, data_max
@@ -100,7 +100,7 @@ contains
 
         center = 0.5_wp*(data_min + data_max)
         half_range = 0.5_wp*(data_max - data_min)
-        half_range = half_range*(1.0_wp + PDF_DATA_RANGE_MARGIN)
+        half_range = half_range*(1.0_wp + DATA_RANGE_MARGIN)
 
         expanded_min = center - half_range
         expanded_max = center + half_range

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -47,7 +47,7 @@ module fortplot_figure_rendering_pipeline
     public :: render_figure_axes_labels_only, render_title_only
     public :: render_polar_axes
 
-    real(wp), parameter :: PDF_DATA_RANGE_MARGIN = 0.02_wp
+    real(wp), parameter :: PDF_DATA_RANGE_MARGIN = 0.05_wp
 
 contains
 
@@ -85,8 +85,8 @@ contains
     end subroutine setup_coordinate_system
 
     subroutine expand_data_range(data_min, data_max, expanded_min, expanded_max)
-        !! Expand a data range by PDF_DATA_RANGE_MARGIN on each side,
-        !! keeping the range center fixed. Prevents data at exact boundaries
+        !! Expand a data range by PDF_DATA_RANGE_MARGIN (5%) on each side,
+        !! keeping the range center fixed. Prevents markers at exact boundaries
         !! from being clipped by the plot frame stroke.
         real(wp), intent(in) :: data_min, data_max
         real(wp), intent(out) :: expanded_min, expanded_max

--- a/test/test_marker_boundary_clipping.f90
+++ b/test/test_marker_boundary_clipping.f90
@@ -1,0 +1,112 @@
+program test_marker_boundary_clipping
+    !! Regression test for issue #1683: markers at data range boundary
+    !! should not be clipped by the plot border.
+    !!
+    !! The fix increases PDF_DATA_RANGE_MARGIN from 2% to 5% so that
+    !! markers at the exact data boundary are pushed far enough inside
+    !! the plot area to avoid overlap with the 1-pixel axes frame.
+    use, intrinsic :: iso_fortran_env, only: wp => real64, error_unit
+    use fortplot_figure_core, only: figure_t
+    implicit none
+
+    integer, parameter :: w = 400
+    integer, parameter :: h = 300
+    real(wp) :: rgb(w, h, 3)
+    integer :: corner_pixels(4)
+    integer :: i
+
+    ! Render four markers, one at each data-range corner
+    call render_four_corners(rgb)
+
+    ! Count dark pixels in each corner region of the plot area.
+    ! The plot area is roughly central; corners are offset from image edges.
+    ! With sufficient margin, each corner marker should have a full set
+    ! of pixels.  With insufficient margin, the marker near the axes
+    ! frame would have fewer visible pixels (clipped by the frame line).
+    call count_corner_pixels(rgb, corner_pixels)
+
+    do i = 1, 4
+        if (corner_pixels(i) < 200) then
+            write (error_unit, *) "FAIL: corner ", i, &
+                " has only ", corner_pixels(i), &
+                " marker pixels (expected >= 200)"
+            write (error_unit, *) "INFO: marker at data boundary may be clipped by plot border"
+            stop 1
+        end if
+    end do
+
+    print *, "PASS: all four corner markers fully visible"
+    print *, "  corner pixel counts:", corner_pixels
+
+contains
+
+    subroutine render_four_corners(rgb)
+        real(wp), intent(out) :: rgb(w, h, 3)
+        type(figure_t) :: fig
+        real(wp) :: x(4), y(4)
+
+        ! Markers at all four corners of the data range [0,1] x [0,1]
+        x = [0.0_wp, 1.0_wp, 0.0_wp, 1.0_wp]
+        y = [0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp]
+
+        call fig%initialize(width=w, height=h, backend='png')
+        call fig%set_xlim(0.0_wp, 1.0_wp)
+        call fig%set_ylim(0.0_wp, 1.0_wp)
+
+        call fig%scatter(x, y, marker='o', facecolor=[0.0_wp, 0.0_wp, 0.0_wp], &
+                         edgecolor=[0.0_wp, 0.0_wp, 0.0_wp])
+
+        call fig%extract_rgb_data_for_animation(rgb)
+    end subroutine render_four_corners
+
+    subroutine count_corner_pixels(rgb, counts)
+        real(wp), intent(in) :: rgb(w, h, 3)
+        integer, intent(out) :: counts(4)
+        integer :: i, j
+        real(wp) :: lum
+
+        ! Define search regions for each corner marker.
+        ! These are approximate regions inside the plot area where the
+        ! corner markers should appear after margin expansion.
+        !
+        ! Corner 1: bottom-left  (data 0,0) -> image bottom-left of plot area
+        ! Corner 2: bottom-right (data 1,0) -> image bottom-right of plot area
+        ! Corner 3: top-left     (data 0,1) -> image top-left of plot area
+        ! Corner 4: top-right    (data 1,1) -> image top-right of plot area
+
+        counts = 0
+
+        ! Corner 1: bottom-left region
+        do j = 3*h/4, h - 10
+            do i = 10, w/4
+                lum = (rgb(i, j, 1) + rgb(i, j, 2) + rgb(i, j, 3)) / 3.0_wp
+                if (lum < 0.5_wp) counts(1) = counts(1) + 1
+            end do
+        end do
+
+        ! Corner 2: bottom-right region
+        do j = 3*h/4, h - 10
+            do i = 3*w/4, w - 10
+                lum = (rgb(i, j, 1) + rgb(i, j, 2) + rgb(i, j, 3)) / 3.0_wp
+                if (lum < 0.5_wp) counts(2) = counts(2) + 1
+            end do
+        end do
+
+        ! Corner 3: top-left region
+        do j = 10, h/4
+            do i = 10, w/4
+                lum = (rgb(i, j, 1) + rgb(i, j, 2) + rgb(i, j, 3)) / 3.0_wp
+                if (lum < 0.5_wp) counts(3) = counts(3) + 1
+            end do
+        end do
+
+        ! Corner 4: top-right region
+        do j = 10, h/4
+            do i = 3*w/4, w - 10
+                lum = (rgb(i, j, 1) + rgb(i, j, 2) + rgb(i, j, 3)) / 3.0_wp
+                if (lum < 0.5_wp) counts(4) = counts(4) + 1
+            end do
+        end do
+    end subroutine count_corner_pixels
+
+end program test_marker_boundary_clipping

--- a/test/test_marker_boundary_clipping.f90
+++ b/test/test_marker_boundary_clipping.f90
@@ -2,7 +2,7 @@ program test_marker_boundary_clipping
     !! Regression test for issue #1683: markers at data range boundary
     !! should not be clipped by the plot border.
     !!
-    !! The fix increases PDF_DATA_RANGE_MARGIN from 2% to 5% so that
+    !! The fix increases DATA_RANGE_MARGIN from 2% to 5% so that
     !! markers at the exact data boundary are pushed far enough inside
     !! the plot area to avoid overlap with the 1-pixel axes frame.
     use, intrinsic :: iso_fortran_env, only: wp => real64, error_unit


### PR DESCRIPTION
## Summary

Increase the data-range margin expansion from 2% to 5% so markers placed at the exact data-range boundary are pushed far enough inside the plot area to avoid visual overlap with the axes frame.

## Changes

- `src/figures/fortplot_figure_rendering_pipeline.f90`: bump `PDF_DATA_RANGE_MARGIN` from `0.02_wp` to `0.05_wp`
- `test/test_marker_boundary_clipping.f90`: new regression test placing markers at all four data-range corners and verifying each has sufficient visible pixel coverage

## Root Cause

The `expand_data_range` subroutine inflates the coordinate system so boundary data points map inside the plot area rather than onto the axes frame. A 2 % inflation on a typical ~400 px plot height gives only ~8 px of clearance, which is barely enough for a 5–7 px marker radius. At that distance the 1 px axes frame line overlaps the outer edge of the marker, making it look "half-clipped".

A 5 % inflation gives ~20 px clearance, which comfortably accommodates all built-in marker sizes.

## Verification

### Test passes after fix

```
$ fpm test --target test_marker_boundary_clipping
 PASS: all four corner markers fully visible
   corner pixel counts:         699         521         463         408
```

### Full test suite green

```
$ fpm test 2>&1 | grep -c "STOP 1\|<ERROR>"
0
```

### Affected examples regenerate cleanly

- `make example ARGS="scatter_demo"` → scatter_basic.png, scatter_multi.png, scatter_gaussian.png
- `make example ARGS="disconnected_lines"` → disconnected_lines.png, disconnected_lines.pdf

Artifact file sizes are consistent with pre-change renders (no regression in output volume).
