### PR TITLE
fix: require y1 in add_fill_between to match matplotlib API (refs #1673)

### DIFF
--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -243,11 +243,11 @@ module fortplot_figure_core
             real(wp), intent(in), optional :: alpha
         end subroutine add_fill
 
-        module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
-                                           interpolate)
+       module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
+                                            interpolate)
             class(figure_t), intent(inout) :: self
-            real(wp), intent(in) :: x(:)
-            real(wp), intent(in), optional :: y1(:), y2(:)
+            real(wp), intent(in) :: x(:), y1(:)
+            real(wp), intent(in), optional :: y2(:)
             logical, intent(in), optional :: where (:)
             character(len=*), intent(in), optional :: color
             real(wp), intent(in), optional :: alpha

--- a/src/figures/core/fortplot_figure_core_specialized.f90
+++ b/src/figures/core/fortplot_figure_core_specialized.f90
@@ -468,8 +468,8 @@ contains
     module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
                                        interpolate)
         class(figure_t), intent(inout) :: self
-        real(wp), intent(in) :: x(:)
-        real(wp), intent(in), optional :: y1(:), y2(:)
+        real(wp), intent(in) :: x(:), y1(:)
+        real(wp), intent(in), optional :: y2(:)
         logical, intent(in), optional :: where (:)
         character(len=*), intent(in), optional :: color
         real(wp), intent(in), optional :: alpha
@@ -518,7 +518,8 @@ contains
                                                  lower_vals, mask_vals, has_mask) &
         result(ok)
         integer, intent(in) :: n
-        real(wp), intent(in), optional :: y1(:), y2(:)
+        real(wp), intent(in) :: y1(:)
+        real(wp), intent(in), optional :: y2(:)
         logical, intent(in), optional :: where(:)
         real(wp), allocatable, intent(out) :: upper_vals(:), lower_vals(:)
         logical, allocatable, intent(out) :: mask_vals(:)
@@ -530,9 +531,13 @@ contains
             call log_error('fill_between: need at least two points to form area')
             return
         end if
+        if (size(y1) /= n) then
+            call log_error('fill_between: y1 size mismatch')
+            return
+        end if
 
         allocate (upper_vals(n), lower_vals(n))
-        if (.not. assign_fill_between_bound(n, y1, upper_vals, 'y1')) return
+        upper_vals = y1
         if (.not. assign_fill_between_bound(n, y2, lower_vals, 'y2')) return
         if (.not. assign_fill_between_mask(n, where, mask_vals, has_mask)) return
         ok = .true.

--- a/test/test_matplotlib_new_functions_oo.f90
+++ b/test/test_matplotlib_new_functions_oo.f90
@@ -94,6 +94,11 @@ program test_matplotlib_new_functions_oo
     call fig%savefig(trim(output_dir)//'test_fill_between_masked_oo.png')
     call fig%clear()
 
+    call fig%add_fill_between(x, y1=y)
+    call fig%set_title('OO add_fill_between() y2 default test')
+    call fig%savefig(trim(output_dir)//'test_fill_between_y2_default_oo.png')
+    call fig%clear()
+
     deallocate(mask)
 
     call fig%add_step(x, y)


### PR DESCRIPTION
## Summary

- Make `y1` non-optional in `figure_t%add_fill_between` to match matplotlib's contract where `y1` is required (the first curve defining the upper boundary).
- `y2` remains optional with a default of zero (already implemented).
- `color` accepts both named strings and RGB triples via overloaded interface (already implemented).
- `step` kwarg ('pre', 'post', 'mid') already supported (already implemented).

## Verification

Build:
```
fpm build
[100%] Project compiled successfully.
```

Tests:
```
fpm test --target test_new_plot_types
 PASS (fill_between):        14197  bytes
 PASS (fill_between step=pre):        15578  bytes
 PASS (fill_between step=post):        15553  bytes
 PASS (fill_between step=mid):        16003  bytes
 PASS (fill_between RGB color):        16532  bytes
 PASS (fill_between y2=default):        16796  bytes
 All new plot type smoke tests PASSED
```

```
fpm test --target test_matplotlib_new_functions_oo
 PASS: OO matplotlib-compatible functions executed without errors
```

```
fpm test --target test_legacy_positional_order
 PASS: Legacy positional ordering works for figure_t add_* helpers
```

```
fpm test --target test_pyplot_legacy_order
 PASS: Pyplot positional wrappers remain OO-compatible
```

CI essential suite:
```
make test-ci
CI essential test suite completed successfully
```

Changes:
- `src/figures/core/fortplot_figure_core_main.f90`: abstract interface `y1` from optional to required
- `src/figures/core/fortplot_figure_core_specialized.f90`: implementation `y1` from optional to required; `prepare_fill_between_values` handles `y1` directly with size check; `assign_fill_between_bound` now only used for optional `y2`
- `test/test_matplotlib_new_functions_oo.f90`: added test for `add_fill_between` with only `y1` (y2 defaults to zero)

(ref #1673)
<!-- orchestrate: fully-resolved -->