### PR TITLE
fix: embed dpi demo output images (refs #1760)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ test-docs: create_build_dirs
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_doc_core || exit 1
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_doc_processing_output || exit 1
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_docs_index_pages || exit 1
+	@$(TIMEOUT_PREFIX) bash scripts/test_validate_github_pages_images.sh || exit 1
 	@echo "Documentation tests completed successfully"
 
 # Run comprehensive functional tests

--- a/doc/examples/dpi_demo.md
+++ b/doc/examples/dpi_demo.md
@@ -10,7 +10,7 @@ Control output DPI when saving figures for consistent sizing across formats.
 ## Files
 
 - `dpi_demo.f90` - Source code
-- Run the example to populate `output/example/fortran/dpi_demo/`
+- Generated media in `output/example/fortran/dpi_demo/`
 
 ## Running
 
@@ -20,5 +20,19 @@ make example ARGS="dpi_demo"
 
 ## Output
 
-Run this example to generate plots and other media assets.
+### Dpi Demo Default
+
+![dpi_demo_default.png](../../media/examples/dpi_demo/dpi_demo_default.png)
+
+### Dpi Demo High
+
+![dpi_demo_high.png](../../media/examples/dpi_demo/dpi_demo_high.png)
+
+### Dpi Demo Low
+
+![dpi_demo_low.png](../../media/examples/dpi_demo/dpi_demo_low.png)
+
+### Dpi Demo Modified
+
+![dpi_demo_modified.png](../../media/examples/dpi_demo/dpi_demo_modified.png)
 

--- a/scripts/test_validate_github_pages_images.sh
+++ b/scripts/test_validate_github_pages_images.sh
@@ -80,4 +80,12 @@ if run_validator "$missing_output_dir"; then
     exit 1
 fi
 
+missing_png_embed="$tmp_root/missing_png_embed"
+make_fixture "$missing_png_embed"
+printf 'No embedded image here.\n' > "$missing_png_embed/doc/examples/basic_plots.md"
+if run_validator "$missing_png_embed"; then
+    echo "FAIL: validator accepted a PNG-producing page with no image embed"
+    exit 1
+fi
+
 echo "PASS: validate_github_pages_images behavior"

--- a/scripts/validate_github_pages_images.sh
+++ b/scripts/validate_github_pages_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Validation script for GitHub Pages media paths - Issues #205, #1649
+# Validation script for GitHub Pages media paths - Issues #205, #1649, #1760
 #
 # This script validates that documentation media (images, pdf, mp4) are correctly
 # staged for GitHub Pages deployment with working relative path resolution.
@@ -15,7 +15,7 @@ SKIP_MEDIA_EXAMPLES=${SKIP_MEDIA_EXAMPLES:-display_demo}
 MEDIA_OUTPUT_ALIASES=${MEDIA_OUTPUT_ALIASES:-animation:save_animation_demo}
 
 echo "============================================================"
-echo "VALIDATING GITHUB PAGES MEDIA PATHS - Issues #205, #1649"
+echo "VALIDATING GITHUB PAGES MEDIA PATHS - Issues #205, #1649, #1760"
 echo "============================================================"
 
 # Test results
@@ -134,7 +134,7 @@ count_media_files() {
 }
 
 validate_expected_examples() {
-    local example_dir example output_dir page_dir root_dir html_file
+    local example_dir example output_dir page_dir root_dir html_file doc_file
     local expected page_count root_count ext
     local examples_checked=0
     local media_examples_checked=0
@@ -197,6 +197,16 @@ validate_expected_examples() {
                     "$root_dir has $root_count, expected at least $expected"
             fi
         done
+
+        doc_file="$DOC_EXAMPLES_ROOT/${example}.md"
+        expected=$(count_media_files "$output_dir" "png")
+        if [ "$expected" -gt 0 ] && [ -f "$doc_file" ]; then
+            if ! rg -q "!\[[^]]*\]\(\.\./\.\./media/examples/${example}/[^)]*\.png\)" \
+                    "$doc_file"; then
+                test_result "PNG embed: $example" "CRITICAL" \
+                    "$doc_file has no embedded PNG output"
+            fi
+        fi
     done < <(find "$EXAMPLE_SOURCE_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
 
     test_result "Expected examples" "PASS" "$examples_checked example pages checked"


### PR DESCRIPTION
## Requirements

- REQ-001: For each example page that has generated PNG output, embed representative PNG media instead of leaving a blank output section (ref #1760).
- REQ-002: Keep image links on the documented `../../media/examples/<example>/...` path.
- REQ-003: Add a regression check so PNG-producing example docs without image embeds fail validation.
- REQ-004: Run the validator through `make test-docs`.

## Changes

- Added the four generated DPI demo PNGs to `doc/examples/dpi_demo.md`.
- Extended `scripts/validate_github_pages_images.sh` to require a PNG embed for PNG-producing example docs.
- Added a negative fixture for missing PNG embeds and wired that test into `make test-docs`.

## Verification

- Before: `git show HEAD^:doc/examples/dpi_demo.md | rg ...` -> `BEFORE: dpi_demo had no embedded PNG output`
- After: `rg ... doc/examples/dpi_demo.md` -> `AFTER: dpi_demo embeds PNG output`
- `bash scripts/test_validate_github_pages_images.sh` -> `PASS: validate_github_pages_images behavior`
- `make test-docs` -> `Documentation tests completed successfully`
- `make doc` -> `Browse the generated documentation: file:///home/ert/code/lazy-fortran/fortplot/build/doc/index.html`
- `bash scripts/validate_github_pages_images.sh` -> `Tests passed: 38`, `Tests failed: 0`, `Critical issues: 0`
- `git diff --check` -> no output
- `$HOME/code/prompts/scripts/check-writing-slop.py ... --threshold medium` -> `PASS: no writing-slop candidates at threshold medium`

<!-- orchestrate: fully-resolved -->
