### PR TITLE
fix: accept scalar add_scatter size (refs #1660)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -55,8 +55,7 @@ contains
         real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
-        real(wp), intent(in), optional :: alpha
-        real(wp), intent(in), optional :: vmin, vmax
+        real(wp), intent(in), optional :: alpha, vmin, vmax
 
         call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
                                  marker=marker, markersize=markersize, color=color, &
@@ -77,8 +76,7 @@ contains
         real(wp), intent(in), optional :: linewidths(..)
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
-        real(wp), intent(in), optional :: alpha
-        real(wp), intent(in), optional :: vmin, vmax
+        real(wp), intent(in), optional :: alpha, vmin, vmax
 
         call scatter_2d_dispatch(x, y, s_scalar=s, c=c, label=label, &
                                  marker=marker, color=color, &
@@ -167,8 +165,7 @@ contains
                                   vmax, linewidths_scalar)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: markersize
-        real(wp), intent(in), optional :: s(:)
-        real(wp), intent(in), optional :: c(:)
+        real(wp), intent(in), optional :: s(..), c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidths(..)
@@ -177,12 +174,33 @@ contains
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
-        call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
-                                 marker=marker, markersize=markersize, color=color, &
-                                 linewidths=linewidths, &
-                                 linewidths_scalar=linewidths_scalar, &
-                                 edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
-                                 vmin=vmin, vmax=vmax)
+        if (present(s)) then
+            select rank (s)
+            rank (0)
+                call scatter_2d_dispatch(x, y, s_scalar=s, c=c, label=label, &
+                                         marker=marker, color=color, &
+                                         linewidths=linewidths, &
+                                         linewidths_scalar=linewidths_scalar, &
+                                         edgecolors=edgecolors, alpha=alpha, &
+                                         cmap=cmap, vmin=vmin, vmax=vmax)
+            rank (1)
+                call scatter_2d_dispatch(x, y, s=s, c=c, label=label, &
+                                         marker=marker, markersize=markersize, &
+                                         color=color, linewidths=linewidths, &
+                                         linewidths_scalar=linewidths_scalar, &
+                                         edgecolors=edgecolors, alpha=alpha, &
+                                         cmap=cmap, vmin=vmin, vmax=vmax)
+            rank default
+                call log_error('scatter: s must be scalar or rank-1')
+            end select
+        else
+            call scatter_2d_dispatch(x, y, c=c, label=label, marker=marker, &
+                                     markersize=markersize, color=color, &
+                                     linewidths=linewidths, &
+                                     linewidths_scalar=linewidths_scalar, &
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
+        end if
     end subroutine add_scatter_2d_rgb
 
     subroutine add_scatter_2d_string(x, y, color, c, label, marker, markersize, &
@@ -197,22 +215,42 @@ contains
         real(wp), intent(in), optional :: linewidths_scalar
         class(*), intent(in), optional :: edgecolors(..)
         real(wp), intent(in), optional :: alpha
-        real(wp), intent(in), optional :: s(:)
+        real(wp), intent(in), optional :: s(..)
         real(wp), intent(in), optional :: vmin, vmax
 
-        call scatter_string(x, y, c=c, label=label, marker=marker, &
-                            markersize=markersize, color=color, &
-                            linewidths=linewidths, edgecolors=edgecolors, &
-                            alpha=alpha, s=s, &
-                            linewidths_scalar=linewidths_scalar, cmap=cmap, &
-                            vmin=vmin, vmax=vmax)
+        if (present(s)) then
+            select rank (s)
+            rank (0)
+                call scatter_string_scalar_s(x, y, s=s, c=c, label=label, &
+                                             marker=marker, color=color, &
+                                             linewidths=linewidths, &
+                                             edgecolors=edgecolors, alpha=alpha, &
+                                             cmap=cmap, vmin=vmin, vmax=vmax, &
+                                             linewidths_scalar=linewidths_scalar)
+            rank (1)
+                call scatter_string(x, y, c=c, label=label, marker=marker, &
+                                    markersize=markersize, color=color, &
+                                    linewidths=linewidths, edgecolors=edgecolors, &
+                                    alpha=alpha, s=s, &
+                                    linewidths_scalar=linewidths_scalar, &
+                                    cmap=cmap, vmin=vmin, vmax=vmax)
+            rank default
+                call log_error('scatter: s must be scalar or rank-1')
+            end select
+        else
+            call scatter_string(x, y, c=c, label=label, marker=marker, &
+                                markersize=markersize, color=color, &
+                                linewidths=linewidths, edgecolors=edgecolors, &
+                                alpha=alpha, linewidths_scalar=linewidths_scalar, &
+                                cmap=cmap, vmin=vmin, vmax=vmax)
+        end if
     end subroutine add_scatter_2d_string
 
     subroutine add_scatter_3d_rgb(x, y, z, s, c, label, marker, markersize, &
-                                   color, linewidths, edgecolors, alpha, cmap, &
-                                   vmin, vmax, linewidths_scalar)
+                                  color, linewidths, edgecolors, alpha, cmap, &
+                                  vmin, vmax, linewidths_scalar)
         real(wp), intent(in) :: x(:), y(:), z(:)
-        real(wp), intent(in), optional :: s(:)
+        real(wp), intent(in), optional :: s(..)
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
@@ -223,21 +261,41 @@ contains
         real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: vmin, vmax
 
-        call scatter_3d_dispatch(x, y, z, s=s, c=c, &
-                                 label=label, marker=marker, markersize=markersize, &
-                                 color=color, linewidths=linewidths, &
-                                 linewidths_scalar=linewidths_scalar, &
-                                 edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
-                                 vmin=vmin, vmax=vmax)
+        if (present(s)) then
+            select rank (s)
+            rank (0)
+                call scatter_3d_dispatch(x, y, z, s_scalar=s, c=c, &
+                                         label=label, marker=marker, color=color, &
+                                         linewidths=linewidths, &
+                                         linewidths_scalar=linewidths_scalar, &
+                                         edgecolors=edgecolors, alpha=alpha, &
+                                         cmap=cmap, vmin=vmin, vmax=vmax)
+            rank (1)
+                call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
+                                         marker=marker, markersize=markersize, &
+                                         color=color, linewidths=linewidths, &
+                                         linewidths_scalar=linewidths_scalar, &
+                                         edgecolors=edgecolors, alpha=alpha, &
+                                         cmap=cmap, vmin=vmin, vmax=vmax)
+            rank default
+                call log_error('scatter: s must be scalar or rank-1')
+            end select
+        else
+            call scatter_3d_dispatch(x, y, z, c=c, label=label, marker=marker, &
+                                     markersize=markersize, color=color, &
+                                     linewidths=linewidths, &
+                                     linewidths_scalar=linewidths_scalar, &
+                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
+                                     vmin=vmin, vmax=vmax)
+        end if
     end subroutine add_scatter_3d_rgb
 
     subroutine add_scatter_3d_string(x, y, z, color, s, c, label, marker, &
-                                      markersize, linewidths, edgecolors, alpha, &
-                                      linewidths_scalar, cmap, vmin, vmax)
+                                     markersize, linewidths, edgecolors, alpha, &
+                                     linewidths_scalar, cmap, vmin, vmax)
         real(wp), intent(in) :: x(:), y(:), z(:)
         character(len=*), intent(in) :: color
