### PR TITLE
fix: scatter edgecolors none sequence (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -558,6 +558,13 @@ contains
             type is (character(len=*))
                 edgecolors_are_none = is_none_color(edgecolors)
             end select
+        rank (1)
+            select type (edgecolors)
+            type is (character(len=*))
+                if (size(edgecolors) == 1) then
+                    edgecolors_are_none = is_none_color(edgecolors(1))
+                end if
+            end select
         end select
     end function edgecolors_are_none
 

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -366,6 +366,7 @@ contains
         real(wp) :: x(5), y(5), z(5), edge_seq(15)
         real(wp) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
         character(len=6) :: edge_names(5)
+        character(len=4) :: edge_none(1)
         real(wp), parameter :: tol = 1.0e-12_wp
         integer :: i
 
@@ -384,6 +385,7 @@ contains
             edge_matrix_n3(i, :) = edge_seq(3*i - 2:3*i)
         end do
         edge_names = ['red   ', 'green ', 'blue  ', 'orange', 'purple']
+        edge_none = ['none']
 
         call figure()
         call scatter(x, y, markersize=25.0_wp, label='markersize only')
@@ -411,14 +413,16 @@ contains
                      label='edge matrix 3xn')
         call scatter(x + 12.0_wp, y, edgecolors=edge_matrix_n3, &
                      label='edge matrix nx3')
+        call scatter(x + 13.0_wp, y, edgecolors=edge_none, &
+                     label='edge none sequence')
 
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 13) then
-            print *, 'FAIL: test_markersize_fallback - expected 13 plots'
+        if (global_figure%plot_count < 14) then
+            print *, 'FAIL: test_markersize_fallback - expected 14 plots'
             return
         end if
 
@@ -499,6 +503,10 @@ contains
         if (any(abs(global_figure%plots(13)%scatter_edgecolors(:, 5) - &
                     [0.0_wp, 0.5_wp, 0.5_wp]) > tol)) then
             print *, 'FAIL: test_markersize_fallback - nx3 edge matrix changed'
+            return
+        end if
+        if (global_figure%plots(14)%marker_edge_alpha > tol) then
+            print *, 'FAIL: test_markersize_fallback - edgecolors=["none"] kept edges'
             return
         end if
 


### PR DESCRIPTION
## Requirements
- REQ-001: Keep `s` as the primary scatter size argument and keep `markersize` only as a backward-compatible alias (ref #1660).
- REQ-002: Preserve scalar and per-point `s` behavior for pyplot and `add_scatter` (ref #1660).
- REQ-003: Preserve `cmap`, `vmin`, and `vmax` forwarding for scalar-mapped `c` (ref #1660).
- REQ-004: Accept `edgecolors` as strings, RGB triples, string/real sequences, and the special value `none` (ref #1660).
- REQ-005: Treat a one-element string sequence `edgecolors=['none']` the same as scalar `edgecolors='none'` (ref #1660).

## Verification
### Test fails on main
`fpm test --target test_scatter` after adding the REQ-005 regression assertion before the implementation change:
```text
FAIL: test_markersize_fallback - edgecolors=["none"] kept edges
Tests passed:          11 /          12
FAIL: Some scatter tests failed
STOP 1
```

### Test passes after fix
`fpm test --target test_scatter`:
```text
PASS: test_markersize_fallback
Tests passed:          12 /          12
All scatter tests PASSED!
STOP 0
```

`make verify-artifacts`:
```text
[png] output/example/fortran/styling_demo/marker_types.png size=28926
[pdfimages] output/example/fortran/quiver_demo/quiver_demo.pdf
[colors] output/example/fortran/contour_demo/ripple_inferno.png => 450
Artifact verification passed.
```

`make test-ci`:
```text
PASS: test_markersize_fallback
Tests passed:          12 /          12
All scatter tests PASSED!
Artifact verification passed.
CI essential test suite completed successfully
```

`$HOME/code/prompts/scripts/check-writing-slop.py src/interfaces/fortplot_matplotlib_scatter.f90 test/test_scatter.f90`:
```text
PASS: no writing-slop candidates at threshold medium
```

<!-- orchestrate: fully-resolved -->