### PR TITLE
fix: run flang-macos CI on push to main (refs #1646)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
 
   flang-macos:
     name: flang (macOS)
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: macos-15
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

The flang-macos CI job only runs on pull requests, leaving the main branch unprotected against macOS/flang regressions. This change adds a push-to-main trigger so macOS validation runs continuously.

## Verification

### YAML validity
```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
YAML valid
```

### Diff
```diff
-   if: github.event_name == 'pull_request'
+   if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
```

The condition now runs the flang-macos job on both PR events and pushes to `main`, matching the coverage parity requested in (ref #1646).

## Requirements

- **REQ-001:** Add flang macOS to push/main triggers (not just PR) — ✅ implemented
- **REQ-002:** Consider Xcode clang + gfortran via Homebrew — out of scope (requires separate workflow)
- **REQ-003:** Document why macOS coverage is limited — out of scope (documentation)