-        real(wp), intent(in), optional :: s(:)
-        real(wp), intent(in), optional :: c(:)
+        real(wp), intent(in), optional :: s(..), c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: linewidths(..)
@@ -252,22 +310,69 @@ contains
         call resolve_color_string_or_rgb(color_str=color, context='scatter', &
                                          rgb_out=color_rgb, has_color=has_color)
 
-        if (has_color) then
-            call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
-                                     marker=marker, markersize=markersize, &
-                                     color=color_rgb, linewidths=linewidths, &
-                                     linewidths_scalar=linewidths_scalar, &
-                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
-                                     vmin=vmin, vmax=vmax)
+        if (present(s)) then
+            select rank (s)
+            rank (0)
+                call scatter_3d_string_dispatch(x, y, z, color_rgb, has_color, &
+                                                s_scalar=s, c=c, label=label, &
+                                                marker=marker, linewidths=linewidths, &
+                                                linewidths_scalar=linewidths_scalar, &
+                                                edgecolors=edgecolors, alpha=alpha, &
+                                                cmap=cmap, vmin=vmin, vmax=vmax)
+            rank (1)
+                call scatter_3d_string_dispatch(x, y, z, color_rgb, has_color, &
+                                                s=s, c=c, label=label, &
+                                                marker=marker, markersize=markersize, &
+                                                linewidths=linewidths, &
+                                                linewidths_scalar=linewidths_scalar, &
+                                                edgecolors=edgecolors, alpha=alpha, &
+                                                cmap=cmap, vmin=vmin, vmax=vmax)
+            rank default
+                call log_error('scatter: s must be scalar or rank-1')
+            end select
         else
