### PR TITLE
fix: clarify animation re-export docs (refs #1761)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,16 @@ call show()                ! viewer
 ```fortran
 use fortplot
 
+type(figure_t) :: fig
+type(animation_t) :: anim
+
 anim = FuncAnimation(update_frame, frames=100, interval=50, fig=fig)
 call anim%save("movie.mp4", fps=24, status=status)   ! ffmpeg
 call anim%save("movie.txt", status=status)           ! ASCII frames
 ```
+
+`fortplot` re-exports `FuncAnimation` and `animation_t`; use `fortplot_animation`
+only when you are not using the main `fortplot` module.
 
 Output formats: `.mp4`, `.avi`, `.mkv` (require ffmpeg), and `.txt` (ASCII frames, no
 extra dependencies).

--- a/test/test_public_api_animation_reexport.f90
+++ b/test/test_public_api_animation_reexport.f90
@@ -1,0 +1,35 @@
+program test_public_api_animation_reexport
+    !! FuncAnimation and animation_t must be available through use fortplot.
+    use fortplot, only: animation_t, figure_t, FuncAnimation
+    implicit none
+
+    type(figure_t), target :: fig
+    type(animation_t) :: anim
+
+    call fig%initialize()
+    anim = FuncAnimation(update_frame, frames=4, interval=25, fig=fig)
+
+    if (anim%frames /= 4) then
+        print *, 'FAIL: FuncAnimation did not preserve frame count'
+        stop 1
+    end if
+    if (anim%interval_ms /= 25) then
+        print *, 'FAIL: FuncAnimation did not preserve interval'
+        stop 1
+    end if
+    if (.not. associated(anim%fig)) then
+        print *, 'FAIL: FuncAnimation did not preserve figure association'
+        stop 1
+    end if
+
+    print *, 'Public API animation re-export test passed'
+
+contains
+
+    subroutine update_frame(frame)
+        integer, intent(in) :: frame
+
+        if (frame < 0) stop 1
+    end subroutine update_frame
+
+end program test_public_api_animation_reexport


### PR DESCRIPTION
## Requirements

REQ-001: README animation examples must not imply `use fortplot_animation` is required when `use fortplot` is already present. (ref #1761)
REQ-002: README must state that `fortplot` re-exports `FuncAnimation` and `animation_t`. (ref #1761)
REQ-003: A behavior test must prove `FuncAnimation`, `animation_t`, and `figure_t` are usable through `use fortplot` only. (ref #1761)

## Verification

Failing before:

```console
$ git show main:README.md | rg 're-exports `FuncAnimation` and `animation_t`; use `fortplot_animation`'
# exit status 1
```

Passing after:

```console
$ check-writing-slop.py README.md test/test_public_api_animation_reexport.f90
PASS: no writing-slop candidates at threshold medium

$ fpm test --target test_public_api_animation_reexport
Project is up to date
 Public API animation re-export test passed

$ make test-ci
Running CI-optimized test suite (essential tests only) with timeout 300s...
...
Artifact verification passed.
CI essential test suite completed successfully
```

<!-- orchestrate: fully-resolved -->
