### PR TITLE
fix: add contourf figure alias (refs #1657)

### DIFF
--- a/.github/workflows/downstream-test.yml
+++ b/.github/workflows/downstream-test.yml
@@ -30,7 +30,8 @@ jobs:
     - name: Test CMake FetchContent integration
       run: |
         cd example/user_compilation_examples/cmake_project_template
-        cmake -S . -B build -G Ninja
+        cmake -S . -B build -G Ninja \
+          -DFORTPLOT_FETCH_SOURCE_DIR="${GITHUB_WORKSPACE}"
         cmake --build build
         ./build/bin/fortplot_demo
 

--- a/doc/api_compatibility.md
+++ b/doc/api_compatibility.md
@@ -96,11 +96,12 @@ call plt%add_contour(x, y, z, linestyle, linewidth, levels, color, &
 **FortPlot:**
 ```fortran
 call fig%add_contour(x_grid, y_grid, z_grid, levels, label)
-call fig%add_contour_filled(x_grid, y_grid, z_grid, levels, colormap, &
-                            show_colorbar, label)
+call fig%add_contourf(x_grid, y_grid, z_grid, levels, cmap, &
+                      show_colorbar, label)
 ```
 
-FortPlot separates line contours from filled contours for clarity.
+FortPlot uses matplotlib's `contourf`/`add_contourf` naming for filled
+contours. `contour_filled` and `add_contour_filled` remain supported aliases.
 
 ### Error Bars
 

--- a/example/user_compilation_examples/README.md
+++ b/example/user_compilation_examples/README.md
@@ -141,8 +141,8 @@ program engineering_results
     ! Create field visualizations
     call figure(1600, 600)
     call subplot(1, 2, 1)
-    call contour_filled(x_grid, y_grid, temperature, &
-                       colormap="plasma", show_colorbar=.true.)
+    call contourf(x_grid, y_grid, temperature, &
+                  cmap="plasma", show_colorbar=.true.)
     call title("Temperature Distribution")
     
     call subplot(1, 2, 2)

--- a/example/user_compilation_examples/cmake_project_template/CMakeLists.txt
+++ b/example/user_compilation_examples/cmake_project_template/CMakeLists.txt
@@ -25,13 +25,27 @@ endif()
 # Fetch fortplot library
 include(FetchContent)
 
+set(FORTPLOT_FETCH_SOURCE_DIR "" CACHE PATH
+    "Use a local fortplot source tree instead of fetching from Git")
+set(FORTPLOT_FETCH_REPOSITORY "https://github.com/lazy-fortran/fortplot"
+    CACHE STRING "fortplot Git repository used by FetchContent")
+set(FORTPLOT_FETCH_TAG "main"
+    CACHE STRING "fortplot Git tag or branch used by FetchContent")
+
 message(STATUS "Fetching fortplot library...")
-FetchContent_Declare(
-    fortplot
-    GIT_REPOSITORY https://github.com/lazy-fortran/fortplot
-    GIT_TAG        main
-    GIT_PROGRESS   TRUE
-)
+if(FORTPLOT_FETCH_SOURCE_DIR)
+    FetchContent_Declare(
+        fortplot
+        SOURCE_DIR "${FORTPLOT_FETCH_SOURCE_DIR}"
+    )
+else()
+    FetchContent_Declare(
+        fortplot
+        GIT_REPOSITORY "${FORTPLOT_FETCH_REPOSITORY}"
+        GIT_TAG        "${FORTPLOT_FETCH_TAG}"
+        GIT_PROGRESS   TRUE
+    )
+endif()
 
 # Make fortplot available
 FetchContent_MakeAvailable(fortplot)

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -24,7 +24,7 @@ module fortplot
     !!
     !! = Core Plot Types =
     !! - Line plots: plot(), add_plot() - Basic line and scatter plotting
-    !! - Contour plots: contour(), contour_filled() - 2D field visualization
+    !! - Contour plots: contour(), contourf() - 2D field visualization
     !! - Heat maps: pcolormesh() - Pseudocolor mesh plots
     !! - Vector fields: streamplot() - Flow visualization with streamlines
     !! - Statistical: hist(), boxplot(), errorbar() - Data distribution plots

--- a/src/figures/core/fortplot_figure_core_impl.f90
+++ b/src/figures/core/fortplot_figure_core_impl.f90
@@ -317,6 +317,22 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
                                        colormap=colormap, plot_count=self%plot_count)
     end subroutine add_contour_filled
 
+    module subroutine add_contourf(self, x_grid, y_grid, z_grid, levels, &
+                                   cmap, show_colorbar, label, colormap)
+        !! Add a filled contour plot to the figure
+        !!
+        !! Matplotlib-canonical alias for add_contour_filled.
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
+        real(wp), intent(in), optional :: levels(:)
+        character(len=*), intent(in), optional :: cmap, label, colormap
+        logical, intent(in), optional :: show_colorbar
+
+        call self%add_contour_filled(x_grid, y_grid, z_grid, levels=levels, &
+                                     cmap=cmap, show_colorbar=show_colorbar, &
+                                     label=label, colormap=colormap)
+    end subroutine add_contourf
+
 module subroutine add_surface(self, x_grid, y_grid, z_grid, label, cmap, &
                                    show_colorbar, alpha, edgecolor, linewidth, filled, &
                                    colormap)

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -87,6 +87,7 @@ module fortplot_figure_core
         generic :: plot => add_plot_real, add_plot_datetime
         procedure :: add_contour
         procedure :: add_contour_filled
+        procedure :: add_contourf
         procedure :: add_surface
         procedure :: add_pcolormesh
         procedure :: streamplot
@@ -408,6 +409,18 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             character(len=*), intent(in), optional :: cmap, label, colormap
             logical, intent(in), optional :: show_colorbar
         end subroutine add_contour_filled
+
+        module subroutine add_contourf(self, x_grid, y_grid, z_grid, levels, &
+                                       cmap, show_colorbar, label, colormap)
+            !! Add a filled contour plot to the figure
+            !!
+            !! Matplotlib-canonical alias for add_contour_filled.
+            class(figure_t), intent(inout) :: self
+            real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
+            real(wp), intent(in), optional :: levels(:)
+            character(len=*), intent(in), optional :: cmap, label, colormap
+            logical, intent(in), optional :: show_colorbar
+        end subroutine add_contourf
 
         module subroutine add_surface(self, x_grid, y_grid, z_grid, label, cmap, &
                                       show_colorbar, alpha, edgecolor, linewidth, &

--- a/src/figures/rendering/fortplot_polar_rendering_helpers.f90
+++ b/src/figures/rendering/fortplot_polar_rendering_helpers.f90
@@ -5,6 +5,7 @@ module fortplot_polar_rendering_helpers
     !! Single Responsibility: Polar axes and plot rendering helpers
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_plot_data, only: plot_data_t
     use fortplot_polar_rendering, only: render_polar_data, render_polar_boundary, &

--- a/src/figures/rendering/fortplot_vector_plot_helpers.f90
+++ b/src/figures/rendering/fortplot_vector_plot_helpers.f90
@@ -5,6 +5,7 @@ module fortplot_vector_plot_helpers
     !! Single Responsibility: Render vector-based plots
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
     use fortplot_plot_data, only: plot_data_t, arrow_data_t
     use fortplot_scales, only: apply_scale_transform
     implicit none

--- a/test/test_matplotlib_api_alignment.f90
+++ b/test/test_matplotlib_api_alignment.f90
@@ -124,6 +124,7 @@ contains
 
     subroutine check_contourf_alias()
         !! Issue #1657: contourf must be a working matplotlib alias
+        type(figure_t) :: local_fig
         real(wp) :: x(4), y(4), z(4, 4)
         integer :: baseline, i, j
 
@@ -155,6 +156,20 @@ contains
         call add_contourf(x, y, z)
         if (fig%plot_count /= baseline + 3) then
             print *, "FAIL: add_contourf did not add a plot"
+            stop 1
+        end if
+
+        call local_fig%initialize()
+        baseline = local_fig%plot_count
+        call local_fig%add_contourf(x, y, z)
+        if (local_fig%plot_count /= baseline + 1) then
+            print *, "FAIL: fig%add_contourf did not add a plot"
+            stop 1
+        end if
+
+        call local_fig%add_contour_filled(x, y, z)
+        if (local_fig%plot_count /= baseline + 2) then
+            print *, "FAIL: fig%add_contour_filled alias regressed"
             stop 1
         end if
     end subroutine check_contourf_alias


### PR DESCRIPTION
## Requirements
REQ-001: Add `contourf` as the canonical pyplot-level name for filled contours, delegating to the existing filled-contour implementation.
REQ-002: Keep `contour_filled` working as a backward-compatible alias.
REQ-003: Add `add_contourf` as the canonical figure/object API name for filled contours.
REQ-004: Keep `add_contour_filled` working as a backward-compatible alias.
REQ-005: Document the matplotlib-parity name and cover it with behavior tests.

## Changes
- Added `figure_t%add_contourf` as a type-bound alias that delegates to `add_contour_filled` (ref #1657).
- Extended the matplotlib API alignment test to exercise `fig%add_contourf` and the retained `fig%add_contour_filled` alias.
- Updated compatibility docs and user compilation examples to present `contourf`/`add_contourf` as canonical.

## Verification
Failing before on `origin/main` with a temporary repro:
```text
$ fpm test --target test_issue_1657_tmp
test/test_issue_1657_tmp.f90:12:26:

   12 |     call fig%add_contourf(x, y, z)
      |                          1
Error: 'add_contourf' at (1) is not a member of the 'figure_t' structure
compilation terminated due to -fmax-errors=1.
<ERROR> Compilation failed for object " test_test_issue_1657_tmp.f90.o "
<ERROR> stopping due to failed compilation
STOP 1
```

Passing after:
```text
$ fpm test --target test_matplotlib_api_alignment
[100%] Project compiled successfully.
All matplotlib API alignment tests passed.

$ make test-ci
CI essential test suite completed successfully

$ make verify-artifacts
Artifact verification passed.
```

<!-- orchestrate: fully-resolved -->
