### PR TITLE
fix: add artifact gate to test-ci (refs #1648)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,8 @@ test-ci:
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_streamplot || exit 1
 	@# Contour level and memory safety guard (Issue #1704)
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_contour || exit 1
+	@echo "Testing generated example artifacts"
+	@$(TIMEOUT_PREFIX) $(MAKE) verify-artifacts || exit 1
 	@echo "CI essential test suite completed successfully"
 
 # Clean build artifacts
@@ -238,6 +240,7 @@ test-docs: create_build_dirs
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_doc_processing_output || exit 1
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_docs_index_pages || exit 1
 	@$(TIMEOUT_PREFIX) bash scripts/test_validate_github_pages_images.sh || exit 1
+	@$(TIMEOUT_PREFIX) bash scripts/test_test_ci_artifact_gate.sh || exit 1
 	@echo "Documentation tests completed successfully"
 
 # Run comprehensive functional tests

--- a/scripts/test_test_ci_artifact_gate.sh
+++ b/scripts/test_test_ci_artifact_gate.sh
@@ -12,7 +12,18 @@ trap cleanup EXIT
 awk '
     /^test-ci:/ { in_target = 1; print; next }
     in_target && /^[A-Za-z0-9_.-]+:/ { in_target = 0 }
-    in_target { print }
+    in_target && /^[[:space:]]/ {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+        while (line ~ /^[@+-]/) {
+            line = substr(line, 2)
+        }
+        sub(/^[[:space:]]+/, "", line)
+        sub(/[[:space:]]+#.*$/, "", line)
+        if (line !~ /^#/) {
+            print line
+        }
+    }
 ' "$makefile" > "$tmp"
 
 if ! grep -Eq '(\$\(MAKE\)|make)[[:space:]]+verify-artifacts' "$tmp"; then

--- a/scripts/test_test_ci_artifact_gate.sh
+++ b/scripts/test_test_ci_artifact_gate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+makefile=${1:-Makefile}
+tmp=$(mktemp /tmp/fortplot_test_ci_artifact_gate.XXXXXX)
+cleanup() {
+    rm -f "$tmp"
+}
+trap cleanup EXIT
+
+awk '
+    /^test-ci:/ { in_target = 1; print; next }
+    in_target && /^[A-Za-z0-9_.-]+:/ { in_target = 0 }
+    in_target { print }
+' "$makefile" > "$tmp"
+
+if ! grep -Eq '(\$\(MAKE\)|make)[[:space:]]+verify-artifacts' "$tmp"; then
+    echo "FAIL: test-ci does not invoke verify-artifacts"
+    exit 1
+fi
+
+echo "PASS: test-ci invokes verify-artifacts"


### PR DESCRIPTION
## Requirements

REQ-001: Add example artifact verification to `test-ci`.
REQ-002: Reuse existing repo tooling instead of introducing a new artifact checker.
REQ-003: Add a regression test that fails if `test-ci` stops invoking `verify-artifacts`.
REQ-004: Keep this as partial progress because doc build validation is still outside `test-ci`.

## Changes

- `test-ci` now invokes `$(MAKE) verify-artifacts` after the curated fpm/API checks.
- `test-docs` now runs `scripts/test_test_ci_artifact_gate.sh` to keep the Makefile contract covered.

Reference: ref #1648.

## Verification

- `bash scripts/test_test_ci_artifact_gate.sh`
  - `PASS: test-ci invokes verify-artifacts`
- `$HOME/code/prompts/scripts/check-writing-slop.py Makefile scripts/test_test_ci_artifact_gate.sh`
  - `PASS: no writing-slop candidates at threshold medium`
- `make test-docs`
  - `PASS: validate_github_pages_images behavior`
  - `PASS: test-ci invokes verify-artifacts`
  - `Documentation tests completed successfully`
- `make test-ci`
  - `Testing generated example artifacts`
  - `Artifact verification passed.`
  - `CI essential test suite completed successfully`
