### PR TITLE
fix: make figure%add_plot public and fix docstring example (fixes #1751)

### DIFF
--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -44,7 +44,7 @@ module fortplot
     !!   ! Advanced figure with multiple plots
     !!   type(figure_t) :: fig
     !!   call fig%initialize(800, 600)
-    !!   call fig%add_plot(x, y, label="data", linestyle='b-o')
+    !!   call fig%add_plot(x, y, label="data", linestyle='-')
     !!   call fig%add_contour(x_grid, y_grid, z_field)
     !!   call fig%legend()
     !!   call fig%savefig('results.pdf')

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -81,8 +81,8 @@ module fortplot_figure_core
 
     contains
         procedure :: initialize
-        procedure, private :: add_plot_real
-        procedure, private :: add_plot_datetime
+        procedure, public :: add_plot_real
+        procedure, public :: add_plot_datetime
         generic :: add_plot => add_plot_real, add_plot_datetime
         generic :: plot => add_plot_real, add_plot_datetime
         procedure :: add_contour

--- a/test/test_oo_api_docstring.f90
+++ b/test/test_oo_api_docstring.f90
@@ -1,0 +1,31 @@
+program test_oo_api_docstring
+    !! Test the OO API pattern shown in the fortplot module docstring
+    !! Verifies that figure%add_plot, figure%legend, and figure%savefig
+    !! are all publicly accessible type-bound procedures.
+    !!
+    !! Regression test for issue #1751.
+    use fortplot
+    use iso_fortran_env, only: real64
+    use test_output_helpers, only: ensure_test_output_dir
+    implicit none
+
+    real(real64), allocatable :: x(:), y(:)
+    type(figure_t) :: fig
+    character(len=:), allocatable :: output_dir
+    integer :: i
+
+    call ensure_test_output_dir('oo_api_docstring', output_dir)
+
+    allocate(x(50), y(50))
+    x = [(real(i-1, real64)*0.2_real64, i=1, 50)]
+    y = sin(x)
+
+    ! Pattern from fortplot.f90 module docstring (issue #1751)
+    call fig%initialize(800, 600)
+    call fig%add_plot(x, y, label="data", linestyle='-')
+    call fig%legend()
+    call fig%savefig(trim(output_dir)//'test_oo_api.png')
+
+    print *, "PASS: OO API from docstring compiles and runs (fixes #1751)"
+
+end program test_oo_api_docstring


### PR DESCRIPTION
## Summary

- Make `add_plot` generic public on `figure_t` (was private, causing docstring example to fail compilation)
- Fix docstring example: `linestyle='b-o'` → `linestyle='-'` (correct parameter types for type-bound `add_plot`)
- Add regression test `test_oo_api_docstring` that exercises the OO API pattern from the module docstring

## Requirements (from issue #1751)

**REQ-001:** The quick-start example in the `fortplot` module docstring calls `fig%add_plot()`, `fig%legend()`, and `fig%savefig()`. `add_plot` was declared `private` on `figure_t`, making the generic inaccessible. Fix: change `procedure, private :: add_plot_real` and `add_plot_datetime` to `procedure, public ::`.

**REQ-002:** The docstring example used `linestyle='b-o'` which mixes color and style syntax. The type-bound `add_plot` signature expects `linestyle` as a character string (e.g., `'-'`, `'--'`) and `color` as `real(wp), optional :: color(3)`. Fix: update example to `linestyle='-'`.

**REQ-003:** Add a behavioral test that compiles and runs the exact OO API pattern from the docstring.

## Verification

```
$ fpm build
[100%] Project compiled successfully.

$ fpm test --target test_oo_api_docstring
 PASS: OO API from docstring compiles and runs (fixes #1751)

$ fpm test --target test_readme_promises
 All README promises tested successfully!

$ fpm test --target test_matplotlib_new_functions
 All new matplotlib-compatible functions are accessible!
```

All key tests pass. The change makes `figure%add_plot()` publicly accessible, matching the documented API.