-            call scatter_3d_dispatch(x, y, z, s=s, c=c, label=label, &
-                                     marker=marker, markersize=markersize, &
-                                     linewidths=linewidths, &
-                                     linewidths_scalar=linewidths_scalar, &
-                                     edgecolors=edgecolors, alpha=alpha, cmap=cmap, &
-                                     vmin=vmin, vmax=vmax)
+            call scatter_3d_string_dispatch(x, y, z, color_rgb, has_color, &
+                                            c=c, label=label, marker=marker, &
+                                            markersize=markersize, &
+                                            linewidths=linewidths, &
+                                            linewidths_scalar=linewidths_scalar, &
+                                            edgecolors=edgecolors, alpha=alpha, &
+                                            cmap=cmap, vmin=vmin, vmax=vmax)
         end if
     end subroutine add_scatter_3d_string
+
+    subroutine scatter_3d_string_dispatch(x, y, z, color_rgb, has_color, s, &
+                                          s_scalar, c, label, marker, markersize, &
+                                          linewidths, linewidths_scalar, &
+                                          edgecolors, alpha, cmap, vmin, vmax)
+        real(wp), intent(in) :: x(:), y(:), z(:), color_rgb(3)
+        logical, intent(in) :: has_color
+        real(wp), intent(in), optional :: s(:), s_scalar, c(:)
+        character(len=*), intent(in), optional :: label, marker, cmap
+        real(wp), intent(in), optional :: markersize
+        real(wp), intent(in), optional :: linewidths(..)
+        real(wp), intent(in), optional :: linewidths_scalar
+        class(*), intent(in), optional :: edgecolors(..)
+        real(wp), intent(in), optional :: alpha
+        real(wp), intent(in), optional :: vmin, vmax
+
+        if (has_color) then
+            call scatter_3d_dispatch(x, y, z, s=s, s_scalar=s_scalar, c=c, &
+                                     label=label, marker=marker, &
+                                     markersize=markersize, color=color_rgb, &
+                                     linewidths=linewidths, &
+                                     linewidths_scalar=linewidths_scalar, &
+                                     edgecolors=edgecolors, alpha=alpha, &
+                                     cmap=cmap, vmin=vmin, vmax=vmax)
+        else
+            call scatter_3d_dispatch(x, y, z, s=s, s_scalar=s_scalar, c=c, &
+                                     label=label, marker=marker, &
+                                     markersize=markersize, linewidths=linewidths, &
+                                     linewidths_scalar=linewidths_scalar, &
+                                     edgecolors=edgecolors, alpha=alpha, &
+                                     cmap=cmap, vmin=vmin, vmax=vmax)
+        end if
+    end subroutine scatter_3d_string_dispatch
 
     subroutine scatter_2d_dispatch(x, y, s, s_scalar, c, label, marker, &
                                     markersize, color, linewidths, &

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -415,14 +415,18 @@ contains
                      label='edge matrix nx3')
         call scatter(x + 13.0_wp, y, edgecolors=edge_none, &
                      label='edge none sequence')
