### PR TITLE
fix: validate docs media completeness (refs #1649)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ doc:
 			cp "$$dir"*.mp4 "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
 		fi; \
 	done
-	# Ensure animation.mp4 explicitly present at expected locations (robust fallback)
+	# Ensure animation.mp4 is present at expected locations.
 	if [ -f output/example/fortran/save_animation_demo/animation.mp4 ]; then \
 		mkdir -p build/doc/page/media/examples/animation build/doc/media/examples/animation; \
 		cp output/example/fortran/save_animation_demo/animation.mp4 build/doc/page/media/examples/animation/ 2>/dev/null || true; \
@@ -270,6 +270,7 @@ create_build_dirs:
 	@mkdir -p output/example/fortran/disconnected_lines
 	@mkdir -p output/example/fortran/boxplot_demo
 	@mkdir -p output/example/fortran/grid_demo
+	@mkdir -p output/example/fortran/dpi_demo
 	@mkdir -p output/example/fortran/datetime_axis_demo
 
 # Create test directories for isolated test artifacts (Issue #820)

--- a/example/fortran/dpi_demo/dpi_demo.f90
+++ b/example/fortran/dpi_demo/dpi_demo.f90
@@ -3,15 +3,21 @@ program dpi_demo
     !! Shows how to use DPI parameter with figure initialization and property access
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure, only: figure_t
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
+    character(len=*), parameter :: OUTDIR = "output/example/fortran/dpi_demo"
     type(figure_t) :: fig1, fig2, fig3
     real(wp), parameter :: pi = 3.14159265358979323846_wp
     real(wp) :: x(100), y(100)
     integer :: i
+    logical :: ok
 
     print *, "FortPlot DPI Demo"
     print *, "================="
+
+    call create_directory_runtime(OUTDIR, ok)
+    if (.not. ok) error stop "failed to create dpi_demo output directory"
 
     ! Generate sample data
     do i = 1, 100
@@ -27,7 +33,7 @@ program dpi_demo
     call fig1%set_xlabel("x")
     call fig1%set_ylabel("sin(x) * exp(-x/(2π))")
     print *, "DPI:", fig1%get_dpi()
-    call fig1%savefig("dpi_demo_default.png")
+    call fig1%savefig(OUTDIR // "/dpi_demo_default.png")
 
     ! Example 2: High DPI (300)
     print *, "Creating figure with high DPI (300)..."
@@ -37,7 +43,7 @@ program dpi_demo
     call fig2%set_xlabel("x")
     call fig2%set_ylabel("sin(x) * exp(-x/(2π))")
     print *, "DPI:", fig2%get_dpi()
-    call fig2%savefig("dpi_demo_high.png")
+    call fig2%savefig(OUTDIR // "/dpi_demo_high.png")
 
     ! Example 3: Low DPI (72)
     print *, "Creating figure with low DPI (72)..."
@@ -47,19 +53,19 @@ program dpi_demo
     call fig3%set_xlabel("x")
     call fig3%set_ylabel("sin(x) * exp(-x/(2π))")
     print *, "DPI:", fig3%get_dpi()
-    call fig3%savefig("dpi_demo_low.png")
+    call fig3%savefig(OUTDIR // "/dpi_demo_low.png")
 
     ! Example 4: DPI property modification
     print *, "Demonstrating DPI property modification..."
     call fig1%set_dpi(150.0_wp)
     print *, "Modified fig1 DPI to:", fig1%get_dpi()
-    call fig1%savefig("dpi_demo_modified.png")
+    call fig1%savefig(OUTDIR // "/dpi_demo_modified.png")
 
     print *, "DPI demo completed!"
     print *, "Generated files:"
-    print *, "  - dpi_demo_default.png  (DPI: 100)"
-    print *, "  - dpi_demo_high.png     (DPI: 300)"
-    print *, "  - dpi_demo_low.png      (DPI: 72)"
-    print *, "  - dpi_demo_modified.png (DPI: 150)"
+    print *, "  - ", OUTDIR // "/dpi_demo_default.png  (DPI: 100)"
+    print *, "  - ", OUTDIR // "/dpi_demo_high.png     (DPI: 300)"
+    print *, "  - ", OUTDIR // "/dpi_demo_low.png      (DPI: 72)"
+    print *, "  - ", OUTDIR // "/dpi_demo_modified.png (DPI: 150)"
 
 end program dpi_demo

--- a/scripts/test_validate_github_pages_images.sh
+++ b/scripts/test_validate_github_pages_images.sh
@@ -48,11 +48,19 @@ passing="$tmp_root/passing"
 make_fixture "$passing"
 run_validator "$passing"
 
-missing_media="$tmp_root/missing_media"
-make_fixture "$missing_media"
-rm "$missing_media/build/doc/page/media/examples/basic_plots/basic.png"
-if run_validator "$missing_media"; then
-    echo "FAIL: validator accepted missing staged media"
+missing_page_media="$tmp_root/missing_page_media"
+make_fixture "$missing_page_media"
+rm "$missing_page_media/build/doc/page/media/examples/basic_plots/basic.png"
+if run_validator "$missing_page_media"; then
+    echo "FAIL: validator accepted missing page-staged media"
+    exit 1
+fi
+
+missing_root_media="$tmp_root/missing_root_media"
+make_fixture "$missing_root_media"
+rm "$missing_root_media/build/doc/media/examples/basic_plots/basic.png"
+if run_validator "$missing_root_media"; then
+    echo "FAIL: validator accepted missing root-staged media"
     exit 1
 fi
 
@@ -61,6 +69,14 @@ make_fixture "$missing_output"
 rm "$missing_output/output/example/fortran/basic_plots/basic.png"
 if run_validator "$missing_output"; then
     echo "FAIL: validator accepted missing generated media"
+    exit 1
+fi
+
+missing_output_dir="$tmp_root/missing_output_dir"
+make_fixture "$missing_output_dir"
+rm -rf "$missing_output_dir/output/example/fortran/basic_plots"
+if run_validator "$missing_output_dir"; then
+    echo "FAIL: validator accepted missing generated media directory"
     exit 1
 fi
 

--- a/scripts/test_validate_github_pages_images.sh
+++ b/scripts/test_validate_github_pages_images.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp_root=$(mktemp -d /tmp/fortplot_media_validation.XXXXXX)
+
+cleanup() {
+    rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+make_fixture() {
+    local root="$1"
+
+    mkdir -p "$root/build/doc/page/examples"
+    mkdir -p "$root/build/doc/page/media/examples/basic_plots"
+    mkdir -p "$root/build/doc/media/examples/basic_plots"
+    mkdir -p "$root/doc/examples"
+    mkdir -p "$root/example/fortran/basic_plots"
+    mkdir -p "$root/example/fortran/display_demo"
+    mkdir -p "$root/output/example/fortran/basic_plots"
+
+    printf '<html></html>\n' > "$root/build/doc/page/examples/basic_plots.html"
+    printf '<html></html>\n' > "$root/build/doc/page/examples/display_demo.html"
+    printf 'call savefig("output/example/fortran/basic_plots/basic.png")\n' \
+        > "$root/example/fortran/basic_plots/basic_plots.f90"
+    printf 'call show()\n' > "$root/example/fortran/display_demo/display_demo.f90"
+    printf '![plot](../../media/examples/basic_plots/basic.png)\n' \
+        > "$root/doc/examples/basic_plots.md"
+    printf 'png\n' > "$root/output/example/fortran/basic_plots/basic.png"
+    printf 'png\n' > "$root/build/doc/page/media/examples/basic_plots/basic.png"
+    printf 'png\n' > "$root/build/doc/media/examples/basic_plots/basic.png"
+}
+
+run_validator() {
+    local root="$1"
+
+    DOC_BUILD_ROOT="$root/build/doc" \
+    DOC_EXAMPLES_ROOT="$root/doc/examples" \
+    EXAMPLE_SOURCE_ROOT="$root/example/fortran" \
+    EXAMPLE_OUTPUT_ROOT="$root/output/example/fortran" \
+    SKIP_MEDIA_EXAMPLES="display_demo" \
+    bash "$repo_root/scripts/validate_github_pages_images.sh" >"$tmp_root/validator.out" 2>&1
+}
+
+passing="$tmp_root/passing"
+make_fixture "$passing"
+run_validator "$passing"
+
+missing_media="$tmp_root/missing_media"
+make_fixture "$missing_media"
+rm "$missing_media/build/doc/page/media/examples/basic_plots/basic.png"
+if run_validator "$missing_media"; then
+    echo "FAIL: validator accepted missing staged media"
+    exit 1
+fi
+
+missing_output="$tmp_root/missing_output"
+make_fixture "$missing_output"
+rm "$missing_output/output/example/fortran/basic_plots/basic.png"
+if run_validator "$missing_output"; then
+    echo "FAIL: validator accepted missing generated media"
+    exit 1
+fi
+
+echo "PASS: validate_github_pages_images behavior"

--- a/scripts/validate_github_pages_images.sh
+++ b/scripts/validate_github_pages_images.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-# Validation script for GitHub Pages media paths - Issue #205
+# Validation script for GitHub Pages media paths - Issues #205, #1649
 #
 # This script validates that documentation media (images, pdf, mp4) are correctly
-# staged for GitHub Pages deployment with working relative path resolution
+# staged for GitHub Pages deployment with working relative path resolution.
 
-set -e
+set -euo pipefail
+
+DOC_BUILD_ROOT=${DOC_BUILD_ROOT:-build/doc}
+DOC_EXAMPLES_ROOT=${DOC_EXAMPLES_ROOT:-doc/examples}
+EXAMPLE_SOURCE_ROOT=${EXAMPLE_SOURCE_ROOT:-example/fortran}
+EXAMPLE_OUTPUT_ROOT=${EXAMPLE_OUTPUT_ROOT:-output/example/fortran}
+SKIP_MEDIA_EXAMPLES=${SKIP_MEDIA_EXAMPLES:-display_demo}
+MEDIA_OUTPUT_ALIASES=${MEDIA_OUTPUT_ALIASES:-animation:save_animation_demo}
 
 echo "============================================================"
-echo "VALIDATING GITHUB PAGES MEDIA PATHS - Issue #205"
+echo "VALIDATING GITHUB PAGES MEDIA PATHS - Issues #205, #1649"
 echo "============================================================"
 
 # Test results
@@ -41,47 +48,162 @@ function test_result() {
 }
 
 # Test 1: Check if documentation build directory exists
-if [ -d "build/doc" ]; then
-    test_result "Documentation build directory" "PASS" "build/doc exists"
+if [ -d "$DOC_BUILD_ROOT" ]; then
+    test_result "Documentation build directory" "PASS" "$DOC_BUILD_ROOT exists"
 else
-    test_result "Documentation build directory" "FAIL" "build/doc not found - run 'make doc' first"
+    test_result "Documentation build directory" "FAIL" "$DOC_BUILD_ROOT not found - run 'make doc' first"
 fi
 
 # Test 2: Check if media staging directories exist (both link roots)
-if [ -d "build/doc/page/media/examples" ]; then
-    test_result "Media staging directory (page)" "PASS" "build/doc/page/media/examples exists"
+if [ -d "$DOC_BUILD_ROOT/page/media/examples" ]; then
+    test_result "Media staging directory (page)" "PASS" "$DOC_BUILD_ROOT/page/media/examples exists"
 else
-    test_result "Media staging directory (page)" "CRITICAL" "build/doc/page/media/examples missing - some links may break"
+    test_result "Media staging directory (page)" "CRITICAL" "$DOC_BUILD_ROOT/page/media/examples missing - some links may break"
 fi
-if [ -d "build/doc/media/examples" ]; then
-    test_result "Media staging directory (root)" "PASS" "build/doc/media/examples exists"
+if [ -d "$DOC_BUILD_ROOT/media/examples" ]; then
+    test_result "Media staging directory (root)" "PASS" "$DOC_BUILD_ROOT/media/examples exists"
 else
-    test_result "Media staging directory (root)" "CRITICAL" "build/doc/media/examples missing - some links may break"
+    test_result "Media staging directory (root)" "CRITICAL" "$DOC_BUILD_ROOT/media/examples missing - some links may break"
 fi
 
 # Test 2b: Verify referenced PNGs exist at staged location
 missing_pngs=0
 # Extract markdown PNG links like ![...](../../media/examples/...png)
-refs=$(grep -rho -E "\((\.\.\/)?\.\.\/media\/examples\/[^)]+\.png\)" doc/examples 2>/dev/null | sort -u || true)
+refs=$(grep -rho -E "\((\.\.\/)?\.\.\/media\/examples\/[^)]+\.(png|pdf|txt|mp4)\)" "$DOC_EXAMPLES_ROOT" 2>/dev/null | sort -u || true)
 for ref in $refs; do
     # Strip surrounding parentheses
     ref="${ref#(}"
     ref="${ref%)}"
     # Compute staged target path
     if [[ "$ref" == ../../* ]]; then
-        base="build/doc"
+        base="$DOC_BUILD_ROOT"
         path=${ref#../../}
     else
-        base="build/doc/page"
+        base="$DOC_BUILD_ROOT/page"
         path=${ref#../}
     fi
     target="$base/${path}"
     if [ ! -f "$target" ]; then
-        test_result "PNG reference missing" "CRITICAL" "$target not found (referenced in docs)"
+        test_result "Media reference missing" "CRITICAL" "$target not found (referenced in docs)"
         missing_pngs=$((missing_pngs+1))
     fi
 done
-[ $missing_pngs -eq 0 ] && test_result "PNG references" "PASS" "All referenced PNGs are present"
+[ $missing_pngs -eq 0 ] && test_result "Media references" "PASS" "All referenced media files are present"
+
+should_skip_media_example() {
+    local example="$1"
+    local skip
+
+    for skip in $SKIP_MEDIA_EXAMPLES; do
+        if [ "$example" = "$skip" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+media_output_name() {
+    local example="$1"
+    local alias
+
+    for alias in $MEDIA_OUTPUT_ALIASES; do
+        if [ "${alias%%:*}" = "$example" ]; then
+            echo "${alias#*:}"
+            return
+        fi
+    done
+    echo "$example"
+}
+
+example_declares_media() {
+    local example_dir="$1"
+
+    rg -q "savefig|save_animation|output/example|\\.png|\\.pdf|\\.txt|\\.mp4" \
+        "$example_dir" -g '*.f90' -g 'README.md' 2>/dev/null
+}
+
+count_media_files() {
+    local dir="$1"
+    local ext="$2"
+
+    if [ ! -d "$dir" ]; then
+        echo 0
+        return
+    fi
+    find "$dir" -maxdepth 1 -type f -name "*.${ext}" | wc -l | tr -d ' '
+}
+
+validate_expected_examples() {
+    local example_dir example output_dir page_dir root_dir html_file
+    local expected page_count root_count ext
+    local examples_checked=0
+    local media_examples_checked=0
+
+    if [ ! -d "$EXAMPLE_SOURCE_ROOT" ]; then
+        test_result "Example source directory" "FAIL" "$EXAMPLE_SOURCE_ROOT missing"
+        return
+    fi
+
+    while IFS= read -r example_dir; do
+        example=$(basename "$example_dir")
+        examples_checked=$((examples_checked + 1))
+
+        html_file="$DOC_BUILD_ROOT/page/examples/${example}.html"
+        if [ -f "$html_file" ]; then
+            test_result "Example page: $example" "PASS" "$html_file exists"
+        else
+            test_result "Example page: $example" "CRITICAL" "$html_file missing"
+        fi
+
+        if should_skip_media_example "$example"; then
+            continue
+        fi
+        if ! example_declares_media "$example_dir"; then
+            continue
+        fi
+
+        media_examples_checked=$((media_examples_checked + 1))
+        output_dir="$EXAMPLE_OUTPUT_ROOT/$(media_output_name "$example")"
+        page_dir="$DOC_BUILD_ROOT/page/media/examples/$example"
+        root_dir="$DOC_BUILD_ROOT/media/examples/$example"
+
+        if [ ! -d "$output_dir" ]; then
+            test_result "Generated media: $example" "CRITICAL" "$output_dir missing"
+            continue
+        fi
+
+        expected=0
+        for ext in png pdf txt mp4; do
+            expected=$((expected + $(count_media_files "$output_dir" "$ext")))
+        done
+        if [ "$expected" -eq 0 ]; then
+            test_result "Generated media: $example" "CRITICAL" "$output_dir has no media files"
+            continue
+        fi
+
+        for ext in png pdf txt mp4; do
+            expected=$(count_media_files "$output_dir" "$ext")
+            if [ "$expected" -eq 0 ]; then
+                continue
+            fi
+            page_count=$(count_media_files "$page_dir" "$ext")
+            root_count=$(count_media_files "$root_dir" "$ext")
+            if [ "$page_count" -lt "$expected" ]; then
+                test_result "Page media count: $example .$ext" "CRITICAL" \
+                    "$page_dir has $page_count, expected at least $expected"
+            fi
+            if [ "$root_count" -lt "$expected" ]; then
+                test_result "Root media count: $example .$ext" "CRITICAL" \
+                    "$root_dir has $root_count, expected at least $expected"
+            fi
+        done
+    done < <(find "$EXAMPLE_SOURCE_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
+
+    test_result "Expected examples" "PASS" "$examples_checked example pages checked"
+    test_result "Expected media examples" "PASS" "$media_examples_checked media-producing examples checked"
+}
+
+validate_expected_examples
 
 # Test 3: Check workflow and Makefile for proper media staging
 if [ -f ".github/workflows/docs.yml" ]; then
@@ -135,7 +257,7 @@ if [ $CRITICAL_ISSUES -gt 0 ]; then
     echo "GitHub Pages documentation will have broken media links!"
     echo ""
     echo "REQUIRED FIXES:"
-    echo "1. Ensure media files are copied to build/doc/page/media/examples/"
+    echo "1. Ensure media files are copied to $DOC_BUILD_ROOT/page/media/examples/"
     echo "2. Validate that HTML files reference media with correct paths"
     echo "3. Test relative path resolution works correctly"
     echo ""


### PR DESCRIPTION
## Requirements

REQ-001: Validate documentation media for all expected example pages, not only one animation file. (ref #1649)
REQ-002: Detect examples that declare media output and fail when their generated media directory is missing or empty.
REQ-003: Compare generated media counts by extension against both staged documentation link roots.
REQ-004: Validate markdown references for `.png`, `.pdf`, `.txt`, and `.mp4` media.
REQ-005: Add a behavior test proving missing staged media and missing generated media are rejected.

## Verification

### Test fails on main
Command: temp fixture using the pre-change validator from `HEAD`, with no generated example media.

```text
FAIL: validator accepted missing generated media
============================================================
VALIDATING GITHUB PAGES MEDIA PATHS - Issue #205
============================================================
PASS: Documentation build directory
  build/doc exists
PASS: Media staging directory (page)
  build/doc/page/media/examples exists
PASS: Media staging directory (root)
  build/doc/media/examples exists
PASS: PNG references
  All referenced PNGs are present
PASS: Workflow media staging
  No media copy found near 'make doc'
PASS: Makefile media staging
  FORD runs first, then media copied under page/media - correct pattern

VALIDATION SUMMARY
Tests passed: 6
Tests failed: 0
Critical issues: 0
PASS: All tests passed - GitHub Pages images should work correctly
```

### Test passes after fix
`bash -n scripts/validate_github_pages_images.sh && bash -n scripts/test_validate_github_pages_images.sh`

```text
exit code 0
```

`bash scripts/test_validate_github_pages_images.sh`

```text
PASS: validate_github_pages_images behavior
```

`make test-docs`

```text
Running documentation tests with timeout 300s...
Project is up to date
 All doc core tests passed!
Project is up to date
 Doc processing/output tests passed
Project is up to date
Documentation tests completed successfully
```

<!-- orchestrate: fully-resolved -->
