### PR TITLE
fix: scatter linewidths scalar keyword (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -51,7 +51,7 @@ contains
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
@@ -73,7 +73,7 @@ contains
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
@@ -95,47 +95,33 @@ contains
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         character(len=*), intent(in) :: color
-        real(wp), intent(in), optional :: linewidths(:)
-        character(len=*), intent(in), optional :: edgecolors
+        real(wp), intent(in), optional :: linewidths(..)
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: s(:)
         real(wp), intent(in), optional :: linewidths_scalar
         real(wp), intent(in), optional :: vmin, vmax
 
-        real(wp) :: color_rgb(3), edge_rgb(3)
-        logical :: has_color, has_edge, edge_none
+        real(wp) :: color_rgb(3)
+        logical :: has_color
 
         call resolve_color_string_or_rgb(color_str=color, context='scatter', &
                                          rgb_out=color_rgb, has_color=has_color)
-        edge_none = is_none_color(edgecolors)
-        has_edge = .false.
-        if (.not. edge_none) then
-            call resolve_color_string_or_rgb(color_str=edgecolors, context='scatter', &
-                                             rgb_out=edge_rgb, has_color=has_edge)
-        end if
 
-        if (has_color .and. has_edge) then
+        if (has_color) then
             call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
                                      marker=marker, markersize=markersize, &
                                      color=color_rgb, linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     edgecolors=edge_rgb, alpha=alpha, cmap=cmap, &
-                                     vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
-        else if (has_color) then
-            call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
-                                     marker=marker, markersize=markersize, &
-                                     color=color_rgb, linewidths=linewidths, &
-                                     linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         else
             call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
                                      marker=marker, markersize=markersize, &
                                      linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         end if
     end subroutine scatter_string
 
@@ -147,45 +133,31 @@ contains
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         character(len=*), intent(in) :: color
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
-        character(len=*), intent(in), optional :: edgecolors
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
-        real(wp) :: color_rgb(3), edge_rgb(3)
-        logical :: has_color, has_edge, edge_none
+        real(wp) :: color_rgb(3)
+        logical :: has_color
 
         call resolve_color_string_or_rgb(color_str=color, context='scatter', &
                                          rgb_out=color_rgb, has_color=has_color)
-        edge_none = is_none_color(edgecolors)
-        has_edge = .false.
-        if (.not. edge_none) then
-            call resolve_color_string_or_rgb(color_str=edgecolors, context='scatter', &
-                                             rgb_out=edge_rgb, has_color=has_edge)
-        end if
 
-        if (has_color .and. has_edge) then
+        if (has_color) then
             call scatter_2d_dispatch(x, y, s_scalar=s, c=c, label=label, &
                                      marker=marker, color=color_rgb, &
                                      linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     edgecolors=edge_rgb, alpha=alpha, cmap=cmap, &
-                                     vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
-        else if (has_color) then
-            call scatter_2d_dispatch(x, y, s_scalar=s, c=c, label=label, &
-                                     marker=marker, color=color_rgb, &
-                                     linewidths=linewidths, &
-                                     linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         else
             call scatter_2d_dispatch(x, y, s_scalar=s, c=c, label=label, &
                                      marker=marker, linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         end if
     end subroutine scatter_string_scalar_s
 
@@ -198,7 +170,7 @@ contains
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
@@ -220,9 +192,9 @@ contains
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
-        character(len=*), intent(in), optional :: edgecolors
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: s(:)
         real(wp), intent(in), optional :: vmin, vmax
@@ -244,7 +216,7 @@ contains
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
@@ -267,46 +239,32 @@ contains
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
-        character(len=*), intent(in), optional :: edgecolors
+        class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
-        real(wp) :: color_rgb(3), edge_rgb(3)
-        logical :: has_color, has_edge, edge_none
+        real(wp) :: color_rgb(3)
+        logical :: has_color
 
         call resolve_color_string_or_rgb(color_str=color, context='scatter', &
                                          rgb_out=color_rgb, has_color=has_color)
-        edge_none = is_none_color(edgecolors)
-        has_edge = .false.
-        if (.not. edge_none) then
-            call resolve_color_string_or_rgb(color_str=edgecolors, context='scatter', &
-                                             rgb_out=edge_rgb, has_color=has_edge)
-        end if
 
-        if (has_color .and. has_edge) then
+        if (has_color) then
             call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
                                      marker=marker, markersize=markersize, &
                                      color=color_rgb, linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     edgecolors=edge_rgb, alpha=alpha, cmap=cmap, &
-                                     vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
-        else if (has_color) then
-            call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
-                                     marker=marker, markersize=markersize, &
-                                     color=color_rgb, linewidths=linewidths, &
-                                     linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         else
             call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
                                      marker=marker, markersize=markersize, &
                                      linewidths=linewidths, &
                                      linewidths_scalar=linewidths_scalar, &
-                                     alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, &
-                                     edgecolors_none=edge_none)
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
         end if
     end subroutine add_scatter_3d_string
 
@@ -319,7 +277,8 @@ contains
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:), linewidths_scalar
+        real(wp), intent(in), optional :: linewidths(..)
+        real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha, vmin, vmax
         logical, intent(in), optional :: edgecolors_none
@@ -363,7 +322,8 @@ contains
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidths(:), linewidths_scalar
+        real(wp), intent(in), optional :: linewidths(..)
+        real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha, vmin, vmax
         logical, intent(in), optional :: edgecolors_none
@@ -437,7 +397,8 @@ contains
     end subroutine build_scatter_size_array
 
     function effective_linewidth(linewidths, linewidths_scalar) result(lw)
-        real(wp), intent(in), optional :: linewidths(:), linewidths_scalar
+        real(wp), intent(in), optional :: linewidths(..)
+        real(wp), intent(in), optional :: linewidths_scalar
         real(wp) :: lw
 
         lw = 1.0_wp
@@ -446,7 +407,14 @@ contains
             return
         end if
         if (present(linewidths)) then
-            if (size(linewidths) > 0) lw = linewidths(1)
+            select rank (linewidths)
+            rank (0)
+                lw = linewidths
+            rank (1)
+                if (size(linewidths) > 0) lw = linewidths(1)
+            rank default
+                call log_error('scatter: linewidths must be scalar or rank-1')
+            end select
         end if
     end function effective_linewidth
 
@@ -516,7 +484,7 @@ contains
     subroutine store_scatter_style_arrays(n, edgecolors, linewidths, no_edges)
         integer, intent(in) :: n
         class(*), intent(in), optional :: edgecolors(..)
-        real(wp), intent(in), optional :: linewidths(:)
+        real(wp), intent(in), optional :: linewidths(..)
         logical, intent(in) :: no_edges
 
         integer :: plot_idx
@@ -531,7 +499,18 @@ contains
 
         call store_edgecolor_sequence(n, edgecolors, plot_idx)
 
-        if (present(linewidths)) then
+        call store_linewidths(n, linewidths, plot_idx)
+    end subroutine store_scatter_style_arrays
+
+    subroutine store_linewidths(n, linewidths, plot_idx)
+        integer, intent(in) :: n, plot_idx
+        real(wp), intent(in), optional :: linewidths(..)
+
+        if (.not. present(linewidths)) return
+        select rank (linewidths)
+        rank (0)
+            fig%plots(plot_idx)%marker_linewidth = max(0.0_wp, linewidths)
+        rank (1)
             if (size(linewidths) == n) then
                 allocate (fig%plots(plot_idx)%scatter_linewidths(n))
                 fig%plots(plot_idx)%scatter_linewidths = linewidths
@@ -540,8 +519,10 @@ contains
             else
                 call log_error('scatter: linewidths length must match data or be 1')
             end if
-        end if
-    end subroutine store_scatter_style_arrays
+        rank default
+            call log_error('scatter: linewidths must be scalar or rank-1')
+        end select
+    end subroutine store_linewidths
 
     logical function edgecolors_are_none(edgecolors)
         class(*), intent(in), optional :: edgecolors(..)

--- a/test/edge_cases/test_simple_edge_cases.f90
+++ b/test/edge_cases/test_simple_edge_cases.f90
@@ -13,7 +13,7 @@ program test_simple_edge_cases
     print *, "Zero-size array test"
     call figure()
     call plot(x_empty, y_empty)
-    call savefig("test/output/test_zero_matplotlib.png")
+    call savefig("build/test/output/test_zero_matplotlib.png")
     
     ! Test 2: Single point
     x_single = [5.0_wp]
@@ -21,7 +21,7 @@ program test_simple_edge_cases
     print *, "Single point test"
     call figure()
     call plot(x_single, y_single)
-    call savefig("test/output/test_single_matplotlib.png")
+    call savefig("build/test/output/test_single_matplotlib.png")
     
     print *, "Tests completed - check output files"
     

--- a/test/edge_cases/test_user_compilation.f90
+++ b/test/edge_cases/test_user_compilation.f90
@@ -33,7 +33,7 @@ program test_user_compilation
     
     ! Test save functionality (this creates directories)
     print *, "Testing save functionality..."
-    call fig%savefig("test/output/test_user_output.png")
+    call fig%savefig("build/test/output/test_user_output.png")
     
     print *, "SUCCESS: User compilation and basic functionality working"
     print *, "This confirms FPM build directories are consistent"

--- a/test/edge_cases/test_user_workflow.f90
+++ b/test/edge_cases/test_user_workflow.f90
@@ -16,7 +16,7 @@ program test_user_workflow
     call ylabel("y") 
     call xlim(0.0_wp, 10.0_wp)
     call ylim(-1.0_wp, 1.0_wp)
-    call savefig("test/output/test_plot.png")
+    call savefig("build/test/output/test_plot.png")
 
     print *, "Test completed successfully"
 end program test_user_workflow

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -394,14 +394,18 @@ contains
                      linewidths=[0.5_wp, 1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp], &
                      label='edge sequence')
         call scatter(x + 7.0_wp, y, edgecolors='red', label='string edge')
+        call scatter(x + 8.0_wp, y, linewidths=1.75_wp, &
+                     label='scalar linewidths')
+        call add_scatter(x + 9.0_wp, y, z, linewidths=2.25_wp, &
+                         label='3d scalar linewidths')
 
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 8) then
-            print *, 'FAIL: test_markersize_fallback - expected 8 plots'
+        if (global_figure%plot_count < 10) then
+            print *, 'FAIL: test_markersize_fallback - expected 10 plots'
             return
         end if
 
