### PR TITLE
fix: enhance test_no_error_stop to verify plot_count, output files, and data storage (ref #1715)

### DIFF
--- a/test/workflow/test_no_error_stop.f90
+++ b/test/workflow/test_no_error_stop.f90
@@ -1,7 +1,7 @@
 program test_no_error_stop
     !! Test that stub functions no longer call error_stop (issue #444)
     !! Also verifies each function stores data (plot_count increments) and
-    !! the final render produces a non-empty file.
+    !! the final render produces a non-empty file (issue #1715).
     use fortplot_matplotlib
     use fortplot_matplotlib_session, only: get_global_figure
     use fortplot_figure_core, only: figure_t


### PR DESCRIPTION
## Requirements

- **REQ-001**: After each plotting function call (bar, barh, hist, histogram, boxplot, scatter, text, annotate, errorbar), verify plot_count has increased. **Status: satisfied** — `assert_plot_count` helper added; called after every function.
- **REQ-002**: Add a final savefig + inquire to confirm the rendering pipeline accepts the accumulated data. **Status: satisfied** — `savefig(outfile)` + `inquire` with file existence and size checks added at end of test.
- **REQ-003**: Verify data arrays are stored correctly (bar x/y, scatter x/y, histogram bins, boxplot data, annotation text/coordinates). **Status: satisfied** — `assert_bar_data`, `assert_xy_data`, `assert_histogram_data`, `assert_boxplot_data`, `assert_annotation_data` helpers added.

## File-set enumeration

| File | Action | Reason |
|------|--------|--------|
| `test/workflow/test_no_error_stop.f90` | Modified | Added docstring reference to issue #1715. Core test with plot_count verification, data storage assertions, and savefig+inquire was added in prior rescue commit (#1900). |
| `Makefile` | Unchanged | CI already includes `test_no_error_stop` in `CI_FPM_TEST_TARGETS`. |
| `fpm.toml` | Unchanged | Auto-discovery picks up the test from `test/` directory. |
| All `src/` files | Unchanged | No source changes needed — the matplotlib wrappers already store data correctly. |

## Verification evidence

```
$ fpm test --target test_no_error_stop
 Testing bar()...
   bar() passed (no error_stop)
 PASS: plot_count =           1  after bar()
 PASS: stored bar data after bar()
 Testing barh()...
   barh() passed (no error_stop)
 PASS: plot_count =           2  after barh()
 PASS: stored bar data after barh()
 Testing scatter()...
   scatter() passed (no error_stop)
 PASS: plot_count =           3  after scatter()
 PASS: stored x/y data after scatter()
 Testing hist()...
   hist() passed (no error_stop)
 PASS: plot_count =           4  after hist()
 PASS: stored x/y data after hist()
 Testing histogram()...
   histogram() passed (no error_stop)
 PASS: plot_count =           5  after histogram()
 PASS: stored x/y data after histogram()
 Testing boxplot()...
   boxplot() passed (no error_stop)
 PASS: plot_count =           6  after boxplot()
 PASS: stored boxplot data after boxplot()
 Testing text()...
   text() passed (no error_stop)
 PASS: annotation_count =           1  after text()
 PASS: stored annotation data after text()
 Testing annotate()...
   annotate() passed (no error_stop)
 PASS: annotation_count =           2  after annotate()
 PASS: stored annotation data after annotate()
 Testing errorbar()...
   errorbar() passed (no error_stop)
 PASS: plot_count =           7  after errorbar()
 PASS: stored x/y data after errorbar()
 PASS: rendering pipeline accepted data (       16537  bytes)

 SUCCESS: All previously stubbed functions work without error_stop.
 Issue #444 is resolved and data is stored correctly.
```

CI suite (full): `make test-ci` — passed.
Artifact verification: `make verify-artifacts` — passed.

(ref #1715)
<!-- orchestrate: fully-resolved -->