### PR TITLE
fix: split fill_between preparation (refs #1747)

### DIFF
--- a/src/figures/core/fortplot_figure_core_specialized.f90
+++ b/src/figures/core/fortplot_figure_core_specialized.f90
@@ -478,106 +478,156 @@ contains
         integer :: n
         real(wp), allocatable :: upper_vals(:), lower_vals(:)
         logical, allocatable :: mask_vals(:)
-        logical :: has_mask, has_color, has_alpha
-        character(len=:), allocatable :: color_value
-        real(wp) :: alpha_value
+        logical :: has_mask
 
         n = size(x)
-        if (n < 2) then
-            call log_error('fill_between: need at least two points to form area')
+        if (.not. prepare_fill_between_values(n, y1, y2, where, upper_vals, &
+                                              lower_vals, mask_vals, has_mask)) then
+            call cleanup_fill_between_values(upper_vals, lower_vals, mask_vals)
             return
-        end if
-
-        allocate (upper_vals(n), lower_vals(n))
-        if (present(y1)) then
-            if (size(y1) /= n) then
-                call log_error('fill_between: y1 size mismatch')
-                deallocate (upper_vals, lower_vals)
-                return
-            end if
-            upper_vals = y1
-        else
-            upper_vals = 0.0_wp
-        end if
-
-        if (present(y2)) then
-            if (size(y2) /= n) then
-                call log_error('fill_between: y2 size mismatch')
-                deallocate (upper_vals, lower_vals)
-                return
-            end if
-            lower_vals = y2
-        else
-            lower_vals = 0.0_wp
-        end if
-
-        has_mask = .false.
-        if (present(where)) then
-            if (size(where) /= n) then
-                call log_error('fill_between: where mask size mismatch')
-                deallocate (upper_vals, lower_vals)
-                return
-            end if
-            allocate (mask_vals(n))
-            mask_vals = where
-            if (.not. any(mask_vals)) then
-                call log_warning('fill_between: mask excludes all data points')
-                deallocate (upper_vals, lower_vals, mask_vals)
-                return
-            end if
-            has_mask = .true.
         end if
 
         if (present(interpolate)) then
             call log_warning('fill_between: interpolate option ignored')
         end if
 
-        has_color = present(color)
-        if (has_color) color_value = color
-        has_alpha = present(alpha)
-        if (has_alpha) alpha_value = alpha
-
-        select case (merge(1, 0, has_mask) + merge(2, 0, has_color) + &
-                     merge(4, 0, has_alpha))
-        case (0)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, plot_count=self%plot_count)
-        case (1)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, mask=mask_vals, &
-                                       plot_count=self%plot_count)
-        case (2)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, color_string=color_value, &
-                                       plot_count=self%plot_count)
-        case (3)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, mask=mask_vals, &
-                                       color_string=color_value, &
-                                       plot_count=self%plot_count)
-        case (4)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, alpha=alpha_value, &
-                                       plot_count=self%plot_count)
-        case (5)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, mask=mask_vals, alpha=alpha_value, &
-                                       plot_count=self%plot_count)
-        case (6)
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, color_string=color_value, &
-                                       alpha=alpha_value, plot_count=self%plot_count)
-        case default
-            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
-                                       lower_vals, mask=mask_vals, &
-                                       color_string=color_value, &
-                                       alpha=alpha_value, plot_count=self%plot_count)
-        end select
+        if (has_mask) then
+            call add_prepared_fill_between(self, x, upper_vals, lower_vals, &
+                                           mask=mask_vals, color=color, alpha=alpha)
+        else
+            call add_prepared_fill_between(self, x, upper_vals, lower_vals, &
+                                           color=color, alpha=alpha)
+        end if
 
         self%plot_count = self%state%plot_count
 
         if (has_mask) deallocate (mask_vals)
         deallocate (upper_vals, lower_vals)
     end subroutine add_fill_between
