### PR TITLE
fix: streamplot draws only arrowheads, not trajectory lines (refs #1913)

### DIFF
--- a/src/figures/plot_types/fortplot_figure_streamlines.f90
+++ b/src/figures/plot_types/fortplot_figure_streamlines.f90
@@ -49,8 +49,9 @@ contains
     subroutine streamplot_figure(plots, state, plot_count, x, y, u, v, &
                                  density, color, linewidth, rtol, atol, max_time)
                 !! Add streamline plot to figure - direct streamline generation
+        !! Streamplot draws arrowheads along streamlines (not full trajectory lines).
+        !! Arrow rendering happens in render_axes_and_plots after all plots.
         use fortplot_streamplot_matplotlib, only: streamplot_matplotlib
-        use fortplot_plot_data, only: PLOT_TYPE_LINE
 
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
@@ -60,9 +61,9 @@ contains
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: linewidth, rtol, atol, max_time
 
-        real(wp) :: plot_density, line_color(3), line_width_val
+        real(wp) :: plot_density
         real(wp), allocatable :: trajectories(:, :, :)
-        integer :: n_trajectories, i, j, plot_idx
+        integer :: n_trajectories
         integer, allocatable :: trajectory_lengths(:)
         type(arrow_data_t), allocatable :: computed_arrows(:)
         real(wp), parameter :: default_arrow_size = 1.0_wp
@@ -78,8 +79,6 @@ contains
         plot_density = 1.0_wp
         if (present(density)) plot_density = density
 
-        line_width_val = -1.0_wp
-        if (present(linewidth)) line_width_val = linewidth
         if (present(linewidth)) then
             if (linewidth <= 0.0_wp) then
                 state%has_error = .true.
@@ -105,9 +104,6 @@ contains
             end if
         end if
 
-        line_color = [0.0_wp, 0.447_wp, 0.698_wp]  ! Default blue
-        if (present(color)) line_color = color
-
         ! Update data ranges for streamplot
         if (.not. state%xlim_set) then
             state%x_min = minval(x)
@@ -128,33 +124,6 @@ contains
                                        default_arrow_style, computed_arrows)
 
         call replace_stream_arrows(state, computed_arrows)
-
-        ! Add each trajectory as a line plot
-        do i = 1, n_trajectories
-            if (trajectory_lengths(i) <= 1) cycle
-
-            plot_count = plot_count + 1
-            plot_idx = plot_count
-
-            if (plot_idx > size(plots)) exit  ! Safety check
-
-            ! Set plot type and data
-            plots(plot_idx)%plot_type = PLOT_TYPE_LINE
-
-            ! Store trajectory data
-            allocate (plots(plot_idx)%x(trajectory_lengths(i)))
-            allocate (plots(plot_idx)%y(trajectory_lengths(i)))
-            do j = 1, trajectory_lengths(i)
-                plots(plot_idx)%x(j) = map_grid_index_to_coord(trajectories(i, j, 1), x)
-                plots(plot_idx)%y(j) = map_grid_index_to_coord(trajectories(i, j, 2), y)
-            end do
-
-            ! Set streamline properties
-            plots(plot_idx)%linestyle = '-'
-            plots(plot_idx)%marker = ''
-            plots(plot_idx)%color = line_color
-            plots(plot_idx)%line_width = line_width_val
-        end do
     end subroutine streamplot_figure
 
 end module fortplot_figure_streamlines

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -113,10 +113,13 @@ contains
                                             arrow_style_val)
         end if
 
-        ! Add trajectories to figure
-        call add_trajectories_to_figure(self, trajectories, n_trajectories, &
-                                        trajectory_lengths, color, x, y, &
-                                        line_width_val)
+        ! Add trajectories to figure only when no arrows are present
+        ! (arrows replace trajectory lines, not supplement them)
+        if (arrow_size_val <= 0.0_wp) then
+            call add_trajectories_to_figure(self, trajectories, n_trajectories, &
+                                            trajectory_lengths, color, x, y, &
+                                            line_width_val)
+        end if
     end subroutine setup_streamplot_parameters
 
     subroutine update_streamplot_ranges(self, x, y)

--- a/test/plot_types/vector/test_streamplot.f90
+++ b/test/plot_types/vector/test_streamplot.f90
@@ -11,17 +11,17 @@ program test_streamplot
     call test_streamplot_rtol_parameter()
     call test_streamplot_grid_validation()
     call test_streamplot_arrow_clearing()
+    call test_streamplot_no_arrows_draws_lines()
 
 contains
 
     subroutine test_basic_streamplot()
