### PR TITLE
ci: add 3D, streamplot, contour tests to test-ci (fixes #1704)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,12 @@ test-ci:
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_new_plot_types || exit 1
 	@# ASCII animation regression: frame clearing and file content (Issue #1699)
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_ascii_animation_output || exit 1
+	@# 3D plotting regression guard (Issue #1704)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_3d || exit 1
+	@# Streamplot rendering guard (Issue #1704)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_streamplot || exit 1
+	@# Contour level and memory safety guard (Issue #1704)
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_contour || exit 1
 	@echo "CI essential test suite completed successfully"
 
 # Clean build artifacts

--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -3,6 +3,15 @@ module fortplot_matplotlib_scatter
     !!
     !! Extracted from fortplot_matplotlib_plot_wrappers to respect module
     !! size limits. Re-exported by that module for backward compatibility.
+    !!
+    !! Color arguments:
+    !!   c      - real array of scalar values mapped through cmap (colormap).
+    !!            Matches matplotlib's c parameter for data-driven coloring.
+    !!   color  - literal RGB triple (or color name string) applied uniformly
+    !!            to all points. This is a fortplot extension; matplotlib uses
+    !!            c for both scalar mapping and literal color via kwargs.
+    !!            If both c and color are provided, c takes precedence for
+    !!            per-point coloring and color is ignored.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_global, only: fig => global_figure


### PR DESCRIPTION
## Summary

Add test_3d, test_streamplot, and test_contour to the curated test-ci target so regressions in these backends are caught on Linux CI.

SVG and animation were already covered (test_svg_savefig, test_ascii_animation_output). This PR closes the remaining gaps identified in #1704.

## Changes

- `Makefile`: added three fpm test targets to test-ci:
  - test_3d (8 tests: 3D plotting, projection, metadata parity)
  - test_streamplot (7 tests: streamplot parameters, grid validation, arrow clearing)
  - test_contour (5 tests: default levels, empty levels, memory safety, unsorted levels)

## Verification

### New tests pass individually
```
$ fpm test --target test_3d
Tests passed: 8 / 8

$ fpm test --target test_streamplot
EXIT: 0

$ fpm test --target test_contour
All contour tests PASSED!
```

### Full CI suite passes
```
$ make test-ci
CI essential test suite completed successfully
```
