### PR TITLE
docs: add descriptions to 5 example pages with placeholder text (fixes #1757)

### DIFF
--- a/doc/examples/datetime_axis_demo.md
+++ b/doc/examples/datetime_axis_demo.md
@@ -5,7 +5,7 @@ title: Datetime Axis Demo
 
 Source: [datetime_axis_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/datetime_axis_demo/datetime_axis_demo.f90)
 
-See source and outputs below.
+Demonstrates date/time axis support using `datetime_t` values for time-series data, with custom date formatting via `set_xaxis_date_format`.
 
 ## Files
 

--- a/doc/examples/display_demo.md
+++ b/doc/examples/display_demo.md
@@ -5,7 +5,7 @@ title: Display Demo
 
 Source: [display_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/display_demo/display_demo.f90)
 
-See source and outputs below.
+Demonstrates the two plot display methods: `show_viewer()` always opens in the system PDF viewer, while `show()` uses intelligent dispatch (viewer if a GUI is available, ASCII output otherwise).
 
 ## Files
 

--- a/doc/examples/probability_animation_demo.md
+++ b/doc/examples/probability_animation_demo.md
@@ -5,7 +5,7 @@ title: Probability Animation Demo
 
 Source: [probability_animation_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/probability_animation_demo/probability_animation_demo.f90)
 
-See source and outputs below.
+Animates a Gaussian probability distribution that broadens over time, producing both MP4 video (requires ffmpeg) and ASCII frame sequences. Uses `FuncAnimation` with a per-frame update callback that increases the Gaussian sigma.
 
 ## Files
 

--- a/doc/examples/quiver_demo.md
+++ b/doc/examples/quiver_demo.md
@@ -5,7 +5,7 @@ title: Quiver Demo
 
 Source: [quiver_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/quiver_demo/quiver_demo.f90)
 
-See source and outputs below.
+Demonstrates quiver plots for discrete vector field arrows. Shows a circular flow field with configurable arrow scale, producing PNG, PDF, and ASCII output.
 
 ## Files
 

--- a/doc/examples/styling_demo.md
+++ b/doc/examples/styling_demo.md
@@ -5,7 +5,7 @@ title: Styling Demo
 
 Source: [styling_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/styling_demo/styling_demo.f90)
 
-See source and outputs below.
+Comprehensive demonstration of line and marker styling: solid, dashed, dotted, and dash-dot line styles; matplotlib-style format strings (e.g. `b-o`); circle, square, diamond, and cross markers; and scatter plots with marker customization.
 
 ## Files
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -42,9 +42,9 @@ make example ARGS="example_name"
 - [Basic Plots](./examples/basic_plots.html) - Basic line plots and saving outputs (PNG, PDF, ASCII).
 - [Boxplot Demo](./examples/boxplot_demo.html) - Demonstrates box-and-whisker plots for statistical data visualization.
 - [Contour Demo](./examples/contour_demo.html) - Comprehensive contour plotting examples: line contours, filled contours, custom levels, colormaps.
-- [Datetime Axis Demo](./examples/datetime_axis_demo.html) - See source and outputs below.
+- [Datetime Axis Demo](./examples/datetime_axis_demo.html) - Date/time axis support with `datetime_t` values and custom date formatting.
 - [Disconnected Lines](./examples/disconnected_lines.html) - Line plots with gaps created by NaN separators.
-- [Display Demo](./examples/display_demo.html) - See source and outputs below.
+- [Display Demo](./examples/display_demo.html) - Plot display methods: `show_viewer()` and intelligent `show()`.
 - [Dpi Demo](./examples/dpi_demo.html) - Control output DPI when saving figures for consistent sizing across formats.
 - [Errorbar Demo](./examples/errorbar_demo.html) - Demonstrates error bar plotting with both symmetric and asymmetric errors for scientific data visualization.
 - [Fill Between Demo](./examples/fill_between_demo.html) - Create filled regions using both the stateful API and `figure_t`.
@@ -54,12 +54,12 @@ make example ARGS="example_name"
 - [Pcolormesh Demo](./examples/pcolormesh_demo.html) - Pcolormesh heatmaps with colormaps and shading.
 - [Pie Chart Demo](./examples/pie_chart_demo.html) - Build pie charts using both the stateful API and `figure_t` (exploded wedges, `autopct`, and start angles).
 - [Polar Demo](./examples/polar_demo.html) - Demonstrates fortplot's polar plotting API with custom colors, linestyles, and markers.
-- [Probability Animation Demo](./examples/probability_animation_demo.html) - See source and outputs below.
-- [Quiver Demo](./examples/quiver_demo.html) - See source and outputs below.
+- [Probability Animation Demo](./examples/probability_animation_demo.html) - Animated Gaussian distribution with broadening sigma (MP4 and ASCII).
+- [Quiver Demo](./examples/quiver_demo.html) - Quiver plots for discrete vector field arrows with configurable scale.
 - [Scale Examples](./examples/scale_examples.html) - Linear, log, and symlog axis scales.
 - [Scatter Demo](./examples/scatter_demo.html) - Demonstrates enhanced scatter plotting with color mapping, variable marker sizes, and bubble charts.
 - [Streamplot Demo](./examples/streamplot_demo.html) - Streamplots for 2D vector fields.
-- [Styling Demo](./examples/styling_demo.html) - See source and outputs below.
+- [Styling Demo](./examples/styling_demo.html) - Line styles, format strings, marker types, and scatter plot styling.
 - [Subplot Demo](./examples/subplot_demo.html) - Demonstration of subplot functionality using the stateful API.
 - [Twin Axes Demo](./examples/twin_axes_demo.html) - Demonstrates `twinx` and `twiny` for multiple axes on one figure.
 - [Unicode Demo](./examples/unicode_demo.html) - Unicode symbols in labels and titles.


### PR DESCRIPTION
## Summary

Replace "See source and outputs below." placeholder in 5 example doc pages with actual one- or two-sentence descriptions, matching the style of better-documented pages such as `errorbar_demo.md`. Also update the gallery index in `doc/index.md` so the example list carries meaningful summaries.

### Files changed
- `doc/examples/display_demo.md` — describes `show_viewer()` and `show()` display methods
- `doc/examples/datetime_axis_demo.md` — describes `datetime_t` axis support
- `doc/examples/probability_animation_demo.md` — describes animated Gaussian with `FuncAnimation`
- `doc/examples/quiver_demo.md` — describes vector field arrow plots
- `doc/examples/styling_demo.md` — describes line styles, format strings, and markers
- `doc/index.md` — updated gallery index entries for all 5 examples

## Verification

### Requirement: replace placeholder text in each page
Each of the 5 pages previously contained only "See source and outputs below." as body text. After this change, each carries a specific description:

```
$ git diff --stat
 doc/examples/datetime_axis_demo.md         |  2 +-
 doc/examples/display_demo.md               |  2 +-
 doc/examples/probability_animation_demo.md |  2 +-
 doc/examples/quiver_demo.md                |  2 +-
 doc/examples/styling_demo.md               |  2 +-
 doc/index.md                               | 10 +++++-----
 6 files changed, 10 insertions(+), 10 deletions(-)
```

### Requirement: update gallery index summaries
The `doc/index.md` example list entries for all 5 demos now carry meaningful one-line summaries instead of "See source and outputs below."

### Build passes
```
$ make build
fpm build --flag -fPIC
Project is up to date
```
