### PR TITLE
fix: add RGB color support to boxplot (boxplot subset of #1684, follow-up #1860)

### DIFF
--- a/src/figures/core/fortplot_figure_core_advanced.f90
+++ b/src/figures/core/fortplot_figure_core_advanced.f90
@@ -66,8 +66,8 @@ contains
                                    label, color)
     end subroutine core_hist
 
-    subroutine core_boxplot(plots, state, plot_count, data, position, width, label, &
-                            show_outliers, horizontal, color, max_plots)
+  subroutine core_boxplot(plots, state, plot_count, data, position, width, label, &
+                             show_outliers, horizontal, color, max_plots)
         !! Create a box plot
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
@@ -78,7 +78,7 @@ contains
         character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: show_outliers
         logical, intent(in), optional :: horizontal
-        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: color(3)
         integer, intent(in) :: max_plots
 
         call ensure_figure_storage(plots, state)

--- a/src/figures/core/fortplot_figure_core_advanced.f90
+++ b/src/figures/core/fortplot_figure_core_advanced.f90
@@ -37,16 +37,14 @@ contains
 
         ! Delegate to efficient scatter implementation
         call ensure_figure_storage(plots, state)
-        call figure_scatter_operation(state, plots, state%plot_count, &
+        call figure_scatter_operation(state, plots, plot_count, &
                                       x, y, s, c, marker, markersize, color, &
                                       colormap, alpha, edgecolor, facecolor, &
                                       linewidth, vmin, vmax, label, show_colorbar, &
                                       default_color)
 
-        ! Update figure state
-        plot_count = state%plot_count
-
-        ! Update data ranges
+        ! Sync plot_count back to state and update data ranges
+        state%plot_count = plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_scatter
 

--- a/src/figures/core/fortplot_figure_core_impl.f90
+++ b/src/figures/core/fortplot_figure_core_impl.f90
@@ -410,7 +410,7 @@ module subroutine add_pcolormesh(self, x, y, c, cmap, vmin, vmax, edgecolors, &
         character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: show_outliers
         logical, intent(in), optional :: horizontal
-        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: color(3)
 
         call core_boxplot(self%plots, self%state, self%plot_count, data, &
                            position, width, &

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -476,8 +476,8 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             real(wp), intent(in), optional :: color(3)
         end subroutine add_hist
 
-        module subroutine boxplot(self, data, position, width, label, show_outliers, &
-                                 horizontal, color)
+       module subroutine boxplot(self, data, position, width, label, show_outliers, &
+                                  horizontal, color)
             class(figure_t), intent(inout) :: self
             real(wp), intent(in) :: data(:)
             real(wp), intent(in), optional :: position
@@ -485,7 +485,7 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             character(len=*), intent(in), optional :: label
             logical, intent(in), optional :: show_outliers
             logical, intent(in), optional :: horizontal
-            character(len=*), intent(in), optional :: color
+            real(wp), intent(in), optional :: color(3)
         end subroutine boxplot
 
         module subroutine set_xlabel(self, label)

--- a/src/figures/core/fortplot_figure_core_ranges.f90
+++ b/src/figures/core/fortplot_figure_core_ranges.f90
@@ -32,6 +32,8 @@ contains
         integer, intent(in) :: plot_count
         integer :: plot_axis
 
+        if (plot_count <= 0) return
+
         plot_axis = plots(plot_count)%axis
 
         select case (plot_axis)

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -230,11 +230,11 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         call set_axis_for_latest_plot(state, plots)
     end subroutine figure_hist_operation
 
-    subroutine figure_boxplot_operation(state, plots, plot_count, data, position, &
-                                        width, label, &
-                                        show_outliers, horizontal, color, max_plots)
+   subroutine figure_boxplot_operation(state, plots, plot_count, data, position, &
+                                         width, label, &
+                                         show_outliers, horizontal, color, max_plots)
         !! Create a box plot
-        type(figure_state_t), intent(in) :: state
+        type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(inout) :: plot_count
         real(wp), intent(in) :: data(:)
@@ -258,6 +258,7 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         if (plot_count > 0 .and. size(plots) >= plot_count) then
             plots(plot_count)%axis = state%active_axis
         end if
+        state%plot_count = plot_count
     end subroutine figure_boxplot_operation
 
     subroutine figure_scatter_operation(state, plots, plot_count, x, y, s, &
@@ -267,7 +268,7 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
                                         facecolor, linewidth, vmin, vmax, label, &
                                         show_colorbar, default_color)
         !! Add an efficient scatter plot using a single plot object
-        type(figure_state_t), intent(in) :: state
+        type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(inout) :: plot_count
         real(wp), intent(in) :: x(:), y(:)
@@ -285,6 +286,7 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         if (plot_count > 0 .and. size(plots) >= plot_count) then
             plots(plot_count)%axis = state%active_axis
         end if
+        state%plot_count = plot_count
     end subroutine figure_scatter_operation
 
     subroutine figure_set_xlabel_operation(state, xlabel_target, label)

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -242,7 +242,7 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: show_outliers
         logical, intent(in), optional :: horizontal
-        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: color(3)
         integer, intent(in) :: max_plots
 
         call add_boxplot(plots, plot_count, data, position, width, label, &

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -31,7 +31,8 @@ module fortplot_figure_operations
                                            set_yscale_figure, &
                                            set_xlim_figure, set_ylim_figure, &
                                            set_line_width_figure
-    use fortplot_figure_plot_management, only: update_plot_ydata, setup_figure_legend
+    use fortplot_figure_plot_management, only: update_plot_ydata, setup_figure_legend, &
+                                               next_plot_color
     use fortplot_figure_render_engine, only: figure_render
     implicit none
 
@@ -244,9 +245,16 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         logical, intent(in), optional :: horizontal
         real(wp), intent(in), optional :: color(3)
         integer, intent(in) :: max_plots
+        real(wp) :: resolved_color(3)
 
-        call add_boxplot(plots, plot_count, data, position, width, label, &
-                         show_outliers, horizontal, color, max_plots)
+        if (.not. present(color)) then
+            resolved_color = next_plot_color(state)
+            call add_boxplot(plots, plot_count, data, position, width, label, &
+                             show_outliers, horizontal, resolved_color, max_plots)
+        else
+            call add_boxplot(plots, plot_count, data, position, width, label, &
+                             show_outliers, horizontal, color, max_plots)
+        end if
         if (plot_count > 0 .and. size(plots) >= plot_count) then
             plots(plot_count)%axis = state%active_axis
         end if

--- a/src/figures/plot_types/fortplot_figure_boxplot.f90
+++ b/src/figures/plot_types/fortplot_figure_boxplot.f90
@@ -19,8 +19,8 @@ module fortplot_figure_boxplot
     
 contains
     
-    subroutine add_boxplot(plots, plot_count, data, position, width, label, &
-                          show_outliers, horizontal, color, max_plots)
+   subroutine add_boxplot(plots, plot_count, data, position, width, label, &
+                           show_outliers, horizontal, color, max_plots)
         !! Add a box plot to the plot array
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(inout) :: plot_count
@@ -30,7 +30,7 @@ contains
         character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: show_outliers
         logical, intent(in), optional :: horizontal
-        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: color(3)
         integer, intent(in) :: max_plots
         
         type(plot_data_t), allocatable :: new_plots(:)
@@ -101,11 +101,9 @@ contains
         ! Compute statistics (quartiles, whiskers, outliers)
         call compute_boxplot_stats_inplace(plots(plot_idx))
 
-        ! Color would need conversion from string to RGB
-        ! For now, use default color from plot_data_t initialization
+        ! Store color if provided
         if (present(color)) then
-            ! Reference optional color to keep interface stable without side effects
-            associate(unused_color_len => len_trim(color)); end associate
+            plots(plot_idx)%color = color
         end if
     end subroutine add_boxplot
     

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -33,6 +33,11 @@ module fortplot_matplotlib_plot_wrappers
     public :: add_scatter
     public :: add_3d_plot
 
+    interface boxplot
+        module procedure boxplot_string
+        module procedure boxplot_rgb
+    end interface boxplot
+
     interface bar
         module procedure bar_rgb
         module procedure bar_string
@@ -219,19 +224,46 @@ contains
         end if
     end subroutine resolve_bar_bottom
 
-    subroutine boxplot(data, position, width, label, show_outliers, horizontal, color)
+    subroutine boxplot_string(data, position, width, label, show_outliers, horizontal, color)
+        !! Boxplot with named-color string (matplotlib-compatible).
+        !! Converts string color to RGB before delegating to the figure.
         real(wp), intent(in) :: data(:)
         real(wp), intent(in), optional :: position
         real(wp), intent(in), optional :: width
         character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: show_outliers, horizontal
-        character(len=*), intent(in), optional :: color
+        character(len=*), intent(in) :: color
+
+        real(wp) :: color_rgb(3)
+        logical :: has_color
+
+        call ensure_fig_init()
+        call resolve_color_string_or_rgb(color_str=color, context='boxplot', &
+                                         rgb_out=color_rgb, has_color=has_color)
+        if (has_color) then
+            call fig%boxplot(data, position=position, width=width, label=label, &
+                             show_outliers=show_outliers, horizontal=horizontal, &
+                             color=color_rgb)
+        else
+            call fig%boxplot(data, position=position, width=width, label=label, &
+                             show_outliers=show_outliers, horizontal=horizontal)
+        end if
+    end subroutine boxplot_string
+
+    subroutine boxplot_rgb(data, position, width, label, show_outliers, horizontal, color)
+        !! Boxplot with RGB-triple color (matplotlib-compatible).
+        real(wp), intent(in) :: data(:)
+        real(wp), intent(in), optional :: position
+        real(wp), intent(in), optional :: width
+        character(len=*), intent(in), optional :: label
+        logical, intent(in), optional :: show_outliers, horizontal
+        real(wp), intent(in), optional :: color(3)
 
         call ensure_fig_init()
         call fig%boxplot(data, position=position, width=width, label=label, &
                          show_outliers=show_outliers, horizontal=horizontal, &
                          color=color)
-    end subroutine boxplot
+    end subroutine boxplot_rgb
 
     subroutine add_plot_rgb(x, y, color, label, linestyle)
         real(wp), intent(in) :: x(:), y(:)

--- a/test/test_boxplot_comprehensive.f90
+++ b/test/test_boxplot_comprehensive.f90
@@ -195,14 +195,16 @@ contains
     end subroutine test_boxplot_rgb_color
 
     subroutine test_boxplot_string_color()
-        !! Verify pyplot boxplot facade accepts string color and renders
+        !! Verify pyplot boxplot facade accepts string color and resolves it to RGB
         character(len=*), parameter :: out_png = 'build/test/output/test_boxplot_string_color.png'
         real(wp), parameter :: test_data(10) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
                                                6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp]
+        real(wp), parameter :: expected_orange(3) = [1.0_wp, 0.647_wp, 0.0_wp]
         type(validation_result_t) :: val
+        type(figure_t), pointer :: fig_ptr => null()
 
         call figure()
-        call boxplot(test_data, color='tab:orange')
+        call boxplot(test_data, color='orange')
         call savefig(out_png)
 
         val = validate_file_exists(out_png)
@@ -214,6 +216,22 @@ contains
         val = validate_file_size(out_png, min_size=2000)
         if (.not. val%passed) then
             print *, 'FAIL: output PNG too small, likely empty plot. Size=', int(val%metric_value)
+            error stop 1
+        end if
+
+        ! Verify the string color was resolved to RGB and stored in plot_data
+        fig_ptr => get_global_figure()
+        if (fig_ptr%plot_count < 1) then
+            print *, 'FAIL: no plots in figure after boxplot with string color'
+            error stop 1
+        end if
+
+        if (abs(fig_ptr%plots(1)%color(1) - expected_orange(1)) > 0.001_wp .or. &
+            abs(fig_ptr%plots(1)%color(2) - expected_orange(2)) > 0.001_wp .or. &
+            abs(fig_ptr%plots(1)%color(3) - expected_orange(3)) > 0.001_wp) then
+            print *, 'FAIL: string color not resolved correctly: ', &
+                     fig_ptr%plots(1)%color(1), fig_ptr%plots(1)%color(2), fig_ptr%plots(1)%color(3), &
+                     ' expected: ', expected_orange(1), expected_orange(2), expected_orange(3)
             error stop 1
         end if
 

--- a/test/test_boxplot_comprehensive.f90
+++ b/test/test_boxplot_comprehensive.f90
@@ -6,6 +6,8 @@ program test_boxplot_comprehensive
     use fortplot, only: figure_t
     use fortplot_validation, only: validation_result_t, validate_file_exists, validate_file_size
     use fortplot_system_runtime, only: create_directory_runtime
+    use fortplot_matplotlib, only: figure, boxplot, savefig
+    use fortplot_matplotlib_session, only: get_global_figure
     implicit none
     logical :: dir_ok
 
@@ -14,6 +16,8 @@ program test_boxplot_comprehensive
     call test_outliers()
     call test_stats()
     call test_rendering_regression_1327()
+    call test_boxplot_rgb_color()
+    call test_boxplot_string_color()
 
     print *, 'All boxplot tests PASSED!'
 
@@ -163,5 +167,57 @@ contains
 
         print *, '  PASS: test_rendering_regression_1327'
     end subroutine test_rendering_regression_1327
+
+    subroutine test_boxplot_rgb_color()
+        !! Verify boxplot accepts RGB triple color and stores it in plot_data
+        type(figure_t) :: fig
+        real(wp), parameter :: test_data(10) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
+                                               6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp]
+        real(wp), parameter :: red_color(3) = [1.0_wp, 0.0_wp, 0.0_wp]
+
+        call fig%initialize(400, 300)
+        call fig%boxplot(test_data, color=red_color)
+
+        if (fig%plot_count /= 1) then
+            print *, 'FAIL: expected plot_count=1, got', fig%plot_count
+            error stop 1
+        end if
+
+        if (fig%plots(1)%color(1) /= 1.0_wp .or. &
+            fig%plots(1)%color(2) /= 0.0_wp .or. &
+            fig%plots(1)%color(3) /= 0.0_wp) then
+            print *, 'FAIL: RGB color not stored correctly: ', &
+                     fig%plots(1)%color(1), fig%plots(1)%color(2), fig%plots(1)%color(3)
+            error stop 1
+        end if
+
+        print *, '  PASS: test_boxplot_rgb_color'
+    end subroutine test_boxplot_rgb_color
+
+    subroutine test_boxplot_string_color()
+        !! Verify pyplot boxplot facade accepts string color and renders
+        character(len=*), parameter :: out_png = 'build/test/output/test_boxplot_string_color.png'
+        real(wp), parameter :: test_data(10) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
+                                               6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp]
+        type(validation_result_t) :: val
+
+        call figure()
+        call boxplot(test_data, color='tab:orange')
+        call savefig(out_png)
+
+        val = validate_file_exists(out_png)
+        if (.not. val%passed) then
+            print *, 'FAIL: expected output PNG not created: ', trim(out_png)
+            error stop 1
+        end if
+
+        val = validate_file_size(out_png, min_size=2000)
+        if (.not. val%passed) then
+            print *, 'FAIL: output PNG too small, likely empty plot. Size=', int(val%metric_value)
+            error stop 1
+        end if
+
+        print *, '  PASS: test_boxplot_string_color'
+    end subroutine test_boxplot_string_color
 
 end program test_boxplot_comprehensive

--- a/test/test_boxplot_comprehensive.f90
+++ b/test/test_boxplot_comprehensive.f90
@@ -17,6 +17,7 @@ program test_boxplot_comprehensive
     call test_stats()
     call test_rendering_regression_1327()
     call test_boxplot_rgb_color()
+    call test_boxplot_palette_progression()
     call test_boxplot_string_color()
 
     print *, 'All boxplot tests PASSED!'
@@ -193,6 +194,42 @@ contains
 
         print *, '  PASS: test_boxplot_rgb_color'
     end subroutine test_boxplot_rgb_color
+
+    subroutine test_boxplot_palette_progression()
+        !! Verify that multiple boxplots without explicit color cycle through palette
+        type(figure_t) :: fig
+        real(wp), parameter :: test_data(10) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
+                                               6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp]
+
+        call fig%initialize(400, 300)
+        call fig%boxplot(test_data)
+        call fig%boxplot(test_data)
+        call fig%boxplot(test_data)
+
+        if (fig%plot_count /= 3) then
+            print *, 'FAIL: expected plot_count=3, got', fig%plot_count
+            error stop 1
+        end if
+
+        ! First boxplot should get palette color 0
+        ! Second boxplot should get palette color 1 (different from first)
+        ! Third boxplot should get palette color 2 (different from second)
+        if (fig%plots(1)%color(1) == fig%plots(2)%color(1) .and. &
+            fig%plots(1)%color(2) == fig%plots(2)%color(2) .and. &
+            fig%plots(1)%color(3) == fig%plots(2)%color(3)) then
+            print *, 'FAIL: second boxplot has same color as first (no palette progression)'
+            error stop 1
+        end if
+
+        if (fig%plots(2)%color(1) == fig%plots(3)%color(1) .and. &
+            fig%plots(2)%color(2) == fig%plots(3)%color(2) .and. &
+            fig%plots(2)%color(3) == fig%plots(3)%color(3)) then
+            print *, 'FAIL: third boxplot has same color as second (no palette progression)'
+            error stop 1
+        end if
+
+        print *, '  PASS: test_boxplot_palette_progression'
+    end subroutine test_boxplot_palette_progression
 
     subroutine test_boxplot_string_color()
         !! Verify pyplot boxplot facade accepts string color and resolves it to RGB


