### PR TITLE
fix: accept scatter string edgecolors (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -53,7 +53,7 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:)
         real(wp), intent(in), optional :: linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
@@ -75,7 +75,7 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:)
         real(wp), intent(in), optional :: linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
@@ -200,7 +200,7 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:)
         real(wp), intent(in), optional :: linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
@@ -246,7 +246,7 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:)
         real(wp), intent(in), optional :: linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
@@ -320,7 +320,7 @@ contains
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:), linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha, vmin, vmax
         logical, intent(in), optional :: edgecolors_none
 
@@ -337,7 +337,8 @@ contains
         call build_scatter_size_array(size(x), s, s_scalar, markersize, s_arr)
         lw_effective = effective_linewidth(linewidths, linewidths_scalar)
         call uniform_edgecolor(size(x), edgecolors, edge_rgb, has_uniform_edge)
-        no_edges = optional_logical(edgecolors_none)
+        no_edges = optional_logical(edgecolors_none) .or. &
+                   edgecolors_are_none(edgecolors)
 
         if (has_uniform_edge) then
             call add_scatter_2d(fig, wx, wy, s=s_arr, c=c, label=label, &
@@ -363,7 +364,7 @@ contains
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(:), linewidths_scalar
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha, vmin, vmax
         logical, intent(in), optional :: edgecolors_none
 
@@ -381,7 +382,8 @@ contains
         call build_scatter_size_array(size(x), s, s_scalar, markersize, s_arr)
         lw_effective = effective_linewidth(linewidths, linewidths_scalar)
         call uniform_edgecolor(size(x), edgecolors, edge_rgb, has_uniform_edge)
-        no_edges = optional_logical(edgecolors_none)
+        no_edges = optional_logical(edgecolors_none) .or. &
+                   edgecolors_are_none(edgecolors)
 
         if (has_uniform_edge) then
             call add_scatter_3d(fig, wx, wy, wz, s=s_arr, c=c, label=label, &
@@ -468,28 +470,56 @@ contains
 
     subroutine uniform_edgecolor(n, edgecolors, edge_rgb, has_uniform_edge)
         integer, intent(in) :: n
-        real(wp), intent(in), optional :: edgecolors(:)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(out) :: edge_rgb(3)
         logical, intent(out) :: has_uniform_edge
+
+        logical :: parsed
 
         edge_rgb = [0.0_wp, 0.0_wp, 0.0_wp]
         has_uniform_edge = .false.
         if (.not. present(edgecolors)) return
 
-        if (size(edgecolors) == 3) then
-            edge_rgb = edgecolors
-            has_uniform_edge = .true.
-        else if (size(edgecolors) /= 3*n) then
-            call log_error('scatter: edgecolors must be an RGB triple or 3*n sequence')
-        end if
+        select rank (edgecolors)
+        rank (0)
+            select type (edgecolors)
+            type is (character(len=*))
+                if (is_none_color(edgecolors)) return
+                call resolve_color_string_or_rgb(color_str=edgecolors, &
+                                                 context='scatter', &
+                                                 rgb_out=edge_rgb, &
+                                                 has_color=parsed)
+                has_uniform_edge = parsed
+            class default
+                call log_error('scatter: edgecolors scalar must be a color string')
+            end select
+        rank (1)
+            select type (edgecolors)
+            type is (real(wp))
+                if (size(edgecolors) == 3) then
+                    edge_rgb = edgecolors
+                    has_uniform_edge = .true.
+                else if (size(edgecolors) /= 3*n) then
+                    call log_error('scatter: edgecolors must be an RGB triple ' // &
+                                   'or 3*n sequence')
+                end if
+            class default
+                call log_error('scatter: edgecolors sequence must contain ' // &
+                               'real RGB values')
+            end select
+        rank default
+            call log_error('scatter: edgecolors must be a string, RGB triple, ' // &
+                           'or 3*n sequence')
+        end select
     end subroutine uniform_edgecolor
 
     subroutine store_scatter_style_arrays(n, edgecolors, linewidths, no_edges)
         integer, intent(in) :: n
-        real(wp), intent(in), optional :: edgecolors(:), linewidths(:)
+        class(*), intent(in), optional :: edgecolors(..)
+        real(wp), intent(in), optional :: linewidths(:)
         logical, intent(in) :: no_edges
 
-        integer :: i, plot_idx
+        integer :: plot_idx
 
         if (.not. allocated(fig%plots)) return
         plot_idx = fig%plot_count
@@ -499,15 +529,7 @@ contains
             fig%plots(plot_idx)%marker_edge_alpha = 0.0_wp
         end if
 
-        if (present(edgecolors)) then
-            if (size(edgecolors) == 3*n .and. n > 1) then
-                allocate (fig%plots(plot_idx)%scatter_edgecolors(3, n))
-                do i = 1, n
-                    fig%plots(plot_idx)%scatter_edgecolors(:, i) = &
-                        edgecolors(3*i - 2:3*i)
-                end do
-            end if
-        end if
+        call store_edgecolor_sequence(n, edgecolors, plot_idx)
 
         if (present(linewidths)) then
             if (size(linewidths) == n) then
@@ -520,5 +542,41 @@ contains
             end if
         end if
     end subroutine store_scatter_style_arrays
+
+    logical function edgecolors_are_none(edgecolors)
+        class(*), intent(in), optional :: edgecolors(..)
+
+        edgecolors_are_none = .false.
+        if (.not. present(edgecolors)) return
+        select rank (edgecolors)
+        rank (0)
+            select type (edgecolors)
+            type is (character(len=*))
+                edgecolors_are_none = is_none_color(edgecolors)
+            end select
+        end select
+    end function edgecolors_are_none
+
+    subroutine store_edgecolor_sequence(n, edgecolors, plot_idx)
+        integer, intent(in) :: n, plot_idx
+        class(*), intent(in), optional :: edgecolors(..)
+
+        integer :: i
+
+        if (.not. present(edgecolors)) return
+        select rank (edgecolors)
+        rank (1)
+            select type (edgecolors)
+            type is (real(wp))
+                if (size(edgecolors) == 3*n .and. n > 1) then
+                    allocate (fig%plots(plot_idx)%scatter_edgecolors(3, n))
+                    do i = 1, n
+                        fig%plots(plot_idx)%scatter_edgecolors(:, i) = &
+                            edgecolors(3*i - 2:3*i)
+                    end do
+                end if
+            end select
+        end select
+    end subroutine store_edgecolor_sequence
 
 end module fortplot_matplotlib_scatter

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -393,14 +393,15 @@ contains
                      edgecolors=edge_seq, &
                      linewidths=[0.5_wp, 1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp], &
                      label='edge sequence')
+        call scatter(x + 7.0_wp, y, edgecolors='red', label='string edge')
 
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 7) then
-            print *, 'FAIL: test_markersize_fallback - expected 7 plots'
+        if (global_figure%plot_count < 8) then
+            print *, 'FAIL: test_markersize_fallback - expected 8 plots'
             return
         end if
 
