### PR TITLE
fix: add contiguous to interpolate_colormap array params (refs #1741)

### DIFF
--- a/src/utilities/colors/fortplot_colormap.f90
+++ b/src/utilities/colors/fortplot_colormap.f90
@@ -406,7 +406,7 @@ contains
     subroutine interpolate_colormap(t, r_points, g_points, b_points, color)
         !! Interpolate between color control points
         real(wp), intent(in) :: t
-        real(wp), dimension(:), intent(in) :: r_points, g_points, b_points
+        real(wp), contiguous, dimension(:), intent(in) :: r_points, g_points, b_points
         real(wp), dimension(3), intent(out) :: color
         
         integer :: n_points, i


### PR DESCRIPTION
fix: add contiguous to interpolate_colormap array params (refs #1741)

## Requirements

- **REQ-001:** Add `contiguous` to assumed-shape real array params in hot-path files — SATISFIED by prior commit `5c3efee` (PR #1898, 387 params added, 388 total `contiguous` occurrences)
- **REQ-002:** Verify callers only pass contiguous arrays — SATISFIED (callers pass local arrays which are contiguous by Fortran definition)
- **REQ-003:** Enable `-Warray-temporaries` in debug/CI build — SATISFIED (`Makefile:23`)
- **REQ-004:** Run `make test-ci` to confirm no regressions — SATISFIED
- **REQ-005:** Add `contiguous` to remaining assumed-shape real array in `fortplot_colormap.f90:409` — SATISFIED by this commit

## Verification

```
$ grep -rn 'contiguous' src/ --include='*.f90' | wc -l
389
$ grep -rn 'real(wp' src/ --include='*.f90' | grep 'intent(in)\|intent(inout)' | grep '(:' | grep -v 'contiguous' | grep -v 'allocatable' | wc -l
0
```

Zero remaining non-contiguous assumed-shape real `intent(in)`/`intent(inout)` parameters.

```
$ make test-ci 2>&1 | tail -5
Artifact verification passed.
make[1]: Leaving directory '/home/ert/code/lazy-fortran/fortplot'
CI essential test suite completed successfully
```

```
$ fpm test --target test_colormap_interpolation_regression
 PASS: colormap interpolation varies across negative range
```

(ref #1741)
<!-- orchestrate: fully-resolved -->