### PR TITLE
feat: add 'east' legend position support to SVG backend (fixes #1826)

### DIFF
--- a/src/backends/vector/fortplot_svg.f90
+++ b/src/backends/vector/fortplot_svg.f90
@@ -551,6 +551,10 @@ contains
         case ('lower right')
             x = real(this%plot_area%left + this%plot_area%width, wp) - 110.0_wp
             y = real(this%plot_area%bottom + this%plot_area%height, wp) - 60.0_wp
+        case ('east')
+            x = real(this%plot_area%left + this%plot_area%width, wp) + 10.0_wp
+            y = real(this%plot_area%bottom, wp) + &
+                real(this%plot_area%height, wp)*0.5_wp - 30.0_wp
         case default
             x = real(this%plot_area%left + this%plot_area%width, wp) - 110.0_wp
             y = real(this%plot_area%bottom, wp) + 10.0_wp


### PR DESCRIPTION
## Summary

Add `case ("east")` to `svg_calc_legend_pos` in the SVG backend to match the `LEGEND_EAST` semantics already implemented in PDF, PNG, and ASCII backends.

## Changes

- `src/backends/vector/fortplot_svg.f90`: added `case ("east")` in `svg_calc_legend_pos` to position the legend outside the plot area to the right, centered vertically

## Verification

### Build

```
$ fpm build
[100%] Project compiled successfully.
```

### SVG backend test

```
$ fpm test --target test_svg_backend
 All SVG backend tests passed
```

The `east` position places the legend at `x = plot_area_left + plot_area_width + 10` (outside right edge) and `y = plot_area_bottom + plot_area_height * 0.5 - 30` (centered vertically), consistent with `LEGEND_EAST` semantics in `fortplot_legend_layout.f90` and `fortplot_ascii_legend.f90`.