+        !! Default streamplot generates arrows (not trajectory lines).
         type(figure_t) :: fig
         real(dp), dimension(5) :: x = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp]
         real(dp), dimension(4) :: y = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
         real(dp), dimension(5, 4) :: u, v
         integer :: i, j
-        integer :: plot_idx
-        logical :: found_nonempty_streamline
 
         do j = 1, 4
             do i = 1, 5
@@ -31,14 +31,9 @@ contains
         end do
 
         call fig%initialize(800, 600)
-
         call fig%streamplot(x, y, u, v)
 
-        if (fig%plot_count == 0) then
-            print *, "ERROR: No plots generated from streamplot"
-            stop 1
-        end if
-
+        ! Default streamplot generates arrows, not trajectory lines
         if (.not. allocated(fig%state%stream_arrows)) then
             print *, "ERROR: Expected streamplot arrows to be generated"
             stop 1
@@ -46,21 +41,6 @@ contains
 
         if (size(fig%state%stream_arrows) == 0) then
             print *, "ERROR: Streamplot arrows array is empty"
-            stop 1
-        end if
-
-        found_nonempty_streamline = .false.
-        do plot_idx = 1, fig%plot_count
-            if (allocated(fig%plots(plot_idx)%x)) then
-                if (size(fig%plots(plot_idx)%x) > 0) then
-                    found_nonempty_streamline = .true.
-                    exit
-                end if
-            end if
-        end do
-
-        if (.not. found_nonempty_streamline) then
-            print *, "ERROR: Expected at least one non-empty streamline"
             stop 1
         end if
     end subroutine
@@ -82,33 +62,37 @@ contains
     end subroutine setup_test_grid_3x3
 
     subroutine test_streamplot_density_parameter()
+        !! Streamplot with arrows at different densities generates different
+        !! arrow counts.
         type(figure_t) :: fig
         real(dp), dimension(3) :: x, y
         real(dp), dimension(3, 3) :: u, v
-        integer :: n_streamlines1, n_streamlines2
+        integer :: n_arrows1, n_arrows2
 
         call setup_test_grid_3x3(x, y, u, v)
 
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v, density=0.5_dp)
-        n_streamlines1 = fig%plot_count
+        n_arrows1 = size(fig%state%stream_arrows)
 
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v, density=2.0_dp)
-        n_streamlines2 = fig%plot_count
+        n_arrows2 = size(fig%state%stream_arrows)
 
-        if (n_streamlines1 <= 0 .or. n_streamlines2 <= 0) then
+        if (n_arrows1 <= 0 .or. n_arrows2 <= 0) then
             print *, "ERROR: Expected streamplot to generate streamlines"
             stop 1
         end if
 
-        if (n_streamlines2 <= n_streamlines1) then
+        if (n_arrows2 <= n_arrows1) then
             print *, "ERROR: Expected higher density to generate more streamlines"
             stop 1
         end if
     end subroutine test_streamplot_density_parameter
 
     subroutine test_streamplot_linewidth_parameter()
+        !! When arrowsize=0, streamplot draws trajectory lines with specified
+        !! linewidth.
         type(figure_t) :: fig
         real(dp), dimension(3) :: x, y
         real(dp), dimension(3, 3) :: u, v
@@ -116,7 +100,7 @@ contains
         call setup_test_grid_3x3(x, y, u, v)
 
         call fig%initialize(800, 600)
-        call fig%streamplot(x, y, u, v, linewidth=2.5_dp)
+        call fig%streamplot(x, y, u, v, linewidth=2.5_dp, arrowsize=0.0_dp)
         if (fig%plot_count <= 0) then
             print *, "ERROR: Expected streamplot with linewidth to generate plots"
             stop 1
@@ -126,19 +110,17 @@ contains
             stop 1
         end if
 
+        ! Default streamplot (with arrows) should not have trajectory plots
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v)
-        if (fig%plot_count <= 0) then
-            print *, "ERROR: Expected default streamplot to generate plots"
-            stop 1
-        end if
-        if (fig%plots(1)%line_width > 0.0_dp) then
-            print *, "ERROR: Expected streamplot linewidth to not leak into other plots"
+        if (fig%plot_count > 0) then
+            print *, "ERROR: Expected streamplot with arrows to not generate plots"
             stop 1
         end if
     end subroutine test_streamplot_linewidth_parameter
 
     subroutine test_streamplot_max_time_parameter()
+        !! When arrowsize=0, max_time controls trajectory point count.
         type(figure_t) :: fig
         real(dp), dimension(3) :: x, y
         real(dp), dimension(3, 3) :: u, v
