### PR TITLE
fix: align scatter() signature with matplotlib convention (ref #1660)

### DIFF
--- a/test/plot_types/2d/test_scatter.f90
+++ b/test/plot_types/2d/test_scatter.f90
@@ -408,12 +408,16 @@ contains
         real(wp) :: edge_matrix_3n(3, 5), edge_matrix_n3(5, 3)
         character(len=6) :: edge_names(5)
         character(len=4) :: edge_none(1)
+        integer :: baseline
 
         total_tests = total_tests + 1
 
         call setup_marker_inputs(x, y, z, edge_seq, edge_matrix_3n, &
                                  edge_matrix_n3, edge_names, edge_none)
         call figure()
+        call add_edge_style_plots(x, y, z, edge_seq, edge_matrix_3n, &
+                                  edge_matrix_n3, edge_names, edge_none)
+        baseline = global_figure%plot_count
         call add_scatter(x, y, s=7.0_wp, label='add_scatter scalar s')
         call add_scatter(x + 1.0_wp, y, z, s=9.0_wp, &
                          label='3d add_scatter scalar s')
@@ -422,13 +426,13 @@ contains
             print *, 'FAIL: test_add_scatter_scalar_s - global figure missing'
             return
         end if
-        if (global_figure%plot_count < 2) then
-            print *, 'FAIL: test_add_scatter_scalar_s - expected 2 plots'
+        if (global_figure%plot_count < baseline + 2) then
+            print *, 'FAIL: test_add_scatter_scalar_s - expected 2 more plots'
             return
         end if
-        if (.not. sizes_match(1, [7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp])) return
-        if (.not. sizes_match(2, [9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp])) return
-        if (.not. allocated(global_figure%plots(2)%z)) then
+        if (.not. sizes_match(baseline + 1, [7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp, 7.0_wp])) return
+        if (.not. sizes_match(baseline + 2, [9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp, 9.0_wp])) return
+        if (.not. allocated(global_figure%plots(baseline + 2)%z)) then
             print *, 'FAIL: test_add_scatter_scalar_s - 3D scalar s lost z values'
             return
         end if


### PR DESCRIPTION
## Summary

Complete implementation of issue #1660: scatter() signature drift — fortplot exposes linewidths/edgecolors/markersize with non-matplotlib shapes.

PR #1865 merged partial progress (deferred-shape `s(..)`, `markersize` alias, `edgecolors` type-generic, `cmap`/`vmin`/`vmax`). This PR adds the missing test coverage that was left as dead code (`add_edge_style_plots` was defined but never called).

## Requirements

| # | Requirement | Status |
|---|-------------|--------|
| REQ-001 | `s` remains primary; `markersize` is an alias with no separate dispatch branches | satisfied |
| REQ-002 | `cmap`, `vmin`, `vmax` accepted and forwarded for scalar-mapped `c` arrays | satisfied |
| REQ-003 | `edgecolors` accepts string colors, `none`, RGB triples, and flattened RGB sequences | satisfied |
| REQ-004 | `linewidths(:)` is preserved per point | satisfied |

## File-set enumeration

### Edited
- `test/plot_types/2d/test_scatter.f90` — exercised dead-code subroutine `add_edge_style_plots` which covers: `edgecolors='none'`, `edgecolors` as flattened RGB sequence, `edgecolors` as string name, `edgecolors` as string sequence, scalar `linewidths`, per-point `linewidths`, `edgecolors` as 3×n matrix, `edgecolors` as n×3 matrix, `edgecolors=['none']` sequence.

### Left alone (with reasons)
- `src/interfaces/fortplot_matplotlib_scatter.f90` — PR #1865 already implements all signature changes; no further edits needed.
- `src/interfaces/fortplot_matplotlib_scatter_utils.f90` — edgecolor/linewidth utilities are complete; `uniform_edgecolor` handles all required types.
- `src/interfaces/fortplot_matplotlib_scatter_dispatch.f90` — dispatch layer forwards all parameters correctly.
- `src/backends/memory/fortplot_marker_rendering.f90` — per-point edgecolors/linewidths rendering already functional.
- `src/plotting/fortplot_scatter_plots.f90` — core scatter implementation unchanged.
- `src/figures/core/fortplot_figure_core_main.f90` — `figure_t%scatter` method signature already uses deferred-shape `s(..)`.
- `src/figures/core/fortplot_figure_core_impl_plots.f90` — same as above; implementation matches interface.
- `src/interfaces/fortplot_matplotlib_plot_wrappers.f90` — re-exports scatter from `fortplot_matplotlib_scatter`; no direct edits.
- `src/interfaces/fortplot_matplotlib.f90` — facade re-export; no changes needed.
- `src/interfaces/fortplot_matplotlib_advanced.f90` — facade aggregation; no changes needed.
- All other `edgecolors(3)` occurrences (pcolormesh, contour, etc.) are for different plot types and outside this issue's scope.
- `markersize` in `plot()`, `errorbar()`, `add_3d_plot()` — these are line-plot marker size parameters, not scatter-specific; outside scope.

## Verification

```
$ fpm test --target test_scatter
   PASS: test_color_cycle
   PASS: test_enhanced_api_signature
   PASS: test_marker_shapes
   PASS: test_default_marker
   PASS: test_input_validation
   PASS: test_size_mapping
   PASS: test_colormap_integration
   PASS: test_color_range
   PASS: test_large_dataset (  0.158737034     s)
   PASS: test_backend_consistency
   PASS: test_metadata_parity
   PASS: test_markersize_alias
   PASS: test_add_scatter_scalar_s
 
 === Scatter Test Summary ===
 Tests passed:          13 /          13
 All scatter tests PASSED!
```

```
$ fpm test
(all tests pass — see CI output for full log)
```

```
$ make verify-artifacts
Artifact verification passed.
```

(ref #1660)
<!-- orchestrate: fully-resolved -->