### PR TITLE
fix: PDF pie chart legend box overlaps slice label (fixes #1680)

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -460,7 +460,7 @@ contains
     subroutine ascii_calculate_legend_position(this, legend, x, y)
         !! Calculate ASCII-specific legend position using character coordinates
         use fortplot_legend, only: legend_t, LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, &
-                                   LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT
+                                   LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT, LEGEND_EAST
         class(ascii_context), intent(in) :: this
         type(legend_t), intent(in) :: legend
         real(wp), intent(out) :: x, y
@@ -488,6 +488,9 @@ contains
         case (LEGEND_LOWER_RIGHT)
             x = real(this%width, wp) - legend_width - margin_x
             y = real(this%height, wp) - legend_height - margin_y
+        case (LEGEND_EAST)
+            x = real(this%width, wp) - legend_width - margin_x
+            y = (real(this%height, wp) - legend_height)*0.5_wp
         case default
             ! Default to upper right corner
             x = real(this%width, wp) - legend_width - margin_x

--- a/src/backends/ascii/fortplot_ascii_legend.f90
+++ b/src/backends/ascii/fortplot_ascii_legend.f90
@@ -7,7 +7,8 @@ module fortplot_ascii_legend
     !! Author: fortplot contributors
 
     use fortplot_legend, only: legend_t, render_ascii_legend
-    use fortplot_legend, only: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT
+    use fortplot_legend, only: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT, &
+                           LEGEND_EAST
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_ascii_utils, only: is_legend_entry_text, is_registered_legend_label, is_autopct_text
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -91,6 +92,9 @@ contains
         case (LEGEND_LOWER_RIGHT)
             x = real(width, wp) - legend_width - margin_x
             y = real(height, wp) - legend_height - margin_y
+        case (LEGEND_EAST)
+            x = real(width, wp) - legend_width - margin_x
+            y = (real(height, wp) - legend_height)*0.5_wp
         case default
             ! Default to upper right corner
             x = real(width, wp) - legend_width - margin_x

--- a/src/ui/fortplot_legend.f90
+++ b/src/ui/fortplot_legend.f90
@@ -15,12 +15,14 @@ module fortplot_legend
     private
     public :: legend_t, legend_entry_t, create_legend, legend_render, render_ascii_legend, render_standard_legend
     public :: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT
+    public :: LEGEND_EAST
     
     ! Legend position constants
     integer, parameter :: LEGEND_UPPER_LEFT = 1
-    integer, parameter :: LEGEND_UPPER_RIGHT = 2  
+    integer, parameter :: LEGEND_UPPER_RIGHT = 2
     integer, parameter :: LEGEND_LOWER_LEFT = 3
     integer, parameter :: LEGEND_LOWER_RIGHT = 4
+    integer, parameter :: LEGEND_EAST = 5
     
     type :: legend_entry_t
         !! Single Responsibility: Represents one legend entry
@@ -114,10 +116,12 @@ contains
             this%position = LEGEND_UPPER_LEFT
         case ("upper right")
             this%position = LEGEND_UPPER_RIGHT
-        case ("lower left") 
+        case ("lower left")
             this%position = LEGEND_LOWER_LEFT
         case ("lower right")
             this%position = LEGEND_LOWER_RIGHT
+        case ("east")
+            this%position = LEGEND_EAST
         case default
             this%position = LEGEND_UPPER_RIGHT  ! Default
         end select
@@ -453,6 +457,9 @@ contains
             case (LEGEND_LOWER_RIGHT)
                 ascii_x = max(margin_x, screen_width - longest_entry - margin_x + 1)
                 ascii_y = max(margin_y + 1, screen_height - total_lines - margin_y + 2)
+            case (LEGEND_EAST)
+                ascii_x = max(margin_x, screen_width - longest_entry - margin_x + 1)
+                ascii_y = (screen_height - total_lines)*0.5_wp + 1
             case default
                 ascii_x = max(margin_x, screen_width - longest_entry - margin_x + 1)
                 ascii_y = margin_y + 1

--- a/src/ui/fortplot_legend_layout.f90
+++ b/src/ui/fortplot_legend_layout.f90
@@ -226,10 +226,11 @@ contains
         
         ! Local constants to avoid circular dependency
         integer, parameter :: LEGEND_UPPER_LEFT = 1
-        integer, parameter :: LEGEND_UPPER_RIGHT = 2  
+        integer, parameter :: LEGEND_UPPER_RIGHT = 2
         integer, parameter :: LEGEND_LOWER_LEFT = 3
         integer, parameter :: LEGEND_LOWER_RIGHT = 4
-        
+        integer, parameter :: LEGEND_EAST = 5
+
         select case (position)
         case (LEGEND_UPPER_LEFT)
             box%x = margins(1)
@@ -243,6 +244,9 @@ contains
         case (LEGEND_LOWER_RIGHT)
             box%x = data_width - box%width - margins(1)
             box%y = box%height + margins(2)
+        case (LEGEND_EAST)
+            box%x = data_width + margins(1)
+            box%y = (data_height - box%height)*0.5_wp
         case default  ! Default to upper right
             box%x = data_width - box%width - margins(1)
             box%y = data_height - margins(2)

--- a/test/test_pie_legend_east_pdf.f90
+++ b/test/test_pie_legend_east_pdf.f90
@@ -1,0 +1,55 @@
+program test_pie_legend_east_pdf
+    !! Verify pie chart legend at 'east' position renders outside plot area in PDF.
+    !! Regression test for issue #1680: legend box overlapped pie slice labels
+    !! causing merged text (e.g. "OnlineNorth" instead of separate entries).
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, pie, title, legend, savefig
+    use test_pdf_utils, only: extract_pdf_stream_text
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'build/test/output/test_pie_legend_east.pdf'
+    character(len=:), allocatable :: stream_text
+    integer :: status
+    logical :: found_north, found_online, found_merged
+    real(wp) :: values(5)
+    character(len=6) :: labels(5)
+
+    values = [30.0_wp, 22.0_wp, 18.0_wp, 15.0_wp, 15.0_wp]
+    labels(1) = 'North'
+    labels(2) = 'East'
+    labels(3) = 'South'
+    labels(4) = 'West'
+    labels(5) = 'Online'
+
+    call figure(figsize=[6.0_wp, 6.0_wp])
+    call pie(values, labels=labels)
+    call title('Regional revenue share')
+    call legend('east')
+    call savefig(out_pdf)
+
+    call extract_pdf_stream_text(out_pdf, stream_text, status)
+    if (status /= 0) then
+        print *, 'FAIL: unable to read PDF stream'
+        stop 1
+    end if
+
+    found_north = index(stream_text, '(North)') > 0
+    found_online = index(stream_text, '(Online)') > 0
+    found_merged = index(stream_text, '(OnlineNorth)') > 0 .or. &
+                   index(stream_text, '(NorthOnline)') > 0
+
+    if (.not. found_north) then
+        print *, 'FAIL: legend entry "North" not found in PDF stream'
+        stop 1
+    end if
+    if (.not. found_online) then
+        print *, 'FAIL: pie slice label "Online" not found in PDF stream'
+        stop 1
+    end if
+    if (found_merged) then
+        print *, 'FAIL: legend and slice label merged in PDF (issue #1680)'
+        stop 1
+    end if
+
+    print *, 'PASS: pie legend at east position does not merge with slice labels in PDF'
+end program test_pie_legend_east_pdf


### PR DESCRIPTION
## Summary

The `'east'` legend location string was unrecognized by `legend_set_position` and fell through to `LEGEND_UPPER_RIGHT`, placing the legend inside the plot area where it overlapped pie slice labels in PDF output. The merged text appeared as "OnlineNorth" instead of two separate entries.

Added `LEGEND_EAST` position constant that places the legend outside the plot area to the right, centered vertically — matching matplotlib semantics.

## Changes

- `src/ui/fortplot_legend.f90`: new `LEGEND_EAST` constant (5); `'east'` case in `legend_set_position`; ASCII layout case
- `src/ui/fortplot_legend_layout.f90`: `LEGEND_EAST` handling in `calculate_legend_position`
- `src/backends/ascii/fortplot_ascii.f90`: `LEGEND_EAST` case in `ascii_calculate_legend_position`
- `src/backends/ascii/fortplot_ascii_legend.f90`: `LEGEND_EAST` case in `calculate_ascii_legend_position`
- `test/test_pie_legend_east_pdf.f90`: regression test — creates pie chart with `'east'` legend, saves PDF, verifies no merged text

## Verification

### Test passes after fix

```
$ fpm test --target test_pie_legend_east_pdf
 PASS: pie legend at east position does not merge with slice labels in PDF
```

### CI test suite passes

```
$ make test-ci
CI essential test suite completed successfully
```

### Artifact verification passes

```
$ make verify-artifacts
Artifact verification passed.
```

### PDF text extraction confirms fix

Before: legend text and slice label merged into single string in PDF.
After: `pdftotext` shows "Online" and "North" as separate text entries:
```
$ pdftotext stateful_sales.pdf -
Regional revenue share
Online
North
15.0%
30.0%
...
```