@@ -147,24 +129,13 @@ contains
 
         call setup_test_grid_3x3(x, y, u, v)
 
+        ! Default (arrows) - no trajectory plots
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v)
-        if (fig%plot_count <= 0) then
-            print *, "ERROR: Expected default streamplot to generate plots"
-            stop 1
-        end if
 
-        total_points_default = 0
-        do plot_idx = 1, fig%plot_count
-            if (.not. allocated(fig%plots(plot_idx)%x)) then
-                print *, "ERROR: Expected streamline x data to be allocated"
-                stop 1
-            end if
-            total_points_default = total_points_default + size(fig%plots(plot_idx)%x)
-        end do
-
+        ! With max_time and arrowsize=0 - shorter trajectories
         call fig%initialize(800, 600)
-        call fig%streamplot(x, y, u, v, max_time=0.2_dp)
+        call fig%streamplot(x, y, u, v, max_time=0.2_dp, arrowsize=0.0_dp)
         if (fig%state%has_error) then
             print *, "ERROR: Unexpected error for valid max_time"
             stop 1
@@ -183,6 +154,23 @@ contains
             total_points_short = total_points_short + size(fig%plots(plot_idx)%x)
         end do
 
+        ! Longer max_time should produce more points
+        call fig%initialize(800, 600)
+        call fig%streamplot(x, y, u, v, max_time=1.0_dp, arrowsize=0.0_dp)
+        if (fig%plot_count <= 0) then
+            print *, "ERROR: Expected streamplot with longer max_time to generate plots"
+            stop 1
+        end if
+
+        total_points_default = 0
+        do plot_idx = 1, fig%plot_count
+            if (.not. allocated(fig%plots(plot_idx)%x)) then
+                print *, "ERROR: Expected streamline x data to be allocated"
+                stop 1
+            end if
+            total_points_default = total_points_default + size(fig%plots(plot_idx)%x)
+        end do
+
         if (total_points_short >= total_points_default) then
             print *, "ERROR: Expected max_time to reduce integrated streamline points"
             stop 1
@@ -190,6 +178,7 @@ contains
     end subroutine test_streamplot_max_time_parameter
 
     subroutine test_streamplot_rtol_parameter()
+        !! When arrowsize=0, rtol controls trajectory point count.
         type(figure_t) :: fig
         real(dp), dimension(3) :: x, y
         real(dp), dimension(3, 3) :: u, v
@@ -199,7 +188,8 @@ contains
         call setup_test_grid_3x3(x, y, u, v)
 
         call fig%initialize(800, 600)
-        call fig%streamplot(x, y, u, v, rtol=1.0e-9_dp, max_time=0.5_dp)
+        call fig%streamplot(x, y, u, v, rtol=1.0e-9_dp, max_time=0.5_dp, &
+                            arrowsize=0.0_dp)
         if (fig%plot_count <= 0) then
             print *, "ERROR: Expected strict rtol streamplot to generate plots"
             stop 1
@@ -215,7 +205,8 @@ contains
         end do
 
         call fig%initialize(800, 600)
-        call fig%streamplot(x, y, u, v, rtol=1.0e-3_dp, max_time=0.5_dp)
+        call fig%streamplot(x, y, u, v, rtol=1.0e-3_dp, max_time=0.5_dp, &
+                            arrowsize=0.0_dp)
         if (fig%plot_count <= 0) then
             print *, "ERROR: Expected lenient rtol streamplot to generate plots"
             stop 1
@@ -282,5 +273,52 @@ contains
             stop 1
         end if
     end subroutine test_streamplot_arrow_clearing
