### PR TITLE
fix: retitle documentation landing page (refs #1763)

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-title: fortplot documentation
+title: Documentation
 ---
 
 # fortplot

--- a/test/test_docs_index_pages.f90
+++ b/test/test_docs_index_pages.f90
@@ -1,9 +1,59 @@
 program test_docs_index_pages
     implicit none
 
+    call assert_landing_page("doc/index.md")
     call assert_examples_sorted("doc/examples/index.md")
 
 contains
+
+    subroutine assert_landing_page(path)
+        character(len=*), intent(in) :: path
+        character(len=1024) :: line
+        logical :: saw_intro, saw_examples
+        integer :: unit
+        integer :: ios
+
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "Cannot open ", trim(path)
+            stop 1
+        end if
+
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0 .or. trim(line) /= 'title: Documentation') then
+            print *, "doc/index.md must be titled Documentation"
+            close(unit)
+            stop 1
+        end if
+
+        saw_intro = .false.
+        saw_examples = .false.
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            call trim_right(line)
+            if (trim(line) == '# Examples') then
+                print *, "doc/index.md must not be an examples-only page"
+                close(unit)
+                stop 1
+            end if
+            if (trim(line) == '## Examples') then
+                saw_examples = .true.
+                exit
+            end if
+            if (index(line, 'Fortran plotting library') > 0) saw_intro = .true.
+        end do
+        close(unit)
+
+        if (.not. saw_intro) then
+            print *, "doc/index.md must introduce fortplot before examples"
+            stop 1
+        end if
+        if (.not. saw_examples) then
+            print *, "doc/index.md must link to examples"
+            stop 1
+        end if
+    end subroutine assert_landing_page
 
     subroutine assert_examples_sorted(path)
         character(len=*), intent(in) :: path


### PR DESCRIPTION
## Requirements

REQ-001: `doc/index.md` must identify the page-tree landing page as documentation, not as an examples-only page. (ref #1763)
REQ-002: `doc/index.md` must keep introductory library content before the example list.
REQ-003: The examples gallery remains at `doc/examples/index.md`.
REQ-004: Add a regression test for the page-tree landing metadata/content.

## Changes

- Retitled `doc/index.md` FORD metadata to `Documentation`.
- Extended `test_docs_index_pages` to check the landing page title, intro text, and examples section.

## Verification

Failing before the doc edit:

```text
$ fpm test --target test_docs_index_pages
[100%] Project compiled successfully.
 doc/index.md must be titled Documentation
STOP 1
<ERROR> Execution for object " test_docs_index_pages " returned exit code  1
```

Passing after the doc edit:

```text
$ fpm test --target test_docs_index_pages
[100%] Project compiled successfully.
```

```text
$ make test
ALL TESTS PASSED (fpm test)
```

```text
$ make doc
Browse the generated documentation: file:///home/ert/code/lazy-fortran/fortplot/build/doc/index.html
```

<!-- orchestrate: fully-resolved -->