### PR DESCRIPTION
## Summary

- Add RGB triple color support to `boxplot()` via generic interface (`boxplot_string` / `boxplot_rgb`)
- Propagate RGB color through the entire boxplot data pipeline (figure method → core → operations → add_boxplot)
- Store RGB color in `plot_data%color` for rendering
- Add behavior tests for both string and RGB color paths
- Fix boxplot default color regression: when no color is specified, use the next palette color from `state%colors` instead of the type-default blue

## Verification

```
$ fpm test --target test_boxplot_comprehensive
   PASS: test_basic_boxplot
   PASS: test_outliers
   PASS: test_stats
   PASS: test_rendering_regression_1327
   PASS: test_boxplot_rgb_color
   PASS: test_boxplot_palette_progression
   PASS: test_boxplot_string_color
 All boxplot tests PASSED!

$ make verify-artifacts
Artifact verification passed.
```

## CI

All checks passed: test (Linux/flang), test (windows), flang (macOS), FPM Dependency, CMake FetchContent

## Scope

This PR implements the **boxplot-specific** subset of issue #1684. It does **not** close #1684.

- REQ-001: `boxplot_rgb` subroutine accepts `color(3)` RGB triple
- REQ-002: Generic `boxplot` interface with both `boxplot_string` and `boxplot_rgb`
- REQ-003: Behavior tests for boxplot with RGB color, string color, and palette progression
- REQ-004: Default color regression fixed — palette progression via `next_plot_color(state)`

The remaining pyplot wrappers (scatter, bar, hist, errorbar, quiver, add_3d_plot) need the same string/RGB generic treatment. Follow-up: #1860