+
+    subroutine test_streamplot_no_arrows_draws_lines()
+        !! When arrowsize=0, streamplot draws trajectory lines (not arrows).
+        type(figure_t) :: fig
+        real(dp), dimension(5) :: x = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp]
+        real(dp), dimension(4) :: y = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+        real(dp), dimension(5, 4) :: u, v
+        integer :: plot_idx
+        logical :: found_nonempty_streamline
+        integer :: ii, jj
+
+        do jj = 1, 4
+            do ii = 1, 5
+                u(ii, jj) = 1.0_dp
+                v(ii, jj) = 0.0_dp
+            end do
+        end do
+
+        call fig%initialize(800, 600)
+        call fig%streamplot(x, y, u, v, arrowsize=0.0_dp)
+
+        if (fig%plot_count == 0) then
+            print *, "ERROR: No plots generated from streamplot (no arrows)"
+            stop 1
+        end if
+
+        ! No arrows when arrowsize=0
+        if (allocated(fig%state%stream_arrows) .and. size(fig%state%stream_arrows) > 0) then
+            print *, "ERROR: Expected no streamplot arrows when arrowsize=0"
+            stop 1
+        end if
+
+        found_nonempty_streamline = .false.
+        do plot_idx = 1, fig%plot_count
+            if (allocated(fig%plots(plot_idx)%x)) then
+                if (size(fig%plots(plot_idx)%x) > 0) then
+                    found_nonempty_streamline = .true.
+                    exit
+                end if
+            end if
+        end do
+
+        if (.not. found_nonempty_streamline) then
+            print *, "ERROR: Expected at least one non-empty streamline"
+            stop 1
+        end if
+    end subroutine test_streamplot_no_arrows_draws_lines
 
 end program test_streamplot

--- a/test/plot_types/vector/test_streamplot_interface_color.f90
+++ b/test/plot_types/vector/test_streamplot_interface_color.f90
@@ -11,21 +11,20 @@ program test_streamplot_interface_color
     class(figure_t), pointer :: fig
     type(plot_data_t), pointer :: plots(:)
     integer :: i, j, n
-    real(wp), dimension(3) :: ref_color
-    logical :: all_same
 
     call test_default_color()
     call test_custom_color()
     call test_cmap_stored_on_plot()
     call test_label_stored_on_plot()
     call test_linewidth_via_wrapper()
+    call test_default_generates_arrows()
 
     print *, "Streamplot interface color tests passed"
 
 contains
 
     subroutine test_default_color()
-        ! Setup a vector field matching test_streamplot.f90 parameters
+        !! Default streamplot color is blue when arrowsize=0 (line mode).
         do i = 1, 5
             x(i) = real(i-1, wp)
         end do
@@ -39,39 +38,25 @@ contains
             end do
         end do
 
-        ! Use explicit figure dimensions like test_streamplot.f90
         call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
 
-        call streamplot(x, y, u, v)
+        call streamplot(x, y, u, v, arrowsize=0.0_wp)
 
         fig => get_global_figure()
         n = fig%get_plot_count()
 
         if (n <= 0) then
-            print *, "ERROR: streamplot produced no plots"
+            print *, "ERROR: streamplot (no arrows) produced no plots"
             stop 1
         end if
 
         plots => fig%get_plots()
-        ref_color = plots(1)%color
-        all_same = .true.
-        do i = 2, n
-            if (any(abs(plots(i)%color - ref_color) > 1.0e-12_wp)) then
-                all_same = .false.
-                exit
+        do i = 1, n
+            if (any(abs(plots(i)%color - [0.0_wp, 0.447_wp, 0.698_wp]) > 1.0e-12_wp)) then
+                print *, "ERROR: Streamplot default color not blue as expected"
+                stop 1
             end if
         end do
-
-        if (.not. all_same) then
-            print *, "ERROR: Streamplot interface assigned varying colors across streamlines"
-            stop 1
-        end if
-
-        ! Check equals default blue
-        if (any(abs(ref_color - [0.0_wp, 0.447_wp, 0.698_wp]) > 1.0e-12_wp)) then
-            print *, "ERROR: Streamplot default color not blue as expected"
-            stop 1
-        end if
 
         print *, "test_default_color passed"
     end subroutine test_default_color
@@ -95,7 +80,7 @@ contains
         call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
         custom_rgb = [1.0_wp, 0.0_wp, 0.0_wp]
 
-        call streamplot(x, y, u, v, color=custom_rgb)
+        call streamplot(x, y, u, v, color=custom_rgb, arrowsize=0.0_wp)
 
         fig => get_global_figure()
         n = fig%get_plot_count()
@@ -131,7 +116,7 @@ contains
 
         call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
 
-        call streamplot(x, y, u, v, cmap='plasma')
+        call streamplot(x, y, u, v, cmap='plasma', arrowsize=0.0_wp)
 
         fig => get_global_figure()
         n = fig%get_plot_count()
@@ -169,7 +154,7 @@ contains
 
         call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
 
-        call streamplot(x, y, u, v, label='flow_field')
+        call streamplot(x, y, u, v, label='flow_field', arrowsize=0.0_wp)
 
         fig => get_global_figure()
         n = fig%get_plot_count()
@@ -190,7 +175,7 @@ contains
     end subroutine test_label_stored_on_plot
 
     subroutine test_linewidth_via_wrapper()
-        ! Verify linewidth parameter flows through the stateful wrapper
+        !! Verify linewidth parameter flows through the stateful wrapper
         do i = 1, 5
             x(i) = real(i-1, wp)
         end do
@@ -206,7 +191,7 @@ contains
 
         call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
 
-        call streamplot(x, y, u, v, linewidth=2.5_wp)
+        call streamplot(x, y, u, v, linewidth=2.5_wp, arrowsize=0.0_wp)
 
         fig => get_global_figure()
         n = fig%get_plot_count()
@@ -225,5 +210,46 @@ contains
 
         print *, "test_linewidth_via_wrapper passed"
     end subroutine test_linewidth_via_wrapper
+
+    subroutine test_default_generates_arrows()
+        !! Default streamplot (no arrowsize specified) generates arrows.
+        do i = 1, 5
+            x(i) = real(i-1, wp)
+        end do
+        do i = 1, 4
+            y(i) = real(i-1, wp)
+        end do
+        do j = 1, 4
+            do i = 1, 5
+                u(i,j) = 1.0_wp
+                v(i,j) = 0.0_wp
+            end do
+        end do
+
+        call figure(figsize=[8.0_wp, 6.0_wp], dpi=100)
+
+        call streamplot(x, y, u, v)
+
+        fig => get_global_figure()
+
+        ! Default streamplot should have arrows, not trajectory plots
+        if (fig%get_plot_count() > 0) then
+            print *, "ERROR: Default streamplot should not generate trajectory plots"
+            stop 1
+        end if
+
+        ! But should have stream arrows
+        if (.not. allocated(fig%state%stream_arrows)) then
+            print *, "ERROR: Default streamplot should generate stream arrows"
+            stop 1
+        end if
+
+        if (size(fig%state%stream_arrows) == 0) then
+            print *, "ERROR: Default streamplot arrows array is empty"
+            stop 1
+        end if
+
+        print *, "test_default_generates_arrows passed"
+    end subroutine test_default_generates_arrows
 
 end program test_streamplot_interface_color


### PR DESCRIPTION
fix: streamplot draws only arrowheads, not trajectory lines (refs #1913)

## Requirements

- **REQ-001**: Streamplot with arrows (`arrowstyle='->'`, `arrowsize > 0`) must draw ONLY arrowheads along streamlines, not full trajectory lines. — **satisfied**
- **REQ-002**: Streamplot without arrows (`arrowsize=0`) must draw full trajectory lines. — **satisfied**
- **REQ-003**: Default streamplot behavior (no explicit `arrowsize`) draws arrows (matching matplotlib default). — **satisfied**

## File-Set Enumeration

| File | Action | Reason |
|------|--------|--------|
| `src/plotting/fortplot_streamplot_core.f90` | **edited** | Core fix: conditionally skip `add_trajectories_to_figure` when `arrow_size_val > 0` |
| `src/figures/plot_types/fortplot_figure_streamlines.f90` | **edited** | Functional API fix: removed trajectory line loop (arrows always generated with defaults) |
| `test/plot_types/vector/test_streamplot.f90` | **edited** | Updated tests: default streamplot checks arrows, line-mode tests use `arrowsize=0.0` |
| `test/plot_types/vector/test_streamplot_interface_color.f90` | **edited** | Updated tests: plot-property tests use `arrowsize=0.0`, added arrow-default test |

Files intentionally left alone:
- `src/interfaces/fortplot_matplotlib_field_wrappers.f90` — wrapper just passes params through; no logic change needed
- `src/figures/management/fortplot_figure_render_engine.f90` — arrow rendering already separate from plot rendering
- `src/figures/rendering/fortplot_vector_plot_helpers.f90` — `render_streamplot_arrows` unchanged
- All other backends — arrow rendering is backend-agnostic via `backend%draw_arrow()`

## Verification

```
$ fpm test --target test_streamplot
[100%] Project compiled successfully.
$ fpm test --target test_streamplot_interface_color
 test_default_color passed
 test_custom_color passed
 test_cmap_stored_on_plot passed
 test_label_stored_on_plot passed
 test_linewidth_via_wrapper passed
 test_default_generates_arrows passed
 Streamplot interface color tests passed
$ fpm test 2>&1 | grep -c "ERROR"
0
$ make verify-artifacts 2>&1 | tail -1
Artifact verification passed.
$ fpm run --example streamplot_demo
 Streamplot demo completed!
```

All 92 fast tests pass. No errors in full test suite. Artifact verification passes.

(ref #1913)
<!-- orchestrate: fully-resolved -->