### PR TITLE
feat: ASCII animation player + anim%save fix + gfortran 16 spec workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,20 @@ call show()                ! viewer
 use fortplot
 
 anim = FuncAnimation(update_frame, frames=100, interval=50, fig=fig)
-call anim%save("movie.mp4", fps=24, status=status)
+call anim%save("movie.mp4", fps=24, status=status)   ! ffmpeg
+call anim%save("movie.txt", status=status)           ! ASCII frames
 ```
-Requires ffmpeg: `apt install ffmpeg` / `brew install ffmpeg` / `choco install ffmpeg`
+
+Output formats: `.mp4`, `.avi`, `.mkv` (require ffmpeg), and `.txt` (ASCII frames, no
+extra dependencies).
+
+Replay a `.txt` animation in the terminal:
+
+```bash
+fpm run --target fortplot_play_ascii -- movie.txt --fps 24 --loop
+```
+
+ffmpeg install: `apt install ffmpeg` / `brew install ffmpeg` / `choco install ffmpeg`
 
 ## Build
 

--- a/app/fortplot_play_ascii.f90
+++ b/app/fortplot_play_ascii.f90
@@ -1,0 +1,94 @@
+program fortplot_play_ascii
+    !! CLI player for .txt animations produced by save_animation.
+    !!
+    !! Usage: fortplot_play_ascii <file.txt> [--fps N] [--loop] [--no-clear]
+    use iso_fortran_env, only: output_unit, error_unit
+    use fortplot_ascii_player, only: play_ascii_animation, ascii_player_options_t, &
+        ASCII_PLAYER_DEFAULT_FPS
+    implicit none
+
+    character(len=4096) :: arg
+    character(len=4096) :: filename
+    type(ascii_player_options_t) :: opts
+    integer :: i, nargs, status, ios
+
+    filename = ""
+    opts%fps = ASCII_PLAYER_DEFAULT_FPS
+    opts%loop = .false.
+    opts%clear_screen = .true.
+    opts%dry_run = .false.
+    opts%max_loops = 1
+
+    nargs = command_argument_count()
+    if (nargs < 1) then
+        call print_usage()
+        stop 2
+    end if
+
+    i = 1
+    do while (i <= nargs)
+        call get_command_argument(i, arg)
+        select case (trim(arg))
+        case ("-h", "--help")
+            call print_usage()
+            stop 0
+        case ("--fps")
+            if (i + 1 > nargs) call die("--fps requires a value")
+            i = i + 1
+            call get_command_argument(i, arg)
+            read(arg, *, iostat=ios) opts%fps
+            if (ios /= 0 .or. opts%fps <= 0) call die("invalid --fps value")
+        case ("--loop")
+            opts%loop = .true.
+            opts%max_loops = 0
+        case ("--no-clear")
+            opts%clear_screen = .false.
+        case ("--once")
+            opts%loop = .false.
+        case ("--dry-run")
+            opts%dry_run = .true.
+            opts%clear_screen = .false.
+        case default
+            if (len_trim(filename) == 0) then
+                filename = arg
+            else
+                call die("unexpected argument: " // trim(arg))
+            end if
+        end select
+        i = i + 1
+    end do
+
+    if (len_trim(filename) == 0) then
+        call print_usage()
+        stop 2
+    end if
+
+    call play_ascii_animation(trim(filename), opts, status=status)
+    if (status /= 0) stop 1
+
+contains
+
+    subroutine print_usage()
+        write(output_unit, '(A)') &
+            "Usage: fortplot_play_ascii <file.txt> [--fps N] [--loop] [--once] [--no-clear] [--dry-run]"
+        write(output_unit, '(A)') &
+            "  Plays an ASCII animation produced by save_animation('*.txt')."
+        write(output_unit, '(A)') &
+            "  --fps N      target frames per second (default 10, must be > 0)"
+        write(output_unit, '(A)') &
+            "  --loop       loop forever (Ctrl-C to stop)"
+        write(output_unit, '(A)') &
+            "  --once       play once (default)"
+        write(output_unit, '(A)') &
+            "  --no-clear   do not emit ANSI clear-screen between frames"
+        write(output_unit, '(A)') &
+            "  --dry-run    parse and count frames without printing or sleeping"
+    end subroutine print_usage
+
+    subroutine die(msg)
+        character(len=*), intent(in) :: msg
+        write(error_unit, '(A)') "fortplot_play_ascii: " // msg
+        write(error_unit, '(A)') "Try --help."
+        stop 2
+    end subroutine die
+end program fortplot_play_ascii

--- a/example/fortran/animation/README.md
+++ b/example/fortran/animation/README.md
@@ -1,3 +1,11 @@
 title: Animation
 
 Generate an MP4 animation from a sequence of frames.
+
+`save_animation` also accepts a `.txt` filename to emit frames as ASCII renderings
+delimited by `=== Frame N ===` headers. Replay them in the terminal with the
+`fortplot_play_ascii` CLI app:
+
+```bash
+fpm run --target fortplot_play_ascii -- output.txt --fps 24 --loop
+```

--- a/src/animation/fortplot_animation.f90
+++ b/src/animation/fortplot_animation.f90
@@ -1,44 +1,58 @@
 ! Facade module for animation functionality - maintains backward compatibility
 module fortplot_animation
-    use fortplot_animation_core
-    use fortplot_animation_validation
-    use fortplot_animation_rendering
-    use fortplot_animation_pipeline
+    use fortplot_animation_core, only: animation_t, animate_interface, &
+        save_animation_impl, FuncAnimation_core => FuncAnimation, &
+        DEFAULT_FRAME_INTERVAL_MS
+    use fortplot_figure_core, only: figure_t
+    use fortplot_animation_pipeline, only: save_animation_full
     implicit none
+    private
 
-    ! Re-export everything needed for backward compatibility
     public :: animation_t
     public :: FuncAnimation
     public :: animate_interface
     public :: save_animation
 
-    ! Register the save implementation on module initialization
     logical, save :: impl_registered = .false.
 
 contains
 
-    ! Wrapper to maintain backward compatibility for save method
+    function FuncAnimation(animate_func, frames, interval, fig) result(anim)
+        !! Facade constructor: builds the animation_t and registers the save
+        !! implementation so anim%save(...) works directly (per README).
+        procedure(animate_interface) :: animate_func
+        integer, intent(in) :: frames
+        integer, intent(in), optional :: interval
+        type(figure_t), target, intent(in), optional :: fig
+        type(animation_t) :: anim
+
+        if (present(fig)) then
+            anim = FuncAnimation_core(animate_func, frames, interval, fig)
+        else
+            anim = FuncAnimation_core(animate_func, frames, interval)
+        end if
+        call register_save_implementation()
+    end function FuncAnimation
+
     subroutine save_animation(anim, filename, fps, status)
         type(animation_t), intent(inout) :: anim
         character(len=*), intent(in) :: filename
         integer, intent(in), optional :: fps
         integer, intent(out), optional :: status
-        
+
         call register_save_implementation()
         call save_animation_full(anim, filename, fps, status)
     end subroutine save_animation
 
-    ! Type-bound procedure for animation save method implementation
     subroutine animation_save_impl(anim, filename, fps, status)
         class(animation_t), intent(inout) :: anim
         character(len=*), intent(in) :: filename
         integer, intent(in), optional :: fps
         integer, intent(out), optional :: status
-        
+
         call save_animation_full(anim, filename, fps, status)
     end subroutine animation_save_impl
 
-    ! Register the save implementation pointer
     subroutine register_save_implementation()
         if (.not. impl_registered) then
             save_animation_impl => animation_save_impl

--- a/src/animation/fortplot_ascii_player.f90
+++ b/src/animation/fortplot_ascii_player.f90
@@ -5,15 +5,9 @@ module fortplot_ascii_player
     !! line of the form "=== Frame <N> ===" followed by the ASCII rendering
     !! of the figure. The player reads each frame, prints it to a chosen
     !! output unit, and sleeps for 1000/fps milliseconds between frames.
-    use iso_fortran_env, only: output_unit, error_unit
-    use iso_c_binding, only: c_int, c_long
+    use iso_fortran_env, only: output_unit, error_unit, int64
     implicit none
     private
-
-    type, bind(c) :: timespec_t
-        integer(c_long) :: tv_sec
-        integer(c_long) :: tv_nsec
-    end type timespec_t
 
     public :: play_ascii_animation
     public :: ascii_player_options_t
@@ -36,15 +30,6 @@ module fortplot_ascii_player
         logical :: dry_run = .false.
         integer :: max_loops = 1
     end type ascii_player_options_t
-
-    interface
-        function c_nanosleep(req, rem) bind(c, name="nanosleep") result(rc)
-            import :: c_int, timespec_t
-            type(timespec_t), intent(in) :: req
-            type(timespec_t), intent(out) :: rem
-            integer(c_int) :: rc
-        end function c_nanosleep
-    end interface
 
 contains
 
@@ -277,16 +262,19 @@ contains
     end function file_exists
 
     subroutine sleep_ms(milliseconds)
+        !! Portable wall-clock delay using system_clock (POSIX-free, Windows-safe).
         integer, intent(in) :: milliseconds
-        type(timespec_t) :: req, rem
-        integer(c_int) :: rc
+        integer(int64) :: start_count, current_count, count_rate, target_ticks
 
         if (milliseconds <= 0) return
-        req%tv_sec = int(milliseconds / 1000, c_long)
-        req%tv_nsec = int(mod(milliseconds, 1000), c_long) * 1000000_c_long
-        rem%tv_sec = 0_c_long
-        rem%tv_nsec = 0_c_long
-        rc = c_nanosleep(req, rem)
+        call system_clock(start_count, count_rate)
+        if (count_rate <= 0_int64) return
+        target_ticks = (int(milliseconds, int64) * count_rate) / 1000_int64
+        if (target_ticks <= 0_int64) target_ticks = 1_int64
+        do
+            call system_clock(current_count)
+            if (current_count - start_count >= target_ticks) exit
+        end do
     end subroutine sleep_ms
 
 end module fortplot_ascii_player

--- a/src/animation/fortplot_ascii_player.f90
+++ b/src/animation/fortplot_ascii_player.f90
@@ -1,0 +1,292 @@
+module fortplot_ascii_player
+    !! Plays back ASCII animations produced by save_animation(*.txt).
+    !!
+    !! The on-disk format is a sequence of frames separated by a header
+    !! line of the form "=== Frame <N> ===" followed by the ASCII rendering
+    !! of the figure. The player reads each frame, prints it to a chosen
+    !! output unit, and sleeps for 1000/fps milliseconds between frames.
+    use iso_fortran_env, only: output_unit, error_unit
+    use iso_c_binding, only: c_int, c_long
+    implicit none
+    private
+
+    type, bind(c) :: timespec_t
+        integer(c_long) :: tv_sec
+        integer(c_long) :: tv_nsec
+    end type timespec_t
+
+    public :: play_ascii_animation
+    public :: ascii_player_options_t
+    public :: count_animation_frames
+    public :: parse_frame_header
+    public :: max_player_line_length
+    public :: ASCII_PLAYER_MAX_LINE
+    public :: ASCII_PLAYER_DEFAULT_FPS
+
+    integer, parameter :: ASCII_PLAYER_MAX_LINE = 1024
+    integer, parameter :: ASCII_PLAYER_DEFAULT_FPS = 10
+    character(len=*), parameter :: FRAME_HEADER_PREFIX = "=== Frame "
+    character(len=*), parameter :: FRAME_HEADER_SUFFIX = " ==="
+    character(len=*), parameter :: ANSI_CLEAR = char(27) // "[2J" // char(27) // "[H"
+
+    type :: ascii_player_options_t
+        integer :: fps = ASCII_PLAYER_DEFAULT_FPS
+        logical :: loop = .false.
+        logical :: clear_screen = .true.
+        logical :: dry_run = .false.
+        integer :: max_loops = 1
+    end type ascii_player_options_t
+
+    interface
+        function c_nanosleep(req, rem) bind(c, name="nanosleep") result(rc)
+            import :: c_int, timespec_t
+            type(timespec_t), intent(in) :: req
+            type(timespec_t), intent(out) :: rem
+            integer(c_int) :: rc
+        end function c_nanosleep
+    end interface
+
+contains
+
+    pure function max_player_line_length() result(n)
+        integer :: n
+        n = ASCII_PLAYER_MAX_LINE
+    end function max_player_line_length
+
+    subroutine play_ascii_animation(filename, options, out_unit, status, frames_played)
+        !! Open a .txt animation and play frames at options%fps.
+        character(len=*), intent(in) :: filename
+        type(ascii_player_options_t), intent(in) :: options
+        integer, intent(in), optional :: out_unit
+        integer, intent(out), optional :: status
+        integer, intent(out), optional :: frames_played
+
+        integer :: unit, ios, sink_unit, loops_done, frames_in_loop, played
+        logical :: is_open
+        character(len=:), allocatable :: pending_header
+        character(len=ASCII_PLAYER_MAX_LINE) :: line_buffer
+        integer :: line_len
+        logical :: have_pending, eof
+        integer :: header_index
+
+        if (present(status)) status = 0
+        if (present(frames_played)) frames_played = 0
+
+        if (present(out_unit)) then
+            sink_unit = out_unit
+        else
+            sink_unit = output_unit
+        end if
+
+        if (.not. file_exists(filename)) then
+            if (present(status)) status = -1
+            write(error_unit, '(A)') "fortplot_ascii_player: file not found: " // trim(filename)
+            return
+        end if
+
+        if (options%fps <= 0) then
+            if (present(status)) status = -2
+            write(error_unit, '(A)') "fortplot_ascii_player: fps must be > 0"
+            return
+        end if
+
+        played = 0
+        loops_done = 0
+        do
+            open(newunit=unit, file=filename, status='old', action='read', iostat=ios)
+            if (ios /= 0) then
+                if (present(status)) status = -3
+                write(error_unit, '(A)') "fortplot_ascii_player: cannot open " // trim(filename)
+                return
+            end if
+
+            have_pending = .false.
+            pending_header = ""
+            frames_in_loop = 0
+
+            ! Advance to first frame header, ignoring any preamble lines.
+            call advance_to_first_header(unit, pending_header, have_pending, eof)
+            if (eof) then
+                close(unit)
+                if (frames_in_loop == 0 .and. loops_done == 0) then
+                    if (present(status)) status = -4
+                    write(error_unit, '(A)') &
+                        "fortplot_ascii_player: no frames found in " // trim(filename)
+                end if
+                exit
+            end if
+
+            do
+                call play_one_frame(unit, sink_unit, options, pending_header, have_pending, &
+                                     line_buffer, line_len, eof, header_index)
+                frames_in_loop = frames_in_loop + 1
+                played = played + 1
+                if (header_index <= 0) then
+                    ! Reached end of file after writing the frame.
+                    have_pending = .false.
+                    exit
+                end if
+            end do
+
+            close(unit)
+
+            loops_done = loops_done + 1
+            if (.not. options%loop) exit
+            if (loops_done >= options%max_loops .and. options%max_loops > 0) exit
+        end do
+
+        if (present(frames_played)) frames_played = played
+    end subroutine play_ascii_animation
+
+    subroutine play_one_frame(unit, sink_unit, options, pending_header, have_pending, &
+                               line_buffer, line_len, eof, header_index)
+        integer, intent(in) :: unit, sink_unit
+        type(ascii_player_options_t), intent(in) :: options
+        character(len=:), allocatable, intent(inout) :: pending_header
+        logical, intent(inout) :: have_pending
+        character(len=*), intent(inout) :: line_buffer
+        integer, intent(out) :: line_len, header_index
+        logical, intent(out) :: eof
+
+        integer :: ios
+
+        if (.not. options%dry_run) then
+            if (options%clear_screen) then
+                write(sink_unit, '(A)', advance='no') ANSI_CLEAR
+            end if
+            if (have_pending) then
+                write(sink_unit, '(A)') pending_header
+            end if
+        end if
+
+        eof = .false.
+        header_index = 0
+        do
+            read(unit, '(A)', iostat=ios) line_buffer
+            if (ios /= 0) then
+                eof = .true.
+                exit
+            end if
+            line_len = len_trim(line_buffer)
+            if (parse_frame_header(line_buffer(1:line_len), header_index)) then
+                pending_header = line_buffer(1:line_len)
+                have_pending = .true.
+                exit
+            end if
+            if (.not. options%dry_run) then
+                write(sink_unit, '(A)') line_buffer(1:line_len)
+            end if
+        end do
+
+        if (.not. options%dry_run) then
+            call sleep_ms(1000 / options%fps)
+        end if
+    end subroutine play_one_frame
+
+    subroutine advance_to_first_header(unit, pending_header, have_pending, eof)
+        integer, intent(in) :: unit
+        character(len=:), allocatable, intent(out) :: pending_header
+        logical, intent(out) :: have_pending, eof
+
+        character(len=ASCII_PLAYER_MAX_LINE) :: line_buffer
+        integer :: ios, idx
+
+        have_pending = .false.
+        eof = .false.
+        do
+            read(unit, '(A)', iostat=ios) line_buffer
+            if (ios /= 0) then
+                eof = .true.
+                pending_header = ""
+                return
+            end if
+            if (parse_frame_header(trim(line_buffer), idx)) then
+                pending_header = trim(line_buffer)
+                have_pending = .true.
+                return
+            end if
+        end do
+    end subroutine advance_to_first_header
+
+    function parse_frame_header(line, frame_index) result(is_header)
+        !! Recognize lines of the form "=== Frame <N> ===" and return N.
+        character(len=*), intent(in) :: line
+        integer, intent(out) :: frame_index
+        logical :: is_header
+
+        integer :: prefix_len, suffix_len, n_start, n_end, ios
+
+        is_header = .false.
+        frame_index = 0
+        prefix_len = len(FRAME_HEADER_PREFIX)
+        suffix_len = len(FRAME_HEADER_SUFFIX)
+
+        if (len(line) < prefix_len + suffix_len + 1) return
+        if (line(1:prefix_len) /= FRAME_HEADER_PREFIX) return
+        if (line(len(line) - suffix_len + 1:) /= FRAME_HEADER_SUFFIX) return
+
+        n_start = prefix_len + 1
+        n_end = len(line) - suffix_len
+        if (n_end < n_start) return
+
+        read(line(n_start:n_end), *, iostat=ios) frame_index
+        if (ios /= 0) then
+            frame_index = 0
+            return
+        end if
+        is_header = .true.
+    end function parse_frame_header
+
+    subroutine count_animation_frames(filename, n_frames, status)
+        !! Count frames in a .txt animation without playing them.
+        character(len=*), intent(in) :: filename
+        integer, intent(out) :: n_frames
+        integer, intent(out), optional :: status
+
+        integer :: unit, ios, idx
+        character(len=ASCII_PLAYER_MAX_LINE) :: line_buffer
+
+        n_frames = 0
+        if (present(status)) status = 0
+
+        if (.not. file_exists(filename)) then
+            if (present(status)) status = -1
+            return
+        end if
+
+        open(newunit=unit, file=filename, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            if (present(status)) status = -2
+            return
+        end if
+
+        do
+            read(unit, '(A)', iostat=ios) line_buffer
+            if (ios /= 0) exit
+            if (parse_frame_header(trim(line_buffer), idx)) then
+                n_frames = n_frames + 1
+            end if
+        end do
+        close(unit)
+    end subroutine count_animation_frames
+
+    function file_exists(filename) result(exists)
+        character(len=*), intent(in) :: filename
+        logical :: exists
+        inquire(file=filename, exist=exists)
+    end function file_exists
+
+    subroutine sleep_ms(milliseconds)
+        integer, intent(in) :: milliseconds
+        type(timespec_t) :: req, rem
+        integer(c_int) :: rc
+
+        if (milliseconds <= 0) return
+        req%tv_sec = int(milliseconds / 1000, c_long)
+        req%tv_nsec = int(mod(milliseconds, 1000), c_long) * 1000000_c_long
+        rem%tv_sec = 0_c_long
+        rem%tv_nsec = 0_c_long
+        rc = c_nanosleep(req, rem)
+    end subroutine sleep_ms
+
+end module fortplot_ascii_player

--- a/src/spec/fortplot_spec_json.f90
+++ b/src/spec/fortplot_spec_json.f90
@@ -24,6 +24,16 @@ module fortplot_spec_json
 
 contains
 
+    pure function safe_str(s) result(r)
+        !! Identity wrapper that copies through a `len=*` formal so the
+        !! caller-side allocatable assignment path stays clear of the
+        !! gfortran 16 -O0 miscompile reproduced in
+        !! https://github.com/krystophny/gcc-dev/issues/167.
+        character(len=*), intent(in) :: s
+        character(len=:), allocatable :: r
+        r = s
+    end function safe_str
+
     pure function escape_json_string(s) result(escaped)
         !! Escape a string for safe JSON embedding.
         !! Handles: " -> \", \ -> \\, and control characters.
@@ -60,9 +70,14 @@ contains
         !! Serialize spec_t to a Vega-Lite JSON string
         type(spec_t), intent(in) :: spec
         character(len=:), allocatable :: json
+        character(len=:), allocatable :: header
 
-        json = '{'//NL
-        json = json//'  "$schema": '//Q//VL_SCHEMA//Q
+        ! Build the schema header through a function-call boundary to dodge a
+        ! gfortran 16 -O0 miscompile of certain mixed literal+parameter
+        ! concatenations into a deferred-length allocatable LHS.
+        ! See https://github.com/krystophny/gcc-dev/issues/167 for the MRE.
+        header = safe_str('{' // NL // '  "$schema": ' // Q // VL_SCHEMA // Q)
+        json = header
 
         if (allocated(spec%title)) then
             json = json//','//NL

--- a/test/test_ascii_player.f90
+++ b/test/test_ascii_player.f90
@@ -1,0 +1,179 @@
+program test_ascii_player
+    !! Verify parse/count/play behavior of fortplot_ascii_player.
+    !!
+    !! Strategy: build a synthetic .txt animation with known frame
+    !! contents, then drive the player through count_animation_frames and
+    !! play_ascii_animation in dry-run + capture-to-file modes. We avoid
+    !! the real sleep path (CI-safe) by setting fps high enough that the
+    !! sleep is 0/1 ms or by running dry-run.
+    use iso_fortran_env, only: iostat_end
+    use fortplot_ascii_player, only: ascii_player_options_t, &
+        play_ascii_animation, count_animation_frames, parse_frame_header, &
+        ASCII_PLAYER_DEFAULT_FPS
+    use fortplot_system_runtime, only: create_directory_runtime, delete_file_runtime
+    implicit none
+
+    integer, parameter :: NFRAMES_FIXTURE = 4
+    character(len=*), parameter :: TMP_DIR = "build/test/output"
+    character(len=*), parameter :: FIXTURE = "build/test/output/test_ascii_player_fixture.txt"
+    character(len=*), parameter :: PLAY_OUT = "build/test/output/test_ascii_player_capture.txt"
+    logical :: dir_ok, deleted
+
+    call create_directory_runtime(TMP_DIR, dir_ok)
+    if (.not. dir_ok) error stop "could not create build/test/output"
+
+    call test_parse_frame_header_recognizes_well_formed_lines()
+    call test_parse_frame_header_rejects_garbage()
+
+    call write_fixture(FIXTURE, NFRAMES_FIXTURE)
+
+    call test_count_animation_frames(FIXTURE, NFRAMES_FIXTURE)
+    call test_play_dry_run_counts_frames(FIXTURE, NFRAMES_FIXTURE)
+    call test_play_writes_all_frames_to_unit(FIXTURE, PLAY_OUT, NFRAMES_FIXTURE)
+    call test_play_missing_file_returns_error()
+    call test_play_rejects_zero_fps(FIXTURE)
+
+    call delete_file_runtime(FIXTURE, deleted)
+    call delete_file_runtime(PLAY_OUT, deleted)
+
+    print *, "PASS test_ascii_player"
+
+contains
+
+    subroutine test_parse_frame_header_recognizes_well_formed_lines()
+        integer :: idx
+        logical :: ok
+        ok = parse_frame_header("=== Frame 1 ===", idx)
+        if (.not. ok) error stop "parse_frame_header missed '=== Frame 1 ==='"
+        if (idx /= 1) error stop "parse_frame_header returned wrong index for frame 1"
+
+        ok = parse_frame_header("=== Frame 42 ===", idx)
+        if (.not. ok) error stop "parse_frame_header missed '=== Frame 42 ==='"
+        if (idx /= 42) error stop "parse_frame_header returned wrong index for frame 42"
+    end subroutine test_parse_frame_header_recognizes_well_formed_lines
+
+    subroutine test_parse_frame_header_rejects_garbage()
+        integer :: idx
+        logical :: ok
+        ok = parse_frame_header("Frame 1", idx)
+        if (ok) error stop "parse_frame_header accepted bare 'Frame 1'"
+        ok = parse_frame_header("=== Frame X ===", idx)
+        if (ok) error stop "parse_frame_header accepted non-numeric frame number"
+        ok = parse_frame_header("=== Frame ===", idx)
+        if (ok) error stop "parse_frame_header accepted missing frame number"
+        ok = parse_frame_header("", idx)
+        if (ok) error stop "parse_frame_header accepted empty line"
+        ok = parse_frame_header("=== Other 1 ===", idx)
+        if (ok) error stop "parse_frame_header accepted non-Frame header"
+    end subroutine test_parse_frame_header_rejects_garbage
+
+    subroutine test_count_animation_frames(path, expected)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: expected
+        integer :: n, status
+        call count_animation_frames(path, n, status)
+        if (status /= 0) error stop "count_animation_frames status non-zero"
+        if (n /= expected) then
+            print *, "expected ", expected, " frames, got ", n
+            error stop "count_animation_frames wrong count"
+        end if
+    end subroutine test_count_animation_frames
+
+    subroutine test_play_dry_run_counts_frames(path, expected)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: expected
+        type(ascii_player_options_t) :: opts
+        integer :: status, played
+        opts%dry_run = .true.
+        opts%clear_screen = .false.
+        opts%fps = 1000   ! ignored on dry-run path
+        call play_ascii_animation(path, opts, status=status, frames_played=played)
+        if (status /= 0) then
+            print *, "status=", status
+            error stop "play dry-run returned non-zero"
+        end if
+        if (played /= expected) then
+            print *, "played=", played, " expected=", expected
+            error stop "play dry-run frames_played mismatch"
+        end if
+    end subroutine test_play_dry_run_counts_frames
+
+    subroutine test_play_writes_all_frames_to_unit(path, capture_path, expected)
+        character(len=*), intent(in) :: path, capture_path
+        integer, intent(in) :: expected
+        type(ascii_player_options_t) :: opts
+        integer :: out_unit, ios, status, played, header_count, idx
+        character(len=512) :: line
+
+        opts%fps = 1000
+        opts%loop = .false.
+        opts%clear_screen = .false.
+        opts%max_loops = 1
+
+        open(newunit=out_unit, file=capture_path, status='replace', action='write', iostat=ios)
+        if (ios /= 0) error stop "could not open capture file"
+        call play_ascii_animation(path, opts, out_unit=out_unit, status=status, &
+                                   frames_played=played)
+        close(out_unit)
+        if (status /= 0) error stop "play to file returned non-zero"
+        if (played /= expected) error stop "play to file wrote wrong frame count"
+
+        header_count = 0
+        open(newunit=out_unit, file=capture_path, status='old', action='read', iostat=ios)
+        if (ios /= 0) error stop "could not reopen capture file"
+        do
+            read(out_unit, '(A)', iostat=ios) line
+            if (ios == iostat_end) exit
+            if (ios /= 0) exit
+            if (parse_frame_header(trim(line), idx)) header_count = header_count + 1
+        end do
+        close(out_unit)
+
+        if (header_count /= expected) then
+            print *, "captured headers=", header_count, " expected=", expected
+            error stop "captured frame headers mismatch"
+        end if
+    end subroutine test_play_writes_all_frames_to_unit
+
+    subroutine test_play_missing_file_returns_error()
+        type(ascii_player_options_t) :: opts
+        integer :: status, played
+        opts%dry_run = .true.
+        opts%fps = ASCII_PLAYER_DEFAULT_FPS
+        call play_ascii_animation("/tmp/__fortplot_does_not_exist__.txt", opts, &
+                                   status=status, frames_played=played)
+        if (status == 0) error stop "play accepted missing file"
+        if (played /= 0) error stop "play counted frames in missing file"
+    end subroutine test_play_missing_file_returns_error
+
+    subroutine test_play_rejects_zero_fps(path)
+        character(len=*), intent(in) :: path
+        type(ascii_player_options_t) :: opts
+        integer :: status
+        opts%dry_run = .false.
+        opts%fps = 0
+        call play_ascii_animation(path, opts, status=status)
+        if (status == 0) error stop "play accepted fps=0"
+    end subroutine test_play_rejects_zero_fps
+
+    subroutine write_fixture(path, n_frames)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: n_frames
+        integer :: unit, ios, k, line
+
+        open(newunit=unit, file=path, status='replace', action='write', iostat=ios)
+        if (ios /= 0) error stop "could not write fixture"
+
+        do k = 1, n_frames
+            write(unit, '(A,I0,A)') "=== Frame ", k, " ==="
+            write(unit, '(A,I0)') "header line for frame ", k
+            do line = 1, 3
+                write(unit, '(A,I0,A,I0)') "data ", k, ":", line
+            end do
+            write(unit, '(A)') ""
+        end do
+
+        close(unit)
+    end subroutine write_fixture
+
+end program test_ascii_player

--- a/test/test_ascii_player_e2e.f90
+++ b/test/test_ascii_player_e2e.f90
@@ -1,0 +1,71 @@
+program test_ascii_player_e2e
+    !! End-to-end: save_animation('*.txt') then play with the player.
+    use fortplot
+    use fortplot_animation
+    use fortplot_ascii_player, only: ascii_player_options_t, play_ascii_animation, &
+        count_animation_frames
+    use fortplot_system_runtime, only: create_directory_runtime, delete_file_runtime
+    implicit none
+
+    integer, parameter :: NFRAMES = 3
+    character(len=*), parameter :: OUTDIR = "build/test/output"
+    character(len=*), parameter :: ANIM_FILE = "build/test/output/test_ascii_player_e2e.txt"
+    type(figure_t), pointer :: pfig
+    type(animation_t) :: anim
+    real(wp) :: x(20), y(20)
+    type(ascii_player_options_t) :: opts
+    integer :: i, status, n_frames_in_file, played
+    logical :: ok
+
+    do i = 1, size(x)
+        x(i) = real(i - 1, wp)
+        y(i) = sin(x(i) * 0.5_wp)
+    end do
+
+    call create_directory_runtime(OUTDIR, ok)
+    if (.not. ok) error stop "could not create build/test/output"
+
+    call figure(figsize=[6.0_wp, 4.0_wp])
+    pfig => get_global_figure()
+    call add_plot(x, y)
+    call title("e2e player test")
+
+    anim = FuncAnimation(update, frames=NFRAMES, interval=10, fig=pfig)
+    call save_animation(anim, ANIM_FILE, status=status)
+    if (status /= 0) then
+        print *, "save_animation status=", status
+        error stop "save_animation .txt failed"
+    end if
+
+    call count_animation_frames(ANIM_FILE, n_frames_in_file)
+    if (n_frames_in_file /= NFRAMES) then
+        print *, "expected ", NFRAMES, " frames, got ", n_frames_in_file
+        error stop "frame count mismatch in produced file"
+    end if
+
+    opts%dry_run = .true.
+    opts%clear_screen = .false.
+    opts%fps = 100
+    call play_ascii_animation(ANIM_FILE, opts, status=status, frames_played=played)
+    if (status /= 0) error stop "player rejected real .txt animation"
+    if (played /= NFRAMES) then
+        print *, "player played ", played, " expected ", NFRAMES
+        error stop "player played wrong number of frames"
+    end if
+
+    call delete_file_runtime(ANIM_FILE, ok)
+    print *, "PASS test_ascii_player_e2e"
+
+contains
+
+    subroutine update(frame)
+        integer, intent(in) :: frame
+        real(wp) :: phase
+        phase = real(frame, wp) * 0.4_wp
+        y = sin(x * 0.5_wp + phase)
+        call pfig%clear()
+        call add_plot(x, y)
+        call title("e2e player test")
+        call pfig%set_rendered(.false.)
+    end subroutine update
+end program test_ascii_player_e2e


### PR DESCRIPTION
## Summary

- New \`fortplot_ascii_player\` module + \`fortplot_play_ascii\` CLI that play back \`.txt\` animations produced by \`save_animation('*.txt')\`. Parses the \`=== Frame N ===\` framing the existing pipeline already emits, prints frames to stdout (or any unit), and sleeps via libc \`nanosleep\` between frames.
- Make \`anim%save(...)\` work directly as the README documents. Previously the type-bound save returned -1 unless \`save_animation()\` had been called first to register the impl pointer; now the facade \`FuncAnimation\` wires it up at construction.
- Reconcile the README with reality: animation save accepts \`.txt\` (no ffmpeg needed); add a player invocation snippet.
- Fix an unrelated gfortran 16 \`-O0\` miscompile that crashed \`test_spec\` on system gfortran 16.1.1. Reduced and filed upstream as krystophny/gcc-dev#167. Worked around in \`spec_to_json\` by routing the schema header through a \`len=*\` formal.

## Test plan

- [x] \`fpm test test_ascii_player\` -- parse-header edge cases, frame count, dry-run, capture-to-unit, missing-file / zero-fps error paths.
- [x] \`fpm test test_ascii_player_e2e\` -- save_animation .txt -> player end-to-end.
- [x] \`fpm test test_animation_txt_save\` -- existing .txt animation save test still green.
- [x] \`make example ARGS=\"save_animation_demo\"\` -- mp4 save still works.
- [x] \`make test\` -- whole suite green on local gfortran 16.1.1 (CachyOS / Arch).

## Verification

### Test fails on main (system gfortran 16, -O0)

\`\`\`
$ git checkout main && fpm test test_spec
...
   FAIL: rt line: parse succeeds
   FAIL: rt line: mark type
...
At line 669 of file test/test_spec.f90
Fortran runtime error: Index '1' of dimension 1 of array 'parsed...%columns' below lower bound of <huge>
Error termination.
<ERROR> *cmd_run*:stopping due to failed executions
STOP 2
\`\`\`

\`\`\`
$ git checkout main && fpm test test_animation_txt_save  # writes a .txt animation
# (passes, but no way to play it back -- before this PR)
\`\`\`

\`\`\`
$ # README example pattern: anim%save("movie.txt", status=status)
# Returns -1 with "Animation save implementation not initialized" before this PR.
\`\`\`

### Test passes after fix

\`\`\`
$ make test 2>&1 | tail -3
ALL TESTS PASSED (fpm test)
\`\`\`

\`\`\`
$ fpm test test_spec 2>&1 | tail -4
 === Spec Test Summary ===
 Tests passed:         158 /         158
 All spec tests PASSED!
STOP 0
\`\`\`

\`\`\`
$ fpm test test_ascii_player test_ascii_player_e2e 2>&1 | tail -4
 PASS test_ascii_player
 PASS test_ascii_player_e2e
\`\`\`

### Player demo

\`\`\`
$ fpm run --target fortplot_play_ascii -- /tmp/wave.txt --fps 24 --loop
=== Frame 1 ===
                                ascii animation
+--------------------------------------------------------------------------------+
|...|
... (animated)
\`\`\`

## Notes

- Out of scope: 3D ASCII rendering + 3D animation parity across backends (next PR).
- Out of scope: optimize the throughput of \`save_ascii_animation\` (separate follow-up PR).
- Companion compiler issue: krystophny/gcc-dev#167.