+
+    subroutine cleanup_fill_between_values(upper_vals, lower_vals, mask_vals)
+        real(wp), allocatable, intent(inout) :: upper_vals(:), lower_vals(:)
+        logical, allocatable, intent(inout) :: mask_vals(:)
+
+        if (allocated(upper_vals)) deallocate (upper_vals)
+        if (allocated(lower_vals)) deallocate (lower_vals)
+        if (allocated(mask_vals)) deallocate (mask_vals)
+    end subroutine cleanup_fill_between_values
+
+    logical function prepare_fill_between_values(n, y1, y2, where, upper_vals, &
+                                                 lower_vals, mask_vals, has_mask) &
+        result(ok)
+        integer, intent(in) :: n
+        real(wp), intent(in), optional :: y1(:), y2(:)
+        logical, intent(in), optional :: where(:)
+        real(wp), allocatable, intent(out) :: upper_vals(:), lower_vals(:)
+        logical, allocatable, intent(out) :: mask_vals(:)
+        logical, intent(out) :: has_mask
+
+        ok = .false.
+        has_mask = .false.
+        if (n < 2) then
+            call log_error('fill_between: need at least two points to form area')
+            return
+        end if
+
+        allocate (upper_vals(n), lower_vals(n))
+        if (.not. assign_fill_between_bound(n, y1, upper_vals, 'y1')) return
+        if (.not. assign_fill_between_bound(n, y2, lower_vals, 'y2')) return
+        if (.not. assign_fill_between_mask(n, where, mask_vals, has_mask)) return
+        ok = .true.
+    end function prepare_fill_between_values
+
+    logical function assign_fill_between_bound(n, source, target, name) result(ok)
+        integer, intent(in) :: n
+        real(wp), intent(in), optional :: source(:)
+        real(wp), intent(out) :: target(:)
+        character(len=*), intent(in) :: name
+
+        ok = .false.
+        if (present(source)) then
+            if (size(source) /= n) then
+                call log_error('fill_between: '//name//' size mismatch')
+                return
+            end if
+            target = source
+        else
+            target = 0.0_wp
+        end if
+        ok = .true.
+    end function assign_fill_between_bound
+
+    logical function assign_fill_between_mask(n, where, mask_vals, has_mask) &
+        result(ok)
+        integer, intent(in) :: n
+        logical, intent(in), optional :: where(:)
+        logical, allocatable, intent(out) :: mask_vals(:)
+        logical, intent(out) :: has_mask
+
+        ok = .false.
+        has_mask = .false.
+        if (.not. present(where)) then
+            ok = .true.
+            return
+        end if
+        if (size(where) /= n) then
+            call log_error('fill_between: where mask size mismatch')
+            return
+        end if
+        allocate (mask_vals(n))
+        mask_vals = where
+        if (.not. any(mask_vals)) then
+            call log_warning('fill_between: mask excludes all data points')
+            return
+        end if
+        has_mask = .true.
+        ok = .true.
+    end function assign_fill_between_mask
+
+    subroutine add_prepared_fill_between(self, x, upper_vals, lower_vals, mask, &
+                                         color, alpha)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:), upper_vals(:), lower_vals(:)
+        logical, intent(in), optional :: mask(:)
+        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: alpha
+
+        select case (merge(1, 0, present(mask)) + merge(2, 0, present(color)) + &
+                     merge(4, 0, present(alpha)))
+        case (0)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, plot_count=self%plot_count)
+        case (1)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask, &
+                                       plot_count=self%plot_count)
+        case (2)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, color_string=color, &
+                                       plot_count=self%plot_count)
+        case (3)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask, &
+                                       color_string=color, &
+                                       plot_count=self%plot_count)
+        case (4)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, alpha=alpha, &
+                                       plot_count=self%plot_count)
+        case (5)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask, alpha=alpha, &
+                                       plot_count=self%plot_count)
+        case (6)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, color_string=color, &
+                                       alpha=alpha, plot_count=self%plot_count)
+        case default
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask, &
+                                       color_string=color, &
+                                       alpha=alpha, plot_count=self%plot_count)
+        end select
+    end subroutine add_prepared_fill_between
 
 end submodule fortplot_figure_core_specialized

--- a/test/test_legacy_positional_order.f90
+++ b/test/test_legacy_positional_order.f90
@@ -1,7 +1,7 @@
 program test_legacy_positional_order
     !! Ensure figure_t add_* helpers accept legacy pyplot positional ordering
     use fortplot, only: figure_t
-    use fortplot_figure_core, only: plot_data_t
+    use fortplot_figure_core, only: PLOT_TYPE_FILL, plot_data_t
     use iso_fortran_env, only: wp => real64
     implicit none
 
@@ -75,9 +75,10 @@ contains
         y2 = y1 * 0.5_wp
         mask = .true.
 
-        call fig%add_fill_between(x, y1, y2, mask)
+        call fig%add_fill_between(x, y1, y2, mask, 'red', 0.25_wp)
         call fetch_plots(fig, plots, n)
         call assert_no_labels(plots, n)
