### PR TITLE
refactor: reduce render_subplots below 100-line hard limit (fixes #1777)

### DIFF
--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -83,7 +83,7 @@ contains
             gap_h = hspace*ax_h
         end if
 
-       do i = 1, nr
+        do i = 1, nr
             do j = 1, nc
                 call render_subplot_cell( &
                     state, subplots_array(i, j), i, j, have_tight, &

--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -36,10 +36,6 @@ contains
         real(wp) :: total_w, total_h
         real(wp) :: ax_w, ax_h
         real(wp) :: gap_w, gap_h
-        real(wp) :: subplot_left, subplot_right
-        real(wp) :: subplot_bottom, subplot_top
-        real(wp) :: lxmin, lxmax, lymin, lymax
-        real(wp) :: lxmin_t, lxmax_t, lymin_t, lymax_t
         character(len=64) :: x_date_format, y_date_format
         real(wp) :: suptitle_height_frac
         real(wp) :: fig_w, fig_h
@@ -87,75 +83,92 @@ contains
             gap_h = hspace*ax_h
         end if
 
-        do i = 1, nr
+       do i = 1, nr
             do j = 1, nc
-                if (have_tight) then
-                    call set_subplot_margins(state%backend, left_f(i, j), &
-                                             right_f(i, j), bottom_f(i, j), &
-                                             top_f(i, j))
-                else
-                    subplot_left = base_left + real(j - 1, wp)*(ax_w + gap_w)
-                    subplot_right = subplot_left + ax_w
-                    subplot_top = base_top - real(i - 1, wp)*(ax_h + gap_h)
-                    subplot_bottom = subplot_top - ax_h
-                    call set_subplot_margins(state%backend, subplot_left, &
-                                             subplot_right, subplot_bottom, &
-                                             subplot_top)
-                end if
-
-                call calculate_figure_data_ranges(subplots_array(i, j)%plots, &
-                                                  subplots_array(i, j)%plot_count, &
-                                                  subplots_array(i, j)%xlim_set, &
-                                                  subplots_array(i, j)%ylim_set, &
-                                                  lxmin, lxmax, lymin, lymax, &
-                                                  lxmin_t, lxmax_t, lymin_t, lymax_t, &
-                                                  state%xscale, state%yscale, &
-                                                  state%symlog_threshold)
-
-                call setup_coordinate_system(state%backend, lxmin_t, lxmax_t, &
-                                             lymin_t, lymax_t)
-
-                call render_figure_axes(state%backend, state%xscale, state%yscale, &
-                                        state%symlog_threshold, lxmin, lxmax, &
-                                        lymin, lymax, subplots_array(i, j)%title, &
-                                        subplots_array(i, j)%xlabel, &
-                                        subplots_array(i, j)%ylabel, &
-                                        subplots_array(i, j)%plots, &
-                                        subplots_array(i, j)%plot_count, &
-                                        has_twinx=.false., has_twiny=.false., &
-                                        state=state)
-
-                if (subplots_array(i, j)%plot_count > 0) then
-                    call render_all_plots(state%backend, subplots_array(i, j)%plots, &
-                                          subplots_array(i, j)%plot_count, &
-                                          lxmin_t, lxmax_t, &
-                                          lymin_t, lymax_t, state%xscale, &
-                                          state%yscale, &
-                                          state%symlog_threshold, state%width, &
-                                          state%height, &
-                                          state%margin_left, state%margin_right, &
-                                          state%margin_bottom, &
-                                          state%margin_top)
-                end if
-
-                call render_figure_axes_labels_only(state%backend, state%xscale, &
-                                                    state%yscale, &
-                                                    state%symlog_threshold, lxmin, &
-                                                    lxmax, lymin, &
-                                                    lymax, subplots_array(i, j)%title, &
-                                                    subplots_array(i, j)%xlabel, &
-                                                    subplots_array(i, j)%ylabel, &
-                                                    subplots_array(i, j)%plots, &
-                                                    subplots_array(i, j)%plot_count, &
-                                                    has_twinx=.false., &
-                                                    has_twiny=.false., &
-                                                    x_date_format=trim(x_date_format), &
-                                                    y_date_format=trim(y_date_format))
+                call render_subplot_cell( &
+                    state, subplots_array(i, j), i, j, have_tight, &
+                    left_f, right_f, bottom_f, top_f, &
+                    base_left, base_bottom, base_top, &
+                    ax_w, ax_h, gap_w, gap_h, &
+                    x_date_format, y_date_format)
             end do
         end do
 
         call render_suptitle(state, suptitle_height_frac)
     end subroutine render_subplots
+
+    subroutine render_subplot_cell(state, sp, i, j, have_tight, &
+                                    left_f, right_f, bottom_f, top_f, &
+                                    base_left, base_bottom, base_top, &
+                                    ax_w, ax_h, gap_w, gap_h, &
+                                    x_date_format, y_date_format)
+        !! Render a single subplot cell: margins, axes, plots, labels
+        type(figure_state_t), intent(inout) :: state
+        type(subplot_data_t), intent(in) :: sp
+        integer, intent(in) :: i, j
+        logical, intent(in) :: have_tight
+        real(wp), intent(in), optional :: left_f(:,:), right_f(:,:)
+        real(wp), intent(in), optional :: bottom_f(:,:), top_f(:,:)
+        real(wp), intent(in) :: base_left, base_bottom, base_top
+        real(wp), intent(in) :: ax_w, ax_h, gap_w, gap_h
+        character(len=*), intent(in) :: x_date_format, y_date_format
+
+        real(wp) :: subplot_left, subplot_right
+        real(wp) :: subplot_bottom, subplot_top
+        real(wp) :: lxmin, lxmax, lymin, lymax
+        real(wp) :: lxmin_t, lxmax_t, lymin_t, lymax_t
+
+        ! Set margins
+        if (have_tight) then
+            call set_subplot_margins(state%backend, left_f(i, j), &
+                                      right_f(i, j), bottom_f(i, j), &
+                                      top_f(i, j))
+        else
+            subplot_left = base_left + real(j - 1, wp)*(ax_w + gap_w)
+            subplot_right = subplot_left + ax_w
+            subplot_top = base_top - real(i - 1, wp)*(ax_h + gap_h)
+            subplot_bottom = subplot_top - ax_h
+            call set_subplot_margins(state%backend, subplot_left, &
+                                      subplot_right, subplot_bottom, &
+                                      subplot_top)
+        end if
+
+        call calculate_figure_data_ranges(sp%plots, sp%plot_count, &
+                                          sp%xlim_set, sp%ylim_set, &
+                                          lxmin, lxmax, lymin, lymax, &
+                                          lxmin_t, lxmax_t, lymin_t, lymax_t, &
+                                          state%xscale, state%yscale, &
+                                          state%symlog_threshold)
+
+        call setup_coordinate_system(state%backend, lxmin_t, lxmax_t, &
+                                     lymin_t, lymax_t)
+
+        call render_figure_axes(state%backend, state%xscale, state%yscale, &
+                                state%symlog_threshold, lxmin, lxmax, &
+                                lymin, lymax, sp%title, sp%xlabel, sp%ylabel, &
+                                sp%plots, sp%plot_count, &
+                                has_twinx=.false., has_twiny=.false., &
+                                state=state)
+
+        if (sp%plot_count > 0) then
+            call render_all_plots(state%backend, sp%plots, sp%plot_count, &
+                                  lxmin_t, lxmax_t, lymin_t, lymax_t, &
+                                  state%xscale, state%yscale, &
+                                  state%symlog_threshold, state%width, &
+                                  state%height, &
+                                  state%margin_left, state%margin_right, &
+                                  state%margin_bottom, state%margin_top)
+        end if
+
+        call render_figure_axes_labels_only(state%backend, state%xscale, &
+                                            state%yscale, state%symlog_threshold, &
+                                            lxmin, lxmax, lymin, lymax, &
+                                            sp%title, sp%xlabel, sp%ylabel, &
+                                            sp%plots, sp%plot_count, &
+                                            has_twinx=.false., has_twiny=.false., &
+                                            x_date_format=trim(x_date_format), &
+                                            y_date_format=trim(y_date_format))
+    end subroutine render_subplot_cell
 
     subroutine render_suptitle(state, suptitle_height_frac)
         !! Render the figure-level suptitle above all subplots


### PR DESCRIPTION
## Summary

Extract the per-subplot rendering loop body from `render_subplots` into a new private helper `render_subplot_cell`, reducing the main function from 134 lines to 74 lines (under the 100-line hard limit).

## Changes

- `src/figures/management/fortplot_subplot_rendering.f90`:
  - Extract `render_subplot_cell` (72 lines) handling margins, data ranges, coordinate setup, axes, plots, and labels for one subplot
  - `render_subplots` now 74 lines (was 134)
  - Module total: 298 lines (under 500-line soft limit)

## Verification

### Tests pass

```
$ fpm test --target test_subplots
   PASS: test_subplot_creation
   PASS: test_subplot_layouts
   PASS: test_subplot_plotting
   PASS: test_subplot_independence
   PASS: test_edge_cases
   PASS: test_grid_returns
   PASS: test_stateful_api
 All subplot tests PASSED!
```

### CI suite passes

```
$ make test-ci
CI essential test suite completed successfully
```

### Example renders correctly

```
$ make example ARGS="subplot_demo"
output/example/fortran/subplot_demo/subplot_2x2_demo.png   (52973 bytes)
output/example/fortran/subplot_demo/subplot_1x3_demo.png   (26138 bytes)
```

### Function size compliance

| Function | Before | After |
|----------|--------|-------|
| `render_subplots` | 134 lines | 74 lines |
| `render_subplot_cell` | N/A | 72 lines |
| Module total | 285 lines | 298 lines |

All under the 100-line hard limit per function and 500-line soft limit per module.