@@ -447,6 +451,14 @@ contains
         if (any(abs(global_figure%plots(8)%marker_edgecolor - &
                     [1.0_wp, 0.0_wp, 0.0_wp]) > tol)) then
             print *, 'FAIL: test_markersize_fallback - string edgecolor changed'
+            return
+        end if
+        if (abs(global_figure%plots(9)%marker_linewidth - 1.75_wp) > tol) then
+            print *, 'FAIL: test_markersize_fallback - scalar linewidths changed'
+            return
+        end if
+        if (abs(global_figure%plots(10)%marker_linewidth - 2.25_wp) > tol) then
+            print *, 'FAIL: test_markersize_fallback - 3D scalar linewidths changed'
             return
         end if
 


### PR DESCRIPTION
## Requirements

REQ-001: Keep `s` as the primary scatter marker-size input and keep `markersize` as a backward-compatible alias.
REQ-002: Keep `cmap`, `vmin`, and `vmax` available for scalar-mapped `c` arrays.
REQ-003: Allow `edgecolors` to accept strings and RGB sequences.
REQ-004: Allow `linewidths` to accept either a scalar or per-point sequence under the matplotlib keyword.
REQ-005: Keep generated test artifacts out of `test/output/` so the CI artifact guard passes.

This continues the scatter API alignment work (ref #1660).

## Changes

- Accept scalar and rank-1 real `linewidths` in the pyplot scatter facade.
- Preserve `linewidths_scalar` as a compatibility escape hatch.
- Route string-color scatter wrappers through the shared edgecolor parser so string and sequence edgecolors use one path.
- Add regression coverage for scalar `linewidths` on 2D `scatter` and 3D `add_scatter`.
- Move edge-case test outputs from `test/output/` to `build/test/output/`.

## Verification

### Test fails on main

`fpm test --target test_scatter` with the new regression before the implementation:

```text
<ERROR> Compilation failed for object " test_test_scatter.f90.o "
test/test_scatter.f90:398:47:

  398 |                      label='scalar linewidths')
      |                                               1
Error: There is no specific subroutine for the generic ‘scatter’ at (1)
compilation terminated due to -fmax-errors=1.
```

### Test passes after fix

`fpm test --target test_scatter`:

```text
PASS: test_markersize_fallback
Tests passed:          12 /          12
All scatter tests PASSED!
```

`make test-ci`:

```text
PASS: test/output/ contains no runtime artifacts
CI essential test suite completed successfully
```

`make verify-artifacts`:

```text
Artifact verification passed.
```

<!-- orchestrate: fully-resolved -->
