### PR TITLE
fix: accept scatter edgecolor matrices (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -488,6 +488,16 @@ contains
                 call log_error('scatter: edgecolors sequence must contain ' // &
                                'real RGB values or color strings')
             end select
+        rank (2)
+            select type (edgecolors)
+            type is (real(wp))
+                if (.not. valid_edgecolor_matrix(n, edgecolors)) then
+                    call log_error('scatter: edgecolors matrix must have ' // &
+                                   'shape 3*n or n*3')
+                end if
+            class default
+                call log_error('scatter: edgecolors matrix must contain real RGB values')
+            end select
         rank default
             call log_error('scatter: edgecolors must be a string, RGB triple, ' // &
                            'or 3*n sequence')
@@ -572,8 +582,41 @@ contains
             type is (character(len=*))
                 call store_character_edgecolor_sequence(n, edgecolors, plot_idx)
             end select
+        rank (2)
+            select type (edgecolors)
+            type is (real(wp))
+                call store_real_edgecolor_matrix(n, edgecolors, plot_idx)
+            end select
         end select
     end subroutine store_edgecolor_sequence
+
+    logical function valid_edgecolor_matrix(n, edgecolors)
+        integer, intent(in) :: n
+        real(wp), intent(in) :: edgecolors(:, :)
+
+        valid_edgecolor_matrix = (size(edgecolors, 1) == 3 .and. &
+                                  size(edgecolors, 2) == n) .or. &
+                                 (size(edgecolors, 1) == n .and. &
+                                  size(edgecolors, 2) == 3)
+    end function valid_edgecolor_matrix
+
+    subroutine store_real_edgecolor_matrix(n, edgecolors, plot_idx)
+        integer, intent(in) :: n, plot_idx
+        real(wp), intent(in) :: edgecolors(:, :)
+
+        integer :: i
+
+        if (.not. valid_edgecolor_matrix(n, edgecolors)) return
+
+        allocate (fig%plots(plot_idx)%scatter_edgecolors(3, n))
+        if (size(edgecolors, 1) == 3) then
+            fig%plots(plot_idx)%scatter_edgecolors = edgecolors(:, 1:n)
+        else
+            do i = 1, n
+                fig%plots(plot_idx)%scatter_edgecolors(:, i) = edgecolors(i, :)
+            end do
+        end if
+    end subroutine store_real_edgecolor_matrix
 
     subroutine store_character_edgecolor_sequence(n, edgecolors, plot_idx)
         integer, intent(in) :: n, plot_idx

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -364,6 +364,7 @@ contains
         !! Issue #1660: markersize is a backward-compatible alias for s.
         !! s remains primary, including pyplot 2D and 3D dispatch paths.
         real(wp) :: x(5), y(5), z(5), edge_seq(15)
+        real(wp) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
         character(len=6) :: edge_names(5)
         real(wp), parameter :: tol = 1.0e-12_wp
         integer :: i
@@ -378,6 +379,10 @@ contains
                     0.0_wp, 0.0_wp, 1.0_wp, &
                     0.5_wp, 0.5_wp, 0.0_wp, &
                     0.0_wp, 0.5_wp, 0.5_wp]
+        do i = 1, size(x)
+            edge_matrix_3n(:, i) = edge_seq(3*i - 2:3*i)
+            edge_matrix_n3(i, :) = edge_seq(3*i - 2:3*i)
+        end do
         edge_names = ['red   ', 'green ', 'blue  ', 'orange', 'purple']
 
         call figure()
@@ -402,14 +407,18 @@ contains
                      label='scalar linewidths')
         call add_scatter(x + 10.0_wp, y, z, linewidths=2.25_wp, &
                          label='3d scalar linewidths')
+        call scatter(x + 11.0_wp, y, edgecolors=edge_matrix_3n, &
+                     label='edge matrix 3xn')
+        call scatter(x + 12.0_wp, y, edgecolors=edge_matrix_n3, &
+                     label='edge matrix nx3')
 
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 11) then
-            print *, 'FAIL: test_markersize_fallback - expected 11 plots'
+        if (global_figure%plot_count < 13) then
+            print *, 'FAIL: test_markersize_fallback - expected 13 plots'
             return
         end if
 
@@ -472,6 +481,24 @@ contains
         end if
         if (abs(global_figure%plots(11)%marker_linewidth - 2.25_wp) > tol) then
             print *, 'FAIL: test_markersize_fallback - 3D scalar linewidths changed'
+            return
+        end if
+        if (.not. allocated(global_figure%plots(12)%scatter_edgecolors)) then
+            print *, 'FAIL: test_markersize_fallback - 3xn edge matrix missing'
+            return
+        end if
+        if (any(abs(global_figure%plots(12)%scatter_edgecolors(:, 4) - &
+                    [0.5_wp, 0.5_wp, 0.0_wp]) > tol)) then
+            print *, 'FAIL: test_markersize_fallback - 3xn edge matrix changed'
+            return
+        end if
+        if (.not. allocated(global_figure%plots(13)%scatter_edgecolors)) then
+            print *, 'FAIL: test_markersize_fallback - nx3 edge matrix missing'
+            return
+        end if
+        if (any(abs(global_figure%plots(13)%scatter_edgecolors(:, 5) - &
+                    [0.0_wp, 0.5_wp, 0.5_wp]) > tol)) then
+            print *, 'FAIL: test_markersize_fallback - nx3 edge matrix changed'
             return
         end if
 


### PR DESCRIPTION
## Requirements

- REQ-001: Keep existing scatter `s`, `markersize`, `cmap`, `vmin`, `vmax`, scalar/string edgecolor, and linewidth behavior unchanged.
- REQ-002: Accept per-point RGB `edgecolors` as rank-2 arrays with shape `(3, n)` or `(n, 3)`.
- REQ-003: Store rank-2 edge colors as `scatter_edgecolors(3, n)` so rendering uses per-point edges.
- REQ-004: Add a behavior test that fails before the implementation and passes after.

Issue reference: (ref #1660)

## Verification

### Test fails on main

With the new regression assertions applied before the implementation:

```text
$ fpm test --target test_scatter
[ERROR] scatter: edgecolors must be a string, RGB triple, or 3*n sequence
[ERROR] scatter: edgecolors must be a string, RGB triple, or 3*n sequence
FAIL: test_markersize_fallback - 3xn edge matrix missing
Tests passed:          11 /          12
FAIL: Some scatter tests failed
<ERROR> Execution for object " test_scatter " returned exit code  1
```

### Test passes after fix

```text
$ fpm test --target test_scatter
PASS: test_markersize_fallback
Tests passed:          12 /          12
All scatter tests PASSED!
```

```text
$ make test-ci
PASS: src/* subfolder item limits respected (<=20 soft, <=50 hard)
PASS: test/output/ contains no runtime artifacts
Artifact verification passed.
CI essential test suite completed successfully
```

```text
$ make verify-artifacts
Artifact verification passed.
```

```text
$ git diff --check
# no output
```

```text
$ $HOME/code/prompts/scripts/check-writing-slop.py src/interfaces/fortplot_matplotlib_scatter.f90 test/test_scatter.f90
PASS: no writing-slop candidates at threshold medium
```

<!-- orchestrate: fully-resolved -->