+        call assert_fill_between_storage(plots(n), x, y1, y2, mask)
     end subroutine test_fill_between
 
     subroutine test_polar()
@@ -168,6 +169,37 @@ contains
         end do
         error stop 'assert_any_label: expected label not found'
     end subroutine assert_any_label
+
+    subroutine assert_fill_between_storage(plot, x, y1, y2, mask)
+        type(plot_data_t), intent(in) :: plot
+        real(wp), intent(in) :: x(:), y1(:), y2(:)
+        logical, intent(in) :: mask(:)
+
+        if (plot%plot_type /= PLOT_TYPE_FILL) then
+            error stop 'assert_fill_between_storage: expected fill plot'
+        end if
+        if (.not. allocated(plot%fill_between_data%x) .or. &
+            .not. allocated(plot%fill_between_data%upper) .or. &
+            .not. allocated(plot%fill_between_data%lower) .or. &
+            .not. allocated(plot%fill_between_data%mask)) then
+            error stop 'assert_fill_between_storage: missing arrays'
+        end if
+        if (.not. plot%fill_between_data%has_mask) then
+            error stop 'assert_fill_between_storage: mask not stored'
+        end if
+        if (any(abs(plot%fill_between_data%x - x) > 1.0e-12_wp) .or. &
+            any(abs(plot%fill_between_data%upper - y1) > 1.0e-12_wp) .or. &
+            any(abs(plot%fill_between_data%lower - y2) > 1.0e-12_wp) .or. &
+            any(plot%fill_between_data%mask .neqv. mask)) then
+            error stop 'assert_fill_between_storage: data mismatch'
+        end if
+        if (abs(plot%fill_alpha - 0.25_wp) > 1.0e-12_wp) then
+            error stop 'assert_fill_between_storage: alpha mismatch'
+        end if
+        if (any(abs(plot%color - [1.0_wp, 0.0_wp, 0.0_wp]) > 1.0e-12_wp)) then
+            error stop 'assert_fill_between_storage: color mismatch'
+        end if
+    end subroutine assert_fill_between_storage
 
     subroutine assert_no_labels(plots, count)
         type(plot_data_t), intent(in) :: plots(:)


### PR DESCRIPTION
## Requirements

REQ-001: Reduce at least one remaining 100+ line Fortran procedure from the audit below the hard 100-line limit.
REQ-002: Preserve fill-between behavior and public calling conventions.
REQ-003: Keep the change scoped to the refactored implementation and behavior coverage.
REQ-004: Verify with targeted behavior tests, line-count evidence, and repo gates.

## Changes

- Split `figure_t%add_fill_between` preparation, cleanup, mask validation, and dispatch into local helpers.
- Kept `add_fill_between` behavior intact for optional `where`, `color`, `alpha`, and `interpolate`.
- Extended the legacy positional-order test to assert stored fill-between data and style.

This is partial progress on the function-length audit (ref #1747). Other 100+ line procedures remain.

## Verification

Before line-count check:

```text
114 HEAD^:src/figures/core/fortplot_figure_core_specialized.f90:468     module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
```

After line-count check:

```text
 39 src/figures/core/fortplot_figure_core_specialized.f90:468     module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
  8 src/figures/core/fortplot_figure_core_specialized.f90:508     subroutine cleanup_fill_between_values(upper_vals, lower_vals, mask_vals)
 23 src/figures/core/fortplot_figure_core_specialized.f90:517     logical function prepare_fill_between_values(n, y1, y2, where, upper_vals, &
 18 src/figures/core/fortplot_figure_core_specialized.f90:541     logical function assign_fill_between_bound(n, source, target, name) result(ok)
 26 src/figures/core/fortplot_figure_core_specialized.f90:560     logical function assign_fill_between_mask(n, where, mask_vals, has_mask) &
 45 src/figures/core/fortplot_figure_core_specialized.f90:587     subroutine add_prepared_fill_between(self, x, upper_vals, lower_vals, mask, &
```

Commands run:

```text
fpm test --target test_legacy_positional_order
Project compiled successfully.
PASS: Legacy positional ordering works for figure_t add_* helpers

make test-ci
CI essential test suite completed successfully

make verify-artifacts
Artifact verification passed.

$HOME/code/prompts/scripts/check-writing-slop.py --threshold soft src/figures/core/fortplot_figure_core_specialized.f90 test/test_legacy_positional_order.f90
PASS: no writing-slop candidates at threshold soft
```