@@ -437,6 +438,15 @@ contains
         if (any(abs(global_figure%plots(7)%scatter_linewidths - &
                     [0.5_wp, 1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp]) > tol)) then
             print *, 'FAIL: test_markersize_fallback - linewidth sequence changed'
+            return
+        end if
+        if (.not. global_figure%plots(8)%marker_edgecolor_set) then
+            print *, 'FAIL: test_markersize_fallback - string edgecolor missing'
+            return
+        end if
+        if (any(abs(global_figure%plots(8)%marker_edgecolor - &
+                    [1.0_wp, 0.0_wp, 0.0_wp]) > tol)) then
+            print *, 'FAIL: test_markersize_fallback - string edgecolor changed'
             return
         end if
 


### PR DESCRIPTION
## Requirements

REQ-001: `scatter` accepts `edgecolors` as a string color name without requiring a separate string `color` argument (ref #1660).
REQ-002: Existing numeric `edgecolors` behavior stays intact for RGB triples and 3*n per-point RGB sequences (ref #1660).
REQ-003: Add behavior coverage that verifies the string edge color is stored on the scatter plot state (ref #1660).

This is partial progress on #1660. Standalone scalar `linewidths=` under the canonical keyword still needs a follow-up because the existing scalar `s=` overload makes a separate scalar `linewidths=` overload ambiguous in the Fortran generic interface.

## Verification

Failing before implementation, after adding the behavior test:

```text
$ fpm test --target test_scatter
Error: There is no specific subroutine for the generic 'scatter' at (1)
<ERROR> Compilation failed for object " test_test_scatter.f90.o "
STOP 1
```

Passing after implementation:

```text
$ fpm test --target test_scatter
[100%] Project compiled successfully.
Tests passed:          12 /          12
All scatter tests PASSED!
STOP 0
```

```text
$ make test
ALL TESTS PASSED (fpm test)
```

```text
$ make verify-artifacts
Artifact verification passed.
```
