### PR TITLE
fix: optimize contour rendering performance (refs #1746)

### DIFF
--- a/src/backends/memory/fortplot_contour_rendering.f90
+++ b/src/backends/memory/fortplot_contour_rendering.f90
@@ -183,9 +183,9 @@ contains
                     z_max_cell = max(z1, z2, z3, z4)
                     if (z_max_cell < lo .or. z_min_cell > hi) cycle
 
-                    xin(1:4) = [x1, x2, x3, x4]
-                    yin(1:4) = [y1, y2, y3, y4]
-                    zin(1:4) = [z1, z2, z3, z4]
+                    xin(1) = x1;  xin(2) = x2;  xin(3) = x3;  xin(4) = x4
+                    yin(1) = y1;  yin(2) = y2;  yin(3) = y3;  yin(4) = y4
+                    zin(1) = z1;  zin(2) = z2;  zin(3) = z3;  zin(4) = z4
                     n0 = 4
 
                     call clip_poly_z_plane(n0, xin, yin, zin, lo, .true., eps_z, &


### PR DESCRIPTION
## Requirements (issue #1746)

**REQ-001:** Hoist scale check out of per-vertex loop — detect `xscale=='linear' .and. yscale=='linear'` once and take a fast path that skips `apply_scale_transform` entirely.
**Status:** ✅ Satisfied by commit `faea5a7` (`src/backends/memory/fortplot_contour_rendering.f90:131,145-146,199-231`)

**REQ-002:** Replace O(n²) segment-chain search with hash/endpoint-keyed lookup.
**Status:** ✅ Satisfied by commit `08405a3` (`endpoint_hash`, `extend_chain_forward_hash`, `extend_chain_backward_hash`)

**REQ-003:** Skip clip for cells whose min/max z do not intersect [lo, hi].
**Status:** ✅ Satisfied by commit `faea5a7` (`src/backends/memory/fortplot_contour_rendering.f90:180-184`)

## Verification

```
$ make build
fpm build --flag -fPIC
Project is up to date

$ fpm test --target test_contour
   PASS: test_default_levels
   PASS: test_empty_levels
   PASS: test_is_not_3d
   PASS: test_memory_safety_regression
   PASS: test_refactoring_combinations
   PASS: test_unsorted_levels
   PASS: test_linear_scale_fast_path
   PASS: test_cell_rejection_optimization
   PASS: test_levels_sorting
 All contour tests PASSED!

$ make test 2>&1 | tail -3
ALL TESTS PASSED (fpm test)

$ make verify-artifacts 2>&1 | tail -3
[colors] output/example/fortran/contour_demo/ripple_jet.png => 446
Artifact verification passed.
```

(ref #1746)
<!-- orchestrate: fully-resolved -->