+        call add_scatter(x + 14.0_wp, y, s=7.0_wp, &
+                         label='add_scatter scalar s')
+        call add_scatter(x + 15.0_wp, y, z, s=9.0_wp, &
+                         label='3d add_scatter scalar s')
 
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 14) then
-            print *, 'FAIL: test_markersize_fallback - expected 14 plots'
+        if (global_figure%plot_count < 16) then
+            print *, 'FAIL: test_markersize_fallback - expected 16 plots'
             return
         end if
 
@@ -507,6 +511,13 @@ contains
         end if
         if (global_figure%plots(14)%marker_edge_alpha > tol) then
             print *, 'FAIL: test_markersize_fallback - edgecolors=["none"] kept edges'
+            return
+        end if
+        if (.not. sizes_match(15, [7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp])) return
+        if (.not. sizes_match(16, [9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp])) return
+
+        if (.not. allocated(global_figure%plots(16)%z)) then
+            print *, 'FAIL: test_markersize_fallback - 3D scalar s lost z values'
             return
         end if
 

--- a/test/test_scatter.f90
+++ b/test/test_scatter.f90
@@ -27,6 +27,7 @@ program test_scatter
     call test_backend_consistency()
     call test_metadata_parity()
     call test_markersize_fallback()
+    call test_add_scatter_scalar_s()
 
     print *, ''
     print *, '=== Scatter Test Summary ==='
@@ -362,15 +363,69 @@ contains
 
     subroutine test_markersize_fallback()
         !! Issue #1660: markersize is a backward-compatible alias for s.
-        !! s remains primary, including pyplot 2D and 3D dispatch paths.
         real(wp) :: x(5), y(5), z(5), edge_seq(15)
         real(wp) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
         character(len=6) :: edge_names(5)
         character(len=4) :: edge_none(1)
         real(wp), parameter :: tol = 1.0e-12_wp
-        integer :: i
 
         total_tests = total_tests + 1
+
+        call setup_marker_inputs(x, y, z, edge_seq, edge_matrix_3n, &
+                                 edge_matrix_n3, edge_names, edge_none)
+        call figure()
+        call add_size_alias_plots(x, y, z)
+        call add_edge_style_plots(x, y, z, edge_seq, edge_matrix_3n, &
+                                  edge_matrix_n3, edge_names, edge_none)
+
+        if (.not. markersize_fallback_matches(tol)) return
+
+        print *, '  PASS: test_markersize_fallback'
+        passed_tests = passed_tests + 1
+    end subroutine test_markersize_fallback
+
+    subroutine test_add_scatter_scalar_s()
+        !! Issue #1660: s remains primary through exported 2D and 3D paths.
+        real(wp) :: x(5), y(5), z(5), edge_seq(15)
+        real(wp) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
+        character(len=6) :: edge_names(5)
+        character(len=4) :: edge_none(1)
+
+        total_tests = total_tests + 1
+
+        call setup_marker_inputs(x, y, z, edge_seq, edge_matrix_3n, &
+                                 edge_matrix_n3, edge_names, edge_none)
+        call figure()
+        call add_scatter(x, y, s=7.0_wp, label='add_scatter scalar s')
+        call add_scatter(x + 1.0_wp, y, z, s=9.0_wp, &
+                         label='3d add_scatter scalar s')
+
+        if (.not. allocated(global_figure)) then
+            print *, 'FAIL: test_add_scatter_scalar_s - global figure missing'
+            return
+        end if
+        if (global_figure%plot_count < 2) then
+            print *, 'FAIL: test_add_scatter_scalar_s - expected 2 plots'
+            return
+        end if
+        if (.not. sizes_match(1, [7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp])) return
+        if (.not. sizes_match(2, [9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp])) return
+        if (.not. allocated(global_figure%plots(2)%z)) then
+            print *, 'FAIL: test_add_scatter_scalar_s - 3D scalar s lost z values'
+            return
+        end if
+
+        print *, '  PASS: test_add_scatter_scalar_s'
+        passed_tests = passed_tests + 1
+    end subroutine test_add_scatter_scalar_s
+
+    subroutine setup_marker_inputs(x, y, z, edge_seq, edge_matrix_3n, &
+                                   edge_matrix_n3, edge_names, edge_none)
+        real(wp), intent(out) :: x(5), y(5), z(5), edge_seq(15)
+        real(wp), intent(out) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
+        character(len=6), intent(out) :: edge_names(5)
+        character(len=4), intent(out) :: edge_none(1)
+        integer :: i
 
         x = [(real(i, wp), i = 1, size(x))]
         y = [(real(i, wp) * 2.0_wp, i = 1, size(x))]
@@ -386,6 +441,10 @@ contains
         end do
         edge_names = ['red   ', 'green ', 'blue  ', 'orange', 'purple']
         edge_none = ['none']
+    end subroutine setup_marker_inputs
+
+    subroutine add_size_alias_plots(x, y, z)
+        real(wp), intent(in) :: x(:), y(:), z(:)
 
         call figure()
         call scatter(x, y, markersize=25.0_wp, label='markersize only')
@@ -396,6 +455,14 @@ contains
         call scatter(x + 3.0_wp, y, s=12.0_wp, label='s scalar')
         call add_scatter(x + 4.0_wp, y, z, s=[5.0_wp], markersize=88.0_wp, &
                          label='3d s priority')
+    end subroutine add_size_alias_plots
+
+    subroutine add_edge_style_plots(x, y, z, edge_seq, edge_matrix_3n, &
+                                    edge_matrix_n3, edge_names, edge_none)
+        real(wp), intent(in) :: x(:), y(:), z(:), edge_seq(:)
+        real(wp), intent(in) :: edge_matrix_3n(:, :), edge_matrix_n3(:, :)
+        character(len=*), intent(in) :: edge_names(:), edge_none(:)
+
         call scatter(x + 5.0_wp, y, color='blue', edgecolors='none', &
                      label='edge none')
         call scatter(x + 6.0_wp, y, color=[0.0_wp, 0.0_wp, 1.0_wp], &
@@ -415,18 +482,19 @@ contains
                      label='edge matrix nx3')
         call scatter(x + 13.0_wp, y, edgecolors=edge_none, &
                      label='edge none sequence')
-        call add_scatter(x + 14.0_wp, y, s=7.0_wp, &
-                         label='add_scatter scalar s')
-        call add_scatter(x + 15.0_wp, y, z, s=9.0_wp, &
-                         label='3d add_scatter scalar s')
+    end subroutine add_edge_style_plots
 
+    logical function markersize_fallback_matches(tol)
+        real(wp), intent(in) :: tol
+
+        markersize_fallback_matches = .false.
         if (.not. allocated(global_figure)) then
             print *, 'FAIL: test_markersize_fallback - global figure missing'
             return
         end if
 
-        if (global_figure%plot_count < 16) then
-            print *, 'FAIL: test_markersize_fallback - expected 16 plots'
+        if (global_figure%plot_count < 14) then
+            print *, 'FAIL: test_markersize_fallback - expected 14 plots'
             return
         end if
 
@@ -440,7 +508,17 @@ contains
             print *, 'FAIL: test_markersize_fallback - 3D scatter lost z values'
             return
         end if
+        if (.not. alpha_and_sequence_edges_match(tol)) return
+        if (.not. string_edges_and_linewidths_match(tol)) return
+        if (.not. edge_matrices_match(tol)) return
 
+        markersize_fallback_matches = .true.
+    end function markersize_fallback_matches
+
+    logical function alpha_and_sequence_edges_match(tol)
+        real(wp), intent(in) :: tol
+
+        alpha_and_sequence_edges_match = .false.
         if (global_figure%plots(6)%marker_edge_alpha > tol) then
             print *, 'FAIL: test_markersize_fallback - edgecolors="none" kept edges'
             return
@@ -465,6 +543,13 @@ contains
             print *, 'FAIL: test_markersize_fallback - linewidth sequence changed'
             return
         end if
+        alpha_and_sequence_edges_match = .true.
+    end function alpha_and_sequence_edges_match
+
+    logical function string_edges_and_linewidths_match(tol)
+        real(wp), intent(in) :: tol
+
+        string_edges_and_linewidths_match = .false.
         if (.not. global_figure%plots(8)%marker_edgecolor_set) then
             print *, 'FAIL: test_markersize_fallback - string edgecolor missing'
             return
@@ -491,6 +576,13 @@ contains
             print *, 'FAIL: test_markersize_fallback - 3D scalar linewidths changed'
             return
         end if
+        string_edges_and_linewidths_match = .true.
+    end function string_edges_and_linewidths_match
+
+    logical function edge_matrices_match(tol)
+        real(wp), intent(in) :: tol
+
+        edge_matrices_match = .false.
         if (.not. allocated(global_figure%plots(12)%scatter_edgecolors)) then
             print *, 'FAIL: test_markersize_fallback - 3xn edge matrix missing'
             return
@@ -513,17 +605,8 @@ contains
             print *, 'FAIL: test_markersize_fallback - edgecolors=["none"] kept edges'
             return
         end if
-        if (.not. sizes_match(15, [7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp])) return
-        if (.not. sizes_match(16, [9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp])) return
-
-        if (.not. allocated(global_figure%plots(16)%z)) then
-            print *, 'FAIL: test_markersize_fallback - 3D scalar s lost z values'
-            return
-        end if
-
-        print *, '  PASS: test_markersize_fallback'
-        passed_tests = passed_tests + 1
-    end subroutine test_markersize_fallback
+        edge_matrices_match = .true.
+    end function edge_matrices_match
 
     logical function sizes_match(plot_idx, expected)
         integer, intent(in) :: plot_idx


### PR DESCRIPTION
## Requirements

- REQ-001: Keep `s` as the primary scatter size argument and accept scalar or per-point sizes.
- REQ-002: Keep `markersize` as a backward-compatible alias with lower priority than `s`.
- REQ-003: Preserve existing #1660 support for `cmap`, `vmin`, `vmax`, string/sequence `edgecolors`, and scalar/sequence `linewidths`.
- REQ-004: Cover scalar `s` through the exported `add_scatter` facade for both 2D and 3D paths (ref #1660).

## Verification

### Test fails before fix

```text
$ fpm test --target test_scatter
[  0%]               test_scatter.f90
[ 50%]               test_scatter.f90  done.

test/test_scatter.f90:419:54:

  419 |                          label='add_scatter scalar s')
      |                                                      1
Error: There is no specific subroutine for the generic ‘add_scatter’ at (1)
compilation terminated due to -fmax-errors=1.
<ERROR> Compilation failed for object " test_test_scatter.f90.o "
<ERROR> stopping due to failed compilation
STOP 1
```

### Test passes after fix

```text
$ fpm test --target test_scatter
[100%] Project compiled successfully.
   PASS: test_markersize_fallback

 === Scatter Test Summary ===
 Tests passed:          12 /          12
 All scatter tests PASSED!
```

```text
$ make test-ci
PASS: pcolormesh test dedup guard (1 Fortran test file)
PASS: src/* subfolder item limits respected (<=20 soft, <=50 hard)
PASS: test/output/ contains no runtime artifacts
Artifact verification passed.
CI essential test suite completed successfully
```

```text
$ $HOME/code/prompts/scripts/check-writing-slop.py src/interfaces/fortplot_matplotlib_scatter.f90 test/test_scatter.f90
PASS: no writing-slop candidates at threshold medium
```

<!-- orchestrate: fully-resolved -->
