### PR TITLE
fix: clip annotation arrows to plot boundary (fixes #1693)

### DIFF
--- a/src/text/fortplot_annotation_rendering.f90
+++ b/src/text/fortplot_annotation_rendering.f90
@@ -18,7 +18,7 @@ module fortplot_annotation_rendering
     implicit none
 
     private
-    public :: render_figure_annotations
+    public :: render_figure_annotations, clip_to_data_bounds
 
 contains
 
@@ -332,12 +332,20 @@ contains
                    dmb => margin_bottom, dmt => margin_top)
         end associate
 
-        call map_xy_to_data_coords(annotation%arrow_coord_type, annotation%arrow_x, &
-                                   annotation%arrow_y, x_min, x_max, y_min, y_max, &
-                                   arrow_end_x, arrow_end_y)
+       call map_xy_to_data_coords(annotation%arrow_coord_type, annotation%arrow_x, &
+                                    annotation%arrow_y, x_min, x_max, y_min, y_max, &
+                                    arrow_end_x, arrow_end_y)
         call map_xy_to_data_coords(annotation%coord_type, annotation%x, annotation%y, &
-                                   x_min, x_max, y_min, y_max, arrow_start_x, &
-                                   arrow_start_y)
+                                    x_min, x_max, y_min, y_max, arrow_start_x, &
+                                    arrow_start_y)
+
+        ! Clip both arrow endpoints to the plot data range so arrows
+        ! cannot extend outside the visible axes frame.
+        call clip_to_data_bounds(arrow_start_x, arrow_start_y, x_min, x_max, y_min, y_max)
+        call clip_to_data_bounds(arrow_end_x, arrow_end_y, x_min, x_max, y_min, y_max)
+
+        ! Skip arrow if both endpoints collapsed to the same clipped point.
+        if (arrow_start_x == arrow_end_x .and. arrow_start_y == arrow_end_y) return
 
         call backend%color(annotation%color(1), annotation%color(2), &
                            annotation%color(3))
@@ -354,6 +362,13 @@ contains
                                 arrow_end_y - arrow_start_y, 1.0_wp, &
                                 trim(arrow_style))
     end subroutine render_annotation_arrow
+
+    pure subroutine clip_to_data_bounds(x, y, x_min, x_max, y_min, y_max)
+        real(wp), intent(inout) :: x, y
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        x = max(x_min, min(x, x_max))
+        y = max(y_min, min(y, y_max))
+    end subroutine clip_to_data_bounds
 
     pure subroutine map_xy_to_data_coords(coord_type, x_in, y_in, x_min, x_max, y_min, &
                                           y_max, x, y)

--- a/test/test_annotation_arrow_clipping_1693.f90
+++ b/test/test_annotation_arrow_clipping_1693.f90
@@ -1,0 +1,73 @@
+program test_annotation_arrow_clipping
+    !! Regression test for Issue #1693 / #1716:
+    !! Annotation arrows must be clipped to the plot data boundary
+    !! so they do not extend outside the visible axes frame.
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot
+    use fortplot_annotation_rendering, only: clip_to_data_bounds
+    implicit none
+
+    real(wp) :: cx, cy
+
+    ! Clip point inside bounds stays unchanged
+    cx = 3.0_wp; cy = 0.5_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cx /= 3.0_wp .or. cy /= 0.5_wp) then
+        print *, 'FAIL: interior point moved'
+        stop 1
+    end if
+
+    ! Clip point below y_min
+    cx = 3.0_wp; cy = -2.0_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cy /= -1.0_wp) then
+        print *, 'FAIL: point below y_min not clipped'
+        stop 1
+    end if
+
+    ! Clip point above y_max
+    cx = 3.0_wp; cy = 5.0_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cy /= 1.0_wp) then
+        print *, 'FAIL: point above y_max not clipped'
+        stop 1
+    end if
+
+    ! Clip point left of x_min
+    cx = -5.0_wp; cy = 0.0_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cx /= 0.0_wp) then
+        print *, 'FAIL: point left of x_min not clipped'
+        stop 1
+    end if
+
+    ! Clip point right of x_max
+    cx = 10.0_wp; cy = 0.0_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cx /= 6.0_wp) then
+        print *, 'FAIL: point right of x_max not clipped'
+        stop 1
+    end if
+
+    ! Clip point beyond both x_max and y_min
+    cx = 20.0_wp; cy = -10.0_wp
+    call clip_to_data_bounds(cx, cy, 0.0_wp, 6.0_wp, -1.0_wp, 1.0_wp)
+    if (cx /= 6.0_wp .or. cy /= -1.0_wp) then
+        print *, 'FAIL: point beyond two bounds not clipped'
+        stop 1
+    end if
+
+    ! End-to-end: annotation with text outside data range renders without error
+    call figure(figsize=[6.4_wp, 4.8_wp])
+    call plot([0.0_wp, 6.0_wp], [0.0_wp, 1.0_wp])
+
+    call annotate("Outside text", &
+                  xy=[3.0_wp, 0.5_wp], &
+                  xytext=[8.0_wp, -2.0_wp], &
+                  xy_coord_type=COORD_DATA, xytext_coord_type=COORD_DATA)
+
+    call savefig('build/test/output/test_annotation_arrow_clipping.pdf')
+
+    print *, 'PASS: annotation arrow clipping works (Issue #1693/#1716)'
+
+end program test_annotation_arrow_clipping


### PR DESCRIPTION
## Summary

Annotation arrows whose text position or target lies outside the data range were drawn beyond the visible axes frame in both the PNG and PDF backends. This fix clips both arrow endpoints to the plot data boundary before drawing.

## Changes

- Added `clip_to_data_bounds` pure subroutine to constrain coordinates to `[x_min, x_max] x [y_min, y_max]`
- Applied clipping to both arrow start (text position) and arrow end (target) in `render_annotation_arrow`
- Skip degenerate arrows where both endpoints collapse to the same clipped point
- Exposed `clip_to_data_bounds` as public for testability
- Added regression test `test_annotation_arrow_clipping_1693.f90`

## Verification

### Test passes

```
$ fpm test 2>&1 | grep -E "annotation_arrow_clipping|Test Summary"
[ 37%] test_annotation_arrow_clipping
[ 42%] test_annotation_arrow_clipping  done.
 PASS: annotation arrow clipping works (Issue #1693/#1716)
Test Summary: 14 of 14 tests passed
```

### Artifact verification

- `output/example/fortran/annotation_demo/annotation_demo.pdf` — annotation arrows remain within plot frame
- `output/example/fortran/annotation_demo/annotation_demo.png` — same, no arrows extending outside boundary
- `build/test/output/test_annotation_arrow_clipping.pdf` — test artifact with out-of-bounds annotation rendered without error

### Requirements mapped

| Requirement | Evidence |
|---|---|
| Arrows clipped in PNG backend | `render_annotation_arrow` clips before `backend%line`/`backend%draw_arrow`; annotation_demo.png verified |
| Arrows clipped in PDF backend | Same clipping path applies to pdf_context; annotation_demo.pdf verified |
| No regression on existing tests | 14/14 tests pass |
| New test coverage | `test_annotation_arrow_clipping_1693.f90` tests 6 clipping cases + end-to-end render |

Fixes #1693, #1716.