### PR TITLE
fix: update GitHub Actions node runtime pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     # Python setup for utility scripts (Ubuntu)
     - name: Setup Python (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           version: 13
           
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -113,10 +113,10 @@ jobs:
           }
         
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload only the documentation directory
           path: './build/doc'
@@ -131,4 +131,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Update GitHub-owned workflow actions that still ran on Node.js 20:

- `actions/setup-python` to `v6`
- `actions/configure-pages` to `v6`
- `actions/upload-pages-artifact` to `v5`
- `actions/deploy-pages` to `v5`

## Verification

### Test fails on main

Main Pages deployment completed, but GitHub emitted the Node.js 20 deprecation warning:

```text
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected:
actions/cache/restore@v4, actions/configure-pages@v5,
actions/setup-python@v5, actions/upload-artifact@v4.
```

### Test passes after fix

```text
$ git ls-remote --tags https://github.com/actions/setup-python.git 'refs/tags/v6'
a309ff8b426b58ec0e2a45f0f869d46889d02405 refs/tags/v6

$ git ls-remote --tags https://github.com/actions/configure-pages.git 'refs/tags/v6'
45bfe0192ca1faeb007ade9deae92b16b8254a0d refs/tags/v6

$ git ls-remote --tags https://github.com/actions/upload-pages-artifact.git 'refs/tags/v5'
fc324d3547104276b827a68afc52ff2a11cc49c9 refs/tags/v5

$ git ls-remote --tags https://github.com/actions/deploy-pages.git 'refs/tags/v5'
cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 refs/tags/v5

$ python - <<'PY'
import pathlib, yaml
for path in pathlib.Path('.github/workflows').glob('*.yml'):
    yaml.safe_load(path.read_text())
    print(f'parsed {path}')
PY
parsed .github/workflows/docs.yml
parsed .github/workflows/ci.yml
parsed .github/workflows/downstream-test.yml

$ git diff --check
<no output>

$ make build
Project is up to date

$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully
```
