### PR TITLE
fix: rename fortplot_figure_core_compat to _io_figure (fixes #1832)

### DIFF
--- a/src/figures/core/fortplot_figure_core_io_figure.f90
+++ b/src/figures/core/fortplot_figure_core_io_figure.f90
@@ -447,16 +447,17 @@ contains
 end module fortplot_figure_core_config
 ! ==== End: src/figures/core/fortplot_figure_core_config.f90 ====
 
-! ==== Begin: src/figures/core/fortplot_figure_core_compat.f90 ====
+! ==== Begin: src/figures/core/fortplot_figure_core_figure.f90 ====
 
-module fortplot_figure_core_compat
-    !! Figure backward compatibility and animation support module
+module fortplot_figure_core_io_figure
+    !! Figure-suffixed public API module
     !!
-    !! This module contains backward compatibility and animation methods
+    !! This module provides the _figure-suffixed public API layer for
+    !! figure state accessors, animation support, and backend operations,
     !! extracted from fortplot_figure_core for architectural compliance
     !!
     !! ARCHITECTURAL REFACTORING (Issue #678):
-    !! - Focused module for backward compatibility operations
+    !! - Focused module for _figure-suffixed public API
     !! - Single Responsibility Principle compliance
     !! - Clean separation from core plotting functionality
 
@@ -598,5 +599,5 @@ contains
         y_max = get_figure_y_max(state)
     end function get_y_max_figure
 
-end module fortplot_figure_core_compat
-! ==== End: src/figures/core/fortplot_figure_core_compat.f90 ====
+end module fortplot_figure_core_io_figure
+! ==== End: src/figures/core/fortplot_figure_core_figure.f90 ====


### PR DESCRIPTION
## Summary

Rename module `fortplot_figure_core_compat` to `fortplot_figure_core_io_figure` and file `fortplot_figure_core_io_compat.f90` to `fortplot_figure_core_io_figure.f90`.

The `_compat` suffix misleadingly suggested legacy passthrough wrappers. The module provides the `_figure`-suffixed public API layer with auto-render-before-extract behaviour, not backward-compatibility shims.

## Changes

- Rename file: `fortplot_figure_core_io_compat.f90` → `fortplot_figure_core_io_figure.f90`
- Rename module: `fortplot_figure_core_compat` → `fortplot_figure_core_io_figure`
- Update module docstring to describe actual purpose
- Update internal `Begin/End` comments

## Verification

### Build passes
```
$ make build
[100%] Project compiled successfully.
```

### CI test suite passes
```
$ make test-ci
CI essential test suite completed successfully
```

### No external dependencies
The module `fortplot_figure_core_compat` was not `use`d by any other file in the codebase. All references were internal to the renamed file.
