### PR TITLE
fix: document fortplot_figure_core_main.f90 as 500-line exception (ref #1925)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ Self-contained Fortran plotting library. Backends: PNG (raster), PDF (vector), A
 
 - Free-form Fortran, no implicit typing. Use `use fortplot, only: wp => real64`.
 - Modules < ~500 lines (hard ceiling 1000). Functions < 50 lines (hard 100).
+  - Exception: `src/figures/core/fortplot_figure_core_main.f90` (817 lines) is a
+    public API facade where Fortran requires all `procedure ::` / `generic ::`
+    type-bound interfaces in the same module as the type definition.
+    Implementations are split across submodules. See issue #1925.
 - Each `test/<area>/` directory under 50 files (soft 20). Tests named `test_*.f90`.
 - Test artifacts go to `build/test/output/` via `src/testing/fortplot_test_helpers.f90`, never to repo root.
 - Conventional Commit subjects: `fix:`, `feat:`, `docs:`, `refactor:`, `cleanup:`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ Self-contained Fortran plotting library. Backends: PNG (raster), PDF (vector), A
 
 - Free-form Fortran, no implicit typing. Use `use fortplot, only: wp => real64`.
 - Modules < ~500 lines (hard ceiling 1000). Functions < 50 lines (hard 100).
+  - Exception: `src/figures/core/fortplot_figure_core_main.f90` (817 lines) is a
+    public API facade where Fortran requires all `procedure ::` / `generic ::`
+    type-bound interfaces in the same module as the type definition.
+    Implementations are split across submodules. See issue #1925.
 - Each `test/<area>/` directory under 50 files (soft 20). Tests named `test_*.f90`.
 - Test artifacts go to `build/test/output/` via `src/testing/fortplot_test_helpers.f90`, never to repo root.
 - Conventional Commit subjects: `fix:`, `feat:`, `docs:`, `refactor:`, `cleanup:`.

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -1,5 +1,13 @@
 module fortplot_figure_core
 
+    !! EXCEPTION: This module is 817 lines, exceeding the ~500-line soft limit.
+    !! Fortran requires all `procedure ::` and `generic ::` type-bound procedure
+    !! interfaces to be declared in the same module as the type definition. The
+    !! ~175 lines of type definition + ~642 lines of explicit interface blocks
+    !! cannot be split without a major architectural refactor (submodule interface
+    !! modules or facade pattern). Implementations are already split across the
+    !! submodules listed in the imports above. See issue #1925.
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_annotations, only: text_annotation_t


### PR DESCRIPTION
## Requirements

- **REQ-001**: Document `fortplot_figure_core_main.f90` as an accepted exception to the ~500-line module limit — **satisfied**
- **REQ-002**: Record the rationale (Fortran constraint: type-bound procedure `procedure ::` / `generic ::` interfaces must coexist with the type definition in the same module) — **satisfied**
- **REQ-003**: Implementations already split across submodules — **satisfied by prior commits (refs #1694)**

## File-set enumeration

| File | Action | Reason |
|------|--------|--------|
| `src/figures/core/fortplot_figure_core_main.f90` | **edited** | Added module-level exception comment explaining the 817-line count |
| `AGENTS.md` | **edited** | Added exception note to module size conventions |
| `CLAUDE.md` | **edited** | Added exception note to module size conventions |
| All other files in scope | leave alone | No other files exceed limits or relate to this issue |

## Verification

```
$ make build
[100%] Project compiled successfully.

$ make test-ci
[100%] Project compiled successfully.
PASS: ALL REFACTORING TESTS PASSED!
PASS: ALL BACKEND SWITCHING TESTS PASSED!
CI essential test suite completed successfully
```

(ref #1925)
<!-- orchestrate: fully-resolved -->
