### PR TITLE
polish: move procedure use statements to module header (fixes #1835)

### DIFF
--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -15,6 +15,8 @@ module fortplot_subplot_rendering
     use fortplot_pdf, only: pdf_context
     use fortplot_pdf_core, only: PDF_TITLE_SIZE
     use fortplot_ascii, only: ascii_context
+    use fortplot_raster_labels, only: render_title_centered_with_size
+    use fortplot_pdf_text, only: estimate_pdf_text_width
     implicit none
 
     private
@@ -174,9 +176,6 @@ contains
         !! Render the figure-level suptitle above all subplots
         !! suptitle_height_frac is the fractional height reserved for suptitle
         !! in the figure layout (used to position the title above subplot area)
-        use fortplot_raster_labels, only: render_title_centered_with_size
-        use fortplot_pdf_text, only: estimate_pdf_text_width
-        use fortplot_pdf_core, only: PDF_TITLE_SIZE
         type(figure_state_t), intent(inout) :: state
         real(wp), intent(in) :: suptitle_height_frac
 


### PR DESCRIPTION
## Summary

Move the three `use` statements from inside `render_suptitle` to the module header in `fortplot_subplot_rendering.f90`.

One of the three (`PDF_TITLE_SIZE`) was already imported at module level, so the procedure-level `use` was a duplicate. The other two (`render_title_centered_with_size` and `estimate_pdf_text_width`) are now added to the module header.

## Changes

- Added `use fortplot_raster_labels, only: render_title_centered_with_size` to module header
- Added `use fortplot_pdf_text, only: estimate_pdf_text_width` to module header
- Removed 3 procedure-level `use` statements from `render_suptitle`

## Verification

### Build passes
```
[100%] Project compiled successfully.
```

### All tests pass
```
ALL TESTS PASSED (fpm test)
```
