### PR TITLE
fix: update GitHub Actions Node runtime (refs #1642)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Root artifact hygiene check (Issue #990)
       if: matrix.os == 'ubuntu-latest'
@@ -70,7 +70,7 @@ jobs:
     - name: Cache full MSYS2 installation (Windows)
       if: runner.os == 'Windows'
       id: msys2_cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.MSYS2_DIR }}
         key: ${{ runner.os }}-msys2-full-MINGW64-${{ hashFiles('.github/workflows/ci.yml') }}
@@ -215,10 +215,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Cache Homebrew downloads (macOS)
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/Library/Caches/Homebrew
         key: ${{ runner.os }}-${{ runner.arch }}-homebrew-flang-fpm-${{ hashFiles('.github/workflows/ci.yml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Fortran
         uses: fortran-lang/setup-fortran@v1

--- a/.github/workflows/downstream-test.yml
+++ b/.github/workflows/downstream-test.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Cache and install apt packages
       uses: awalsh128/cache-apt-pkgs-action@v1.5.3
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Cache and install apt packages
       uses: awalsh128/cache-apt-pkgs-action@v1.5.3

--- a/test/test_png_file_size_scaling.f90
+++ b/test/test_png_file_size_scaling.f90
@@ -2,6 +2,7 @@ program test_png_file_size_scaling
     !! Test that PNG files scale appropriately with content complexity
     use fortplot, only: figure_t, wp
     use fortplot_logging, only: set_log_level, LOG_LEVEL_ERROR
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
     
     integer :: simple_size, complex_size, empty_size
@@ -135,27 +136,14 @@ contains
     
     subroutine get_output_directory(output_dir)
         character(len=*), intent(out) :: output_dir
-        logical :: dir_exists
-        integer :: unit, ios
-        
-        ! Try Unix-style test directory first
-        output_dir = 'test/output'
-        open(newunit=unit, file=trim(output_dir)//'/test_dir.tmp', iostat=ios)
-        if (ios == 0) then
-            close(unit, status='delete')
-            return
+        logical :: dir_ok
+
+        output_dir = 'build/test/output'
+        call create_directory_runtime(output_dir, dir_ok)
+        if (.not. dir_ok) then
+            print '(A)', 'FAIL: could not create build/test/output'
+            stop 1
         end if
-        
-        ! Try Windows CI build directory
-        output_dir = 'build/test'
-        open(newunit=unit, file=trim(output_dir)//'/test_dir.tmp', iostat=ios)
-        if (ios == 0) then
-            close(unit, status='delete')
-            return
-        end if
-        
-        ! Fallback to current directory
-        output_dir = '.'
     end subroutine get_output_directory
     
     function get_file_size(filename) result(size)


### PR DESCRIPTION
## Requirements

REQ-001: Replace Node 20 `actions/checkout@v4` pins in workflows with a Node 24 compatible release. (ref #1642)
REQ-002: Replace Node 20 `actions/cache@v4` pins in workflows with a Node 24 compatible release. (ref #1642)
REQ-003: Keep workflow behavior otherwise unchanged.
REQ-004: Keep test artifacts out of `test/output/` so the CI-fast artifact guard passes.

## Changes

- Updated `actions/checkout` pins from `v4` to `v5` in CI, downstream, and docs workflows.
- Updated `actions/cache` pins from `v4` to `v5` in CI workflow cache steps.
- Updated `test_png_file_size_scaling` to write generated PNGs under `build/test/output/`, matching the artifact policy enforced by `test-ci`.

## Verification

- `rg -n "actions/(checkout|cache)@v4" .github/workflows || true`
  - no output
- `fpm test --target test_png_file_size_scaling`
  - `PASS: PNG file sizes scale appropriately with content`
- `python3 scripts/test_directory_organization_limits.py`
  - `PASS: src/* subfolder item limits respected (<=20 soft, <=50 hard)`
  - `PASS: test/output/ contains no runtime artifacts`
- `make test-ci`
  - `CI essential test suite completed successfully`

<!-- orchestrate: fully-resolved -->
