### PR TITLE
fix: preserve multi-byte UTF-8 in text preprocessing (fixes #1705)

### DIFF
--- a/src/text/fortplot_text_layout.f90
+++ b/src/text/fortplot_text_layout.f90
@@ -222,10 +222,11 @@ contains
 
     subroutine preprocess_math_text(input_text, result_text, result_len)
         !! Remove '$' delimiters and escape '^'/'_' outside math so they render literally
+        !! UTF-8 aware: multi-byte characters are copied as intact sequences
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: result_text
         integer, intent(out) :: result_len
-        integer :: i, n, pos
+        integer :: i, n, pos, char_len
         logical :: in_math
         character(len=1) :: ch
 
@@ -237,26 +238,39 @@ contains
 
         i = 1
         do while (i <= n)
-            ch = input_text(i:i)
-            if (ch == '$') then
-                in_math = .not. in_math
-                i = i + 1
-                cycle
-            end if
+            char_len = utf8_char_length(input_text(i:i))
+            if (char_len <= 0) char_len = 1
 
-            if (.not. in_math .and. (ch == '_' .or. ch == '^')) then
-                ! Escape to prevent math parsing
-                result_text(pos:pos) = '\'
-                pos = pos + 1
+            if (char_len == 1) then
+                ch = input_text(i:i)
+                if (ch == '$') then
+                    in_math = .not. in_math
+                    i = i + 1
+                    cycle
+                end if
+
+                if (.not. in_math .and. (ch == '_' .or. ch == '^')) then
+                    ! Escape to prevent math parsing
+                    result_text(pos:pos) = '\'
+                    pos = pos + 1
+                    result_text(pos:pos) = ch
+                    pos = pos + 1
+                    i = i + 1
+                    cycle
+                end if
+
                 result_text(pos:pos) = ch
                 pos = pos + 1
                 i = i + 1
-                cycle
+            else
+                ! Multi-byte UTF-8 character: copy entire sequence intact
+                if (pos + char_len - 1 <= len(result_text)) then
+                    result_text(pos:pos + char_len - 1) = &
+                        input_text(i:i + char_len - 1)
+                    pos = pos + char_len
+                end if
+                i = i + char_len
             end if
-
-            result_text(pos:pos) = ch
-            pos = pos + 1
-            i = i + 1
         end do
 
         result_len = pos - 1

--- a/src/utilities/text/fortplot_latex_parser.f90
+++ b/src/utilities/text/fortplot_latex_parser.f90
@@ -1,5 +1,6 @@
 module fortplot_latex_parser
     !! LaTeX command parser for Greek letters and mathematical symbols
+    use fortplot_unicode, only: utf8_char_length
     implicit none
     
     private
@@ -213,11 +214,12 @@ contains
     
     subroutine process_latex_in_text(input_text, result_text, result_len)
         !! Convert LaTeX-style commands to Unicode while preserving math scopes
+        !! UTF-8 aware: multi-byte characters are copied as intact sequences
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: result_text
         integer, intent(out) :: result_len
         integer :: i, pos, n
-        integer :: cmd_end
+        integer :: cmd_end, char_len
         character(len=20) :: command, unicode_char
         logical :: success
 
@@ -228,42 +230,55 @@ contains
         i = 1
 
         do while (i <= n)
-            if (input_text(i:i) == '$') then
-                result_text(pos:pos) = '$'
+            char_len = utf8_char_length(input_text(i:i))
+            if (char_len <= 0) char_len = 1
+
+            if (char_len == 1) then
+                if (input_text(i:i) == '$') then
+                    result_text(pos:pos) = '$'
+                    pos = pos + 1
+                    i = i + 1
+                    cycle
+                end if
+
+                if (input_text(i:i) == '\') then
+                    cmd_end = i + 1
+                    do while (cmd_end <= n)
+                        if (.not. is_alpha(input_text(cmd_end:cmd_end))) exit
+                        cmd_end = cmd_end + 1
+                    end do
+                    if (cmd_end - 1 > i) then
+                        call extract_latex_command(input_text, i, cmd_end - 1, command)
+                        call latex_to_unicode(trim(command), unicode_char, success)
+                        if (success) then
+                            result_text(pos:pos + len_trim(unicode_char) - 1) = trim(unicode_char)
+                            pos = pos + len_trim(unicode_char)
+                            i = cmd_end
+                            cycle
+                        end if
+
+                        ! Handle \sqrt{...} or \sqrt x -> Unicode radical + content
+                        if (trim(command) == 'sqrt') then
+                            call process_sqrt_block(input_text, cmd_end, n, pos, &
+                                                    result_text, i)
+                            cycle
+                        end if
+                    end if
+                    ! If not a recognized command, fall through and copy the backslash
+                end if
+
+                result_text(pos:pos) = input_text(i:i)
                 pos = pos + 1
                 i = i + 1
-                cycle
-            end if
-
-            if (input_text(i:i) == '\') then
-                cmd_end = i + 1
-                do while (cmd_end <= n)
-                    if (.not. is_alpha(input_text(cmd_end:cmd_end))) exit
-                    cmd_end = cmd_end + 1
-                end do
-                if (cmd_end - 1 > i) then
-                    call extract_latex_command(input_text, i, cmd_end - 1, command)
-                    call latex_to_unicode(trim(command), unicode_char, success)
-                    if (success) then
-                        result_text(pos:pos + len_trim(unicode_char) - 1) = trim(unicode_char)
-                        pos = pos + len_trim(unicode_char)
-                        i = cmd_end
-                        cycle
-                    end if
-
-                    ! Handle \sqrt{...} or \sqrt x -> Unicode radical + content
-                    if (trim(command) == 'sqrt') then
-                        call process_sqrt_block(input_text, cmd_end, n, pos, &
-                                                result_text, i)
-                        cycle
-                    end if
+            else
+                ! Multi-byte UTF-8 character: copy entire sequence intact
+                if (pos + char_len - 1 <= len(result_text)) then
+                    result_text(pos:pos + char_len - 1) = &
+                        input_text(i:i + char_len - 1)
+                    pos = pos + char_len
                 end if
-                ! If not a recognized command, fall through and copy the backslash
+                i = i + char_len
             end if
-
-            result_text(pos:pos) = input_text(i:i)
-            pos = pos + 1
-            i = i + 1
         end do
 
         result_len = pos - 1

--- a/test/test_utf8_text_preprocessing.f90
+++ b/test/test_utf8_text_preprocessing.f90
@@ -1,0 +1,214 @@
+program test_utf8_text_preprocessing
+    !! Test UTF-8 handling in text preprocessing pipeline (fixes #1705)
+    !! Verifies that multi-byte UTF-8 characters are preserved intact
+    !! through preprocess_math_text, process_latex_in_text, and
+    !! prepare_text_for_raster.
+    use fortplot_text_layout, only: preprocess_math_text
+    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_text_helpers, only: prepare_text_for_raster
+    use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
+    use fortplot, only: figure, subplots, suptitle, plot, ylabel, title, xlabel, savefig, &
+                        subplot
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call test_preprocess_math_text_utf8(all_passed)
+    call test_process_latex_utf8(all_passed)
+    call test_prepare_raster_utf8(all_passed)
+    call test_suptitle_scenario(all_passed)
+
+    if (all_passed) then
+        print *, 'All UTF-8 text preprocessing tests PASSED!'
+    else
+        print *, 'Some UTF-8 text preprocessing tests FAILED!'
+        stop 1
+    end if
+contains
+
+    subroutine test_preprocess_math_text_utf8(passed)
+        !! Verify preprocess_math_text preserves multi-byte UTF-8 characters
+        logical, intent(out) :: passed
+        character(len=256) :: result
+        integer :: result_len, backslash_pos
+        integer :: cp_input, cp_output
+
+        passed = .true.
+
+        ! Test superscript 2 (U+00B2): bytes C2 B2
+        call preprocess_math_text('x²', result, result_len)
+        if (result_len < 3) then
+            print *, 'FAIL: x² preprocessing lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+        cp_input = utf8_to_codepoint('x²', 2)
+        cp_output = utf8_to_codepoint(result, 2)
+        if (cp_input /= cp_output) then
+            print *, 'FAIL: x² superscript codepoint changed:', cp_input, '->', cp_output
+            passed = .false.
+            return
+        end if
+
+        ! Test superscript 3 (U+00B3): bytes C2 B3
+        call preprocess_math_text('x³', result, result_len)
+        if (result_len < 3) then
+            print *, 'FAIL: x³ preprocessing lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+        cp_input = utf8_to_codepoint('x³', 2)
+        cp_output = utf8_to_codepoint(result, 2)
+        if (cp_input /= cp_output) then
+            print *, 'FAIL: x³ superscript codepoint changed:', cp_input, '->', cp_output
+            passed = .false.
+            return
+        end if
+
+        ! Test Greek letter alpha (U+03B1): 2-byte UTF-8
+        call preprocess_math_text('α', result, result_len)
+        if (result_len < 2) then
+            print *, 'FAIL: α preprocessing lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+        cp_input = utf8_to_codepoint('α', 1)
+        cp_output = utf8_to_codepoint(result, 1)
+        if (cp_input /= cp_output) then
+            print *, 'FAIL: α codepoint changed:', cp_input, '->', cp_output
+            passed = .false.
+            return
+        end if
+
+        ! Test mixed ASCII + UTF-8 with ^ escaping
+        ! x²^2: 'x' (1 byte) + '²' (2 bytes) + '^' (1 byte) + '2' (1 byte) = 5 bytes
+        ! After preprocessing: 'x' + '²' + '\^' + '2' = 6 bytes
+        call preprocess_math_text('x²^2', result, result_len)
+        if (result_len < 6) then
+            print *, 'FAIL: x²^2 preprocessing lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+        ! The ^ should be escaped to \^; find it by scanning for '\'
+        backslash_pos = index(result(1:result_len), '\')
+        if (backslash_pos <= 0) then
+            print *, 'FAIL: ^ in x²^2 should be escaped to \^ but no backslash found'
+            passed = .false.
+            return
+        end if
+        if (result(backslash_pos + 1:backslash_pos + 1) /= '^') then
+            print *, 'FAIL: backslash in x²^2 should be followed by ^'
+            passed = .false.
+            return
+        end if
+
+        print *, 'PASS: preprocess_math_text preserves UTF-8 characters'
+    end subroutine test_preprocess_math_text_utf8
+
+    subroutine test_process_latex_utf8(passed)
+        !! Verify process_latex_in_text preserves multi-byte UTF-8 characters
+        logical, intent(out) :: passed
+        character(len=256) :: result
+        integer :: result_len
+        integer :: cp_input, cp_output
+
+        passed = .true.
+
+        ! Test superscript 2 passes through unchanged
+        call process_latex_in_text('x²', result, result_len)
+        if (result_len < 3) then
+            print *, 'FAIL: process_latex x² lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+        cp_input = utf8_to_codepoint('x²', 2)
+        cp_output = utf8_to_codepoint(result, 2)
+        if (cp_input /= cp_output) then
+            print *, 'FAIL: process_latex x² codepoint changed:', cp_input, '->', cp_output
+            passed = .false.
+            return
+        end if
+
+        ! Test LaTeX command with UTF-8 after it
+        call process_latex_in_text('\alpha²', result, result_len)
+        ! \alpha should become α (U+03B1, 2 bytes), then ² (U+00B2, 2 bytes)
+        if (result_len < 4) then
+            print *, 'FAIL: process_latex \alpha² lost bytes (len=', result_len, ')'
+            passed = .false.
+            return
+        end if
+
+        print *, 'PASS: process_latex_in_text preserves UTF-8 characters'
+    end subroutine test_process_latex_utf8
+
+    subroutine test_prepare_raster_utf8(passed)
+        !! Verify prepare_text_for_raster preserves multi-byte UTF-8 characters
+        logical, intent(out) :: passed
+        character(len=600) :: result
+        integer :: cp_input, cp_output
+
+        passed = .true.
+
+        ! Test full pipeline with superscript
+        call prepare_text_for_raster('x²', result)
+        cp_input = utf8_to_codepoint('x²', 2)
+        cp_output = utf8_to_codepoint(result, 2)
+        if (cp_input /= cp_output) then
+            print *, 'FAIL: prepare_raster x² codepoint changed:', cp_input, '->', cp_output
+            passed = .false.
+            return
+        end if
+
+        ! Test plain ASCII text (suptitle scenario)
+        call prepare_text_for_raster('Polynomial Growth Comparison', result)
+        if (trim(result) /= 'Polynomial Growth Comparison') then
+            print *, 'FAIL: prepare_raster changed plain ASCII suptitle text'
+            print *, '  Expected: Polynomial Growth Comparison'
+            print *, '  Got     :', trim(result)
+            passed = .false.
+            return
+        end if
+
+        print *, 'PASS: prepare_text_for_raster preserves UTF-8 characters'
+    end subroutine test_prepare_raster_utf8
+
+    subroutine test_suptitle_scenario(passed)
+        !! Test the exact scenario from issue #1705:
+        !! 1x3 subplot with suptitle and ylabels containing Unicode superscripts
+        logical, intent(out) :: passed
+        integer :: i
+        real(wp), allocatable :: x(:), y(:)
+        character(len=128) :: output_file
+        logical :: file_exists
+
+        passed = .true.
+        output_file = 'build/test/output/test_utf8_suptitle.png'
+
+        allocate(x(100), y(100))
+        x = [(real(i, wp), i = 1, 100)]
+        y = x**2
+
+        ! Use stateful API: figure, suptitle, subplot, ylabel, savefig
+        call figure(figsize=[12.0_wp, 4.0_wp])
+        call suptitle('Polynomial Growth Comparison')
+        call subplot(1, 3, 1)
+        call plot(x, y)
+        call ylabel('x²')
+        call title('Quadratic')
+        call savefig(output_file)
+
+        ! Check file was created
+        inquire(file=output_file, exist=file_exists)
+        if (.not. file_exists) then
+            print *, 'FAIL: UTF-8 suptitle test did not create output file'
+            passed = .false.
+        else
+            print *, 'PASS: 1x3 subplot with Unicode ylabel and ASCII suptitle renders without error'
+        end if
+
+        deallocate(x, y)
+    end subroutine test_suptitle_scenario
+end program test_utf8_text_preprocessing


### PR DESCRIPTION
## Summary
- Make `preprocess_math_text` and `process_latex_in_text` UTF-8 aware so multi-byte characters (superscripts, Greek letters, etc.) are copied as intact byte sequences rather than being processed byte-by-byte
- Fixes spurious glyph appearing in suptitle when adjacent labels contain Unicode superscripts (e.g. x², x³)

## Changes
- `src/text/fortplot_text_layout.f90`: `preprocess_math_text` uses `utf8_char_length` to detect and copy multi-byte sequences intact
- `src/utilities/text/fortplot_latex_parser.f90`: `process_latex_in_text` uses `utf8_char_length` to detect and copy multi-byte sequences intact
- `test/test_utf8_text_preprocessing.f90`: new test covering UTF-8 preservation through the full preprocessing pipeline plus the exact issue scenario

## Verification

### Requirement: suptitle renders without spurious glyph
**Command**: `pdftotext output/example/fortran/subplot_demo/subplot_1x3_demo.pdf -`
**Output excerpt**: `Polynomial Growth Comparison` — clean text, no extra characters between "Growth" and "Comparison"

### Requirement: Unicode superscripts in labels preserved
**Command**: `fpm test --target test_utf8_text_preprocessing`
**Output**:
```
 PASS: preprocess_math_text preserves UTF-8 characters
 PASS: process_latex_in_text preserves UTF-8 characters
 PASS: prepare_text_for_raster preserves UTF-8 characters
 PASS: 1x3 subplot with Unicode ylabel and ASCII suptitle renders without error
 All UTF-8 text preprocessing tests PASSED!
```

### Requirement: artifact verification passes
**Command**: `make verify-artifacts`
**Output**: `Artifact verification passed.` (all checks green, including unicode_demo α and ω assertions)

### Artifact paths
- `output/example/fortran/subplot_demo/subplot_1x3_demo.pdf` — suptitle clean
- `output/example/fortran/subplot_demo/subplot_1x3_demo.png` — suptitle clean
- `build/test/output/test_utf8_suptitle.png` — test-generated artifact with Unicode ylabel + ASCII suptitle
