### PR TITLE
fix: scatter string edgecolor sequences (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -16,7 +16,8 @@ module fortplot_matplotlib_scatter
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_global, only: fig => global_figure
     use fortplot_logging, only: log_error
-    use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb
+    use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb, &
+                                               resolve_sequence_to_rgb
     use fortplot_matplotlib_session, only: ensure_fig_init
     use fortplot_scatter_plots, only: add_scatter_2d, add_scatter_3d
 
@@ -471,9 +472,21 @@ contains
                     call log_error('scatter: edgecolors must be an RGB triple ' // &
                                    'or 3*n sequence')
                 end if
+            type is (character(len=*))
+                if (size(edgecolors) == 1) then
+                    if (is_none_color(edgecolors(1))) return
+                    call resolve_color_string_or_rgb(color_str=edgecolors(1), &
+                                                     context='scatter', &
+                                                     rgb_out=edge_rgb, &
+                                                     has_color=parsed)
+                    has_uniform_edge = parsed
+                else if (size(edgecolors) /= n) then
+                    call log_error('scatter: edgecolors string sequence length ' // &
+                                   'must match data or be 1')
+                end if
             class default
                 call log_error('scatter: edgecolors sequence must contain ' // &
-                               'real RGB values')
+                               'real RGB values or color strings')
             end select
         rank default
             call log_error('scatter: edgecolors must be a string, RGB triple, ' // &
@@ -556,8 +569,26 @@ contains
                             edgecolors(3*i - 2:3*i)
                     end do
                 end if
+            type is (character(len=*))
+                call store_character_edgecolor_sequence(n, edgecolors, plot_idx)
             end select
         end select
     end subroutine store_edgecolor_sequence
+
+    subroutine store_character_edgecolor_sequence(n, edgecolors, plot_idx)
+        integer, intent(in) :: n, plot_idx
+        character(len=*), intent(in) :: edgecolors(:)
+
+        real(wp), allocatable :: rgb(:, :)
+        logical :: ok
+
+        if (size(edgecolors) /= n .or. n <= 1) return
+
+        call resolve_sequence_to_rgb(edgecolors, rgb, 'scatter', ok)
+        if (.not. ok) return
+
+        allocate (fig%plots(plot_idx)%scatter_edgecolors(3, n))
+        fig%plots(plot_idx)%scatter_edgecolors = rgb
+    end subroutine store_character_edgecolor_sequence
 
 end module fortplot_matplotlib_scatter

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -364,6 +364,7 @@ contains
         !! Issue #1660: markersize is a backward-compatible alias for s.
         !! s remains primary, including pyplot 2D and 3D dispatch paths.
         real(wp) :: x(5), y(5), z(5), edge_seq(15)
+        character(len=6) :: edge_names(5)
         real(wp), parameter :: tol = 1.0e-12_wp
         integer :: i
 
@@ -377,6 +378,7 @@ contains
                     0.0_wp, 0.0_wp, 1.0_wp, &
                     0.5_wp, 0.5_wp, 0.0_wp, &
                     0.0_wp, 0.5_wp, 0.5_wp]
+        edge_names = ['red   ', 'green ', 'blue  ', 'orange', 'purple']
 
         call figure()
         call scatter(x, y, markersize=25.0_wp, label='markersize only')
@@ -394,9 +396,11 @@ contains
                      linewidths=[0.5_wp, 1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp], &
                      label='edge sequence')
         call scatter(x + 7.0_wp, y, edgecolors='red', label='string edge')
-        call scatter(x + 8.0_wp, y, linewidths=1.75_wp, &
+        call scatter(x + 8.0_wp, y, edgecolors=edge_names, &
+                     label='string edge sequence')
+        call scatter(x + 9.0_wp, y, linewidths=1.75_wp, &
                      label='scalar linewidths')
-        call add_scatter(x + 9.0_wp, y, z, linewidths=2.25_wp, &
+        call add_scatter(x + 10.0_wp, y, z, linewidths=2.25_wp, &
                          label='3d scalar linewidths')
 
         if (.not. allocated(global_figure)) then
@@ -404,8 +408,8 @@ contains
             return
         end if
 
-        if (global_figure%plot_count < 10) then
-            print *, 'FAIL: test_markersize_fallback - expected 10 plots'
+        if (global_figure%plot_count < 11) then
+            print *, 'FAIL: test_markersize_fallback - expected 11 plots'
             return
         end if
 
@@ -453,11 +457,20 @@ contains
             print *, 'FAIL: test_markersize_fallback - string edgecolor changed'
             return
         end if
-        if (abs(global_figure%plots(9)%marker_linewidth - 1.75_wp) > tol) then
+        if (.not. allocated(global_figure%plots(9)%scatter_edgecolors)) then
+            print *, 'FAIL: test_markersize_fallback - string edge sequence missing'
+            return
+        end if
+        if (any(abs(global_figure%plots(9)%scatter_edgecolors(:, 2) - &
+                    [0.0_wp, 0.5_wp, 0.0_wp]) > tol)) then
+            print *, 'FAIL: test_markersize_fallback - string edge sequence changed'
+            return
+        end if
+        if (abs(global_figure%plots(10)%marker_linewidth - 1.75_wp) > tol) then
             print *, 'FAIL: test_markersize_fallback - scalar linewidths changed'
             return
         end if
-        if (abs(global_figure%plots(10)%marker_linewidth - 2.25_wp) > tol) then
+        if (abs(global_figure%plots(11)%marker_linewidth - 2.25_wp) > tol) then
             print *, 'FAIL: test_markersize_fallback - 3D scalar linewidths changed'
             return
         end if


### PR DESCRIPTION
## Requirements
- REQ-001: Keep scatter `s` as the primary size argument, with `markersize` only as a backward-compatible fallback.
- REQ-002: Preserve mapped scalar colors through `c`, `cmap`, `vmin`, and `vmax`.
- REQ-003: Accept matplotlib-style `edgecolors` strings and per-point string sequences, not only RGB triples.
- REQ-004: Preserve existing RGB edgecolor sequence and linewidth behavior.

## Changes
- Parse rank-1 character `edgecolors` arrays through the existing color sequence resolver.
- Store parsed per-point string edge colors in scatter plot metadata.
- Extend `test_scatter` to cover string edgecolor sequences alongside existing numeric sequence and scalar string cases.

## Verification
- Failing before: `fpm test --target test_scatter` exited 1 with `[ERROR] scatter: edgecolors sequence must contain real RGB values`, `FAIL: test_markersize_fallback - string edge sequence missing`, and `Tests passed: 11 / 12`.
- Passing after: `fpm test --target test_scatter` exited 0 with `Tests passed: 12 / 12` and `All scatter tests PASSED!`.
- Passing after: `make test-ci` exited 0 with `CI essential test suite completed successfully`.

(ref #1660)

<!-- orchestrate: fully-resolved -->
