### PR TITLE
fix: streamplot arrows render heads only and preserve user axis range

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -65,6 +65,7 @@ module fortplot_ascii
         procedure :: set_marker_colors_with_alpha => ascii_set_marker_colors_with_alpha
         procedure :: fill_heatmap => ascii_fill_heatmap
         procedure :: draw_arrow => ascii_draw_arrow
+        procedure :: draw_arrowhead => ascii_draw_arrowhead
         procedure :: get_ascii_output => ascii_get_output_method
 
         !! New polymorphic methods to eliminate SELECT TYPE
@@ -277,6 +278,19 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
                               this%has_rendered_arrows, this%uses_vector_arrows, &
                               this%has_triangular_arrows)
     end subroutine ascii_draw_arrow
+
+    subroutine ascii_draw_arrowhead(this, x, y, dx, dy, size, style)
+        !! ASCII has no separate head-only glyph; reuse draw_arrow.
+        class(ascii_context), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        call draw_ascii_arrow(this%canvas, x, y, dx, dy, size, style, &
+                              this%x_min, this%x_max, this%y_min, this%y_max, &
+                              this%width, this%height, &
+                              this%has_rendered_arrows, this%uses_vector_arrows, &
+                              this%has_triangular_arrows)
+    end subroutine ascii_draw_arrowhead
 
     function ascii_get_output_method(this) result(output)
         class(ascii_context), intent(in) :: this

--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -79,6 +79,7 @@ module fortplot_raster
         procedure :: set_marker_colors_with_alpha => raster_set_marker_colors_with_alpha
         procedure :: fill_quad => raster_fill_quad_context
         procedure :: draw_arrow => raster_draw_arrow
+        procedure :: draw_arrowhead => raster_draw_arrowhead
         procedure :: get_ascii_output => raster_get_ascii_output
         ! Polymorphic methods to eliminate SELECT TYPE
         procedure :: get_width_scale => raster_get_width_scale
@@ -187,6 +188,12 @@ module fortplot_raster
             real(wp), intent(in) :: x, y, dx, dy, size
             character(len=*), intent(in) :: style
         end subroutine raster_draw_arrow
+
+        module subroutine raster_draw_arrowhead(this, x, y, dx, dy, size, style)
+            class(raster_context), intent(inout) :: this
+            real(wp), intent(in) :: x, y, dx, dy, size
+            character(len=*), intent(in) :: style
+        end subroutine raster_draw_arrowhead
 
         module function raster_get_ascii_output(this) result(output)
             class(raster_context), intent(in) :: this

--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -257,4 +257,57 @@ contains
         this%has_triangular_arrows = .true.
     end subroutine raster_draw_arrow
 
+    module subroutine raster_draw_arrowhead(this, x, y, dx, dy, size, style)
+        !! Draw a streamplot-style arrowhead glyph at (x, y) with a fixed
+        !! pixel size. (dx, dy) is a unit direction; size controls head
+        !! length in pixels and does NOT scale with the data range, unlike
+        !! draw_arrow which carries quiver shaft semantics.
+        class(raster_context), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        real(wp) :: arrow_length, arrow_width
+        real(wp) :: norm_dx, norm_dy, perp_x, perp_y
+        real(wp) :: px, py, ddx, ddy, magnitude
+        real(wp) :: x1, y1, x2, y2, x3, y3
+        integer(1) :: r, g, b
+        associate (dsl => len_trim(style)); end associate
+
+        ! Transform tip position to pixel coordinates.
+        px = (x - this%x_min)/(this%x_max - this%x_min)*real(this%plot_area%width, wp) &
+             + real(this%plot_area%left, wp)
+        py = real(this%plot_area%bottom + this%plot_area%height, wp) - &
+             (y - this%y_min)/(this%y_max - this%y_min)*real(this%plot_area%height, wp)
+
+        ! Reuse the data->pixel transform purely to flip Y for screen space;
+        ! direction magnitude is irrelevant since size is a pixel length.
+        ddx = dx*(real(this%plot_area%width, wp)/max(1.0_wp, (this%x_max - this%x_min)))
+        ddy = -dy*(real(this%plot_area%height, wp)/max(1.0_wp, (this%y_max - &
+                                                                this%y_min)))
+        magnitude = sqrt(ddx*ddx + ddy*ddy)
+        if (magnitude < 1.0e-10_wp) return
+        norm_dx = ddx/magnitude
+        norm_dy = ddy/magnitude
+
+        arrow_length = size*8.0_wp
+        arrow_width = arrow_length*0.5_wp
+        perp_x = -norm_dy
+        perp_y = norm_dx
+
+        x1 = px
+        y1 = py
+        x2 = px - arrow_length*norm_dx + arrow_width*perp_x
+        y2 = py - arrow_length*norm_dy + arrow_width*perp_y
+        x3 = px - arrow_length*norm_dx - arrow_width*perp_x
+        y3 = py - arrow_length*norm_dy - arrow_width*perp_y
+
+        call this%raster%get_color_bytes(r, g, b)
+        call fill_triangle(this%raster%image_data, this%width, this%height, &
+                           x1, y1, x2, y2, x3, y3, r, g, b)
+
+        this%has_rendered_arrows = .true.
+        this%uses_vector_arrows = .false.
+        this%has_triangular_arrows = .true.
+    end subroutine raster_draw_arrowhead
+
 end submodule fortplot_raster_impl

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -55,6 +55,7 @@ module fortplot_pdf
         procedure :: set_marker_colors_with_alpha => &
             set_marker_colors_with_alpha_wrapper
         procedure :: draw_arrow => draw_pdf_arrow_wrapper
+        procedure :: draw_arrowhead => draw_pdf_arrowhead_wrapper
         procedure :: get_ascii_output => pdf_get_ascii_output
 
         procedure :: get_width_scale => get_width_scale_wrapper
@@ -161,6 +162,12 @@ module fortplot_pdf
             real(wp), intent(in) :: x, y, dx, dy, size
             character(len=*), intent(in) :: style
         end subroutine draw_pdf_arrow_wrapper
+
+        module subroutine draw_pdf_arrowhead_wrapper(this, x, y, dx, dy, size, style)
+            class(pdf_context), intent(inout) :: this
+            real(wp), intent(in) :: x, y, dx, dy, size
+            character(len=*), intent(in) :: style
+        end subroutine draw_pdf_arrowhead_wrapper
 
         module function pdf_get_ascii_output(this) result(output)
             class(pdf_context), intent(in) :: this

--- a/src/backends/vector/pdf/fortplot_pdf_draw.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_draw.f90
@@ -366,6 +366,16 @@ contains
                                       dy, size, style)
     end subroutine draw_pdf_arrow_wrapper
 
+    module subroutine draw_pdf_arrowhead_wrapper(this, x, y, dx, dy, size, style)
+        class(pdf_context), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        call this%update_coord_context()
+        call draw_pdf_arrowhead_at_coords(this%coord_ctx, this%stream_writer, x, y, &
+                                          dx, dy, size, style)
+    end subroutine draw_pdf_arrowhead_wrapper
+
     module function pdf_get_ascii_output(this) result(output)
         class(pdf_context), intent(in) :: this
         character(len=:), allocatable :: output

--- a/src/backends/vector/pdf/fortplot_pdf_drawing.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_drawing.f90
@@ -17,6 +17,7 @@ module fortplot_pdf_drawing
     private
     public :: draw_pdf_circle_with_outline, draw_pdf_square_with_outline
     public :: draw_pdf_diamond_with_outline, draw_pdf_x_marker, draw_pdf_arrow
+    public :: draw_pdf_arrowhead
     public :: pdf_stream_writer
 
     type, extends(vector_stream_writer) :: pdf_stream_writer
@@ -454,5 +455,49 @@ contains
             end if
         end if
     end subroutine draw_pdf_arrow
+
+    subroutine draw_pdf_arrowhead(this, x, y, dx, dy, size, style)
+        !! Streamplot arrowhead only: head triangle at (x, y) tip, no shaft.
+        class(pdf_stream_writer), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        real(wp) :: arrow_length, arrow_width, arrow_angle
+        real(wp) :: base_x, base_y, left_x, left_y, right_x, right_y
+        real(wp) :: nx, ny, px, py, mag
+
+        mag = sqrt(dx*dx + dy*dy)
+        if (mag < 1.0e-12_wp) return
+
+        nx = dx/mag
+        ny = dy/mag
+        arrow_angle = atan2(ny, nx)
+
+        arrow_length = max(2.0_wp, 1.5_wp*size)
+        arrow_width = 0.55_wp*arrow_length
+
+        px = -ny
+        py = nx
+
+        base_x = x - arrow_length*cos(arrow_angle)
+        base_y = y - arrow_length*sin(arrow_angle)
+        left_x = base_x + arrow_width*px
+        left_y = base_y + arrow_width*py
+        right_x = base_x - arrow_width*px
+        right_y = base_y - arrow_width*py
+
+        if (index(style, '>') > 0 .or. index(style, '<') > 0 .or. &
+            style == 'filled' .or. style == 'open') then
+            call this%write_move(x, y)
+            call this%write_line(left_x, left_y)
+            call this%write_line(right_x, right_y)
+            call this%write_command("h")
+            if (style == 'filled') then
+                call this%write_command("B")
+            else
+                call this%write_stroke()
+            end if
+        end if
+    end subroutine draw_pdf_arrowhead
 
 end module fortplot_pdf_drawing

--- a/src/backends/vector/pdf/fortplot_pdf_markers.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_markers.f90
@@ -5,6 +5,7 @@ module fortplot_pdf_markers
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use fortplot_pdf_drawing, only: pdf_stream_writer, draw_pdf_arrow, &
+                                    draw_pdf_arrowhead, &
                                     draw_pdf_circle_with_outline, &
                                     draw_pdf_square_with_outline, &
                                     draw_pdf_diamond_with_outline, draw_pdf_x_marker
@@ -15,7 +16,7 @@ module fortplot_pdf_markers
 
     public :: draw_pdf_marker_at_coords
     public :: pdf_set_marker_colors, pdf_set_marker_colors_with_alpha
-    public :: draw_pdf_arrow_at_coords
+    public :: draw_pdf_arrow_at_coords, draw_pdf_arrowhead_at_coords
 
 contains
 
@@ -118,6 +119,48 @@ contains
         call draw_pdf_arrow(stream_writer, pdf_x, pdf_y, pdf_dx, pdf_dy, &
                             pdf_size, style)
     end subroutine draw_pdf_arrow_at_coords
+
+    subroutine draw_pdf_arrowhead_at_coords(ctx_handle, stream_writer, x, y, dx, dy, &
+                                            size, style)
+        !! Streamplot arrowhead: head glyph at (x, y), no shaft.
+        !! (dx, dy) is a unit direction in data coords; only its angle matters.
+        type(pdf_context_handle), intent(in) :: ctx_handle
+        type(pdf_stream_writer), intent(inout) :: stream_writer
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+        real(wp) :: pdf_x, pdf_y, pdf_dx, pdf_dy, pdf_size
+        real(wp) :: x_range, y_range, left, right, bottom, top, scale_factor
+        real(wp), parameter :: EPSILON = 1.0e-10_wp
+
+        call normalize_to_pdf_coords(ctx_handle, x, y, pdf_x, pdf_y)
+
+        x_range = ctx_handle%x_max - ctx_handle%x_min
+        y_range = ctx_handle%y_max - ctx_handle%y_min
+
+        left = real(ctx_handle%plot_area%left, wp)
+        right = real(ctx_handle%plot_area%left + ctx_handle%plot_area%width, wp)
+        bottom = real(ctx_handle%plot_area%bottom, wp)
+        top = real(ctx_handle%plot_area%bottom + ctx_handle%plot_area%height, wp)
+
+        scale_factor = sqrt((right - left)**2 + (top - bottom)**2)/sqrt(2.0_wp)
+
+        if (abs(x_range) > EPSILON) then
+            pdf_dx = dx*(right - left)/x_range
+        else
+            pdf_dx = 0.0_wp
+        end if
+        if (abs(y_range) > EPSILON) then
+            pdf_dy = dy*(top - bottom)/y_range
+        else
+            pdf_dy = 0.0_wp
+        end if
+        if (abs(pdf_dx) < EPSILON .and. abs(pdf_dy) < EPSILON) return
+
+        pdf_size = size*scale_factor/100.0_wp
+
+        call draw_pdf_arrowhead(stream_writer, pdf_x, pdf_y, pdf_dx, pdf_dy, &
+                                pdf_size, style)
+    end subroutine draw_pdf_arrowhead_at_coords
 
     subroutine pdf_set_stroke_color(stream_writer, r, g, b)
         type(pdf_stream_writer), intent(inout) :: stream_writer

--- a/src/backends/vector/svg/fortplot_svg.f90
+++ b/src/backends/vector/svg/fortplot_svg.f90
@@ -14,6 +14,7 @@ module fortplot_svg
                                     svg_set_legend_border_impl, svg_calc_legend_pos_impl
     use fortplot_svg_axes, only: svg_render_ylabel_impl, svg_draw_axes_labels_impl
     use fortplot_svg_draw, only: svg_draw_line_impl, svg_draw_arrow_impl, &
+                                  svg_draw_arrowhead_impl, &
                                   svg_fill_quad_impl, svg_fill_heatmap_impl, &
                                   svg_write_file_impl, svg_add_to_stream
     implicit none
@@ -45,6 +46,7 @@ module fortplot_svg
         procedure :: set_marker_colors => set_svg_marker_colors
         procedure :: set_marker_colors_with_alpha => set_svg_marker_colors_alpha
         procedure :: draw_arrow => draw_svg_arrow
+        procedure :: draw_arrowhead => draw_svg_arrowhead
         procedure :: get_ascii_output => svg_get_ascii_output
         procedure :: get_width_scale => svg_get_width_scale
         procedure :: get_height_scale => svg_get_height_scale
@@ -235,6 +237,19 @@ contains
             this%current_r, this%current_g, this%current_b, &
             this%content_stream)
     end subroutine draw_svg_arrow
+
+  subroutine draw_svg_arrowhead(this, x, y, dx, dy, size, style)
+        class(svg_context), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        call svg_draw_arrowhead_impl(x, y, dx, dy, size, style, &
+            real(this%plot_area%left, wp), real(this%plot_area%bottom, wp), &
+            real(this%plot_area%width, wp), real(this%plot_area%height, wp), &
+            this%x_min, this%x_max, this%y_min, this%y_max, &
+            this%current_r, this%current_g, this%current_b, &
+            this%content_stream)
+    end subroutine draw_svg_arrowhead
 
   subroutine svg_fill_quad(this, x_quad, y_quad)
         class(svg_context), intent(inout) :: this

--- a/src/backends/vector/svg/fortplot_svg_draw.f90
+++ b/src/backends/vector/svg/fortplot_svg_draw.f90
@@ -8,7 +8,8 @@ module fortplot_svg_draw
    implicit none
 
    private
-   public :: svg_draw_line_impl, svg_draw_arrow_impl, svg_fill_quad_impl, &
+   public :: svg_draw_line_impl, svg_draw_arrow_impl, svg_draw_arrowhead_impl, &
+             svg_fill_quad_impl, &
              svg_fill_heatmap_impl, svg_write_file_impl, svg_add_to_stream
 
 contains
@@ -120,6 +121,59 @@ contains
          call svg_add_to_stream(svg_content, trim(elem))
       end if
    end subroutine svg_draw_arrow_impl
+
+   subroutine svg_draw_arrowhead_impl(x, y, dx, dy, size, style, &
+                                      pa_left, pa_bottom, pa_width, pa_height, &
+                                      x_min, x_max, y_min, y_max, &
+                                      r, g, b, svg_content)
+      !! Streamplot arrowhead glyph at (x, y); no shaft. (dx, dy) is a unit
+      !! direction in data coords; only its angle matters for the head.
+      real(wp), intent(in) :: x, y, dx, dy, size
+      character(len=*), intent(in) :: style
+      real(wp), intent(in) :: pa_left, pa_bottom, pa_width, pa_height
+      real(wp), intent(in) :: x_min, x_max, y_min, y_max
+      real(wp), intent(in) :: r, g, b
+      character(len=:), allocatable, intent(inout) :: svg_content
+      real(wp) :: sx, sy, mag, nx, ny, px, py
+      real(wp) :: arrow_len, arrow_w, base_x, base_y
+      real(wp) :: left_x, left_y, right_x, right_y
+      real(wp) :: x_range, y_range
+      character(len=1024) :: elem
+
+      x_range = x_max - x_min
+      y_range = y_max - y_min
+      if (abs(x_range) < 1.0e-12_wp) x_range = 1.0_wp
+      if (abs(y_range) < 1.0e-12_wp) y_range = 1.0_wp
+
+      sx = pa_left + (x - x_min)/x_range*pa_width
+      sy = pa_bottom + pa_height - (y - y_min)/y_range*pa_height
+
+      mag = sqrt(dx*dx + dy*dy)
+      if (mag < 1.0e-12_wp) return
+      nx = dx/mag
+      ny = -dy/mag
+      px = -ny
+      py = nx
+
+      arrow_len = max(4.0_wp, 1.5_wp*size)
+      arrow_w = 0.55_wp*arrow_len
+      base_x = sx - arrow_len*nx
+      base_y = sy - arrow_len*ny
+      left_x = base_x + arrow_w*px
+      left_y = base_y + arrow_w*py
+      right_x = base_x - arrow_w*px
+      right_y = base_y - arrow_w*py
+
+      if (index(style, '>') > 0 .or. index(style, '<') > 0 .or. &
+          style == 'filled' .or. style == 'open') then
+         write (elem, '(A,F0.3,A,F0.3,A,F0.3,A,F0.3,A,F0.3,A,F0.3,A,F0.1,A, &
+&               F0.1,A,F0.1,A)') &
+              '<polygon points="', sx, ',', sy, ' ', left_x, ',', left_y, &
+              ' ', right_x, ',', right_y, '" fill="rgb(', &
+              r*255.0_wp, ',', g*255.0_wp, ',', b*255.0_wp, ')"/>'
+         call svg_add_to_stream(svg_content, trim(elem))
+      end if
+   end subroutine svg_draw_arrowhead_impl
 
    subroutine svg_fill_quad_impl(x_quad, y_quad, &
                                  pa_left, pa_bottom, pa_width, pa_height, &

--- a/src/core/fortplot_context.f90
+++ b/src/core/fortplot_context.f90
@@ -32,6 +32,7 @@ module fortplot_context
         procedure(marker_colors_alpha_interface), deferred :: &
             set_marker_colors_with_alpha
         procedure(arrow_interface), deferred :: draw_arrow
+        procedure(arrowhead_interface), deferred :: draw_arrowhead
         procedure(ascii_output_interface), deferred :: get_ascii_output
 
         !! Additional polymorphic methods to eliminate SELECT TYPE violations
@@ -118,6 +119,19 @@ module fortplot_context
             real(wp), intent(in) :: x, y, dx, dy, size
             character(len=*), intent(in) :: style
         end subroutine arrow_interface
+
+        subroutine arrowhead_interface(this, x, y, dx, dy, size, style)
+            !! Draw an arrowhead glyph only (no shaft).
+            !! (x,y) is the tip in data coordinates; (dx,dy) is a unit
+            !! direction in data coordinates pointing into the tip; size is
+            !! the head scale in pixel-like units, independent of the data
+            !! range. Used by streamplot, where draw_arrow's data-coord shaft
+            !! is unwanted.
+            import :: plot_context, wp
+            class(plot_context), intent(inout) :: this
+            real(wp), intent(in) :: x, y, dx, dy, size
+            character(len=*), intent(in) :: style
+        end subroutine arrowhead_interface
 
         function ascii_output_interface(this) result(output)
             import :: plot_context

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -23,6 +23,7 @@ module fortplot_figure_render_engine
         render_labels_overlay, render_decorations, &
         apply_aspect_ratio_if_needed, resolve_plot_colorbar_request
     use fortplot_raster, only: raster_context
+    use fortplot_scales, only: apply_scale_transform
     implicit none
 
     private
@@ -192,6 +193,7 @@ contains
                                           state%symlog_threshold, &
                                           state%symlog_base, state%symlog_linscale, &
                                           axis_filter=AXIS_PRIMARY)
+        call fold_stream_arrows_into_ranges(state, plot_count)
 
         if (state%has_twinx) then
             x_min_dummy = state%x_min
@@ -245,6 +247,51 @@ contains
             state%twiny_x_max_transformed = twiny_x_max_trans
         end if
     end subroutine compute_all_data_ranges
+
+    subroutine fold_stream_arrows_into_ranges(state, plot_count)
+        !! Streamplot in arrow-only mode adds no plot entries, so
+        !! calculate_figure_data_ranges resets the primary axis to its 0..1
+        !! default. Expand x/y back over the queued arrow positions so the
+        !! visible range covers the user's vector field.
+        type(figure_state_t), intent(inout) :: state
+        integer, intent(in) :: plot_count
+        real(wp) :: ax_min, ax_max, ay_min, ay_max
+        integer :: i
+
+        if (plot_count > 0) return
+        if (.not. allocated(state%stream_arrows)) return
+        if (size(state%stream_arrows) == 0) return
+
+        ax_min = state%stream_arrows(1)%x; ax_max = ax_min
+        ay_min = state%stream_arrows(1)%y; ay_max = ay_min
+        do i = 2, size(state%stream_arrows)
+            ax_min = min(ax_min, state%stream_arrows(i)%x)
+            ax_max = max(ax_max, state%stream_arrows(i)%x)
+            ay_min = min(ay_min, state%stream_arrows(i)%y)
+            ay_max = max(ay_max, state%stream_arrows(i)%y)
+        end do
+
+        if (.not. state%xlim_set) then
+            state%x_min = ax_min
+            state%x_max = ax_max
+        end if
+        if (.not. state%ylim_set) then
+            state%y_min = ay_min
+            state%y_max = ay_max
+        end if
+        state%x_min_transformed = apply_scale_transform(state%x_min, &
+            state%xscale, state%symlog_threshold, &
+            base=state%symlog_base, linscale=state%symlog_linscale)
+        state%x_max_transformed = apply_scale_transform(state%x_max, &
+            state%xscale, state%symlog_threshold, &
+            base=state%symlog_base, linscale=state%symlog_linscale)
+        state%y_min_transformed = apply_scale_transform(state%y_min, &
+            state%yscale, state%symlog_threshold, &
+            base=state%symlog_base, linscale=state%symlog_linscale)
+        state%y_max_transformed = apply_scale_transform(state%y_max, &
+            state%yscale, state%symlog_threshold, &
+            base=state%symlog_base, linscale=state%symlog_linscale)
+    end subroutine fold_stream_arrows_into_ranges
 
     subroutine resolve_date_formats(state, x_fmt, y_fmt, twinx_fmt, twiny_fmt)
         type(figure_state_t), intent(in) :: state

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -249,16 +249,18 @@ contains
     end subroutine compute_all_data_ranges
 
     subroutine fold_stream_arrows_into_ranges(state, plot_count)
-        !! Streamplot in arrow-only mode adds no plot entries, so
-        !! calculate_figure_data_ranges resets the primary axis to its 0..1
-        !! default. Expand x/y back over the queued arrow positions so the
-        !! visible range covers the user's vector field.
+        !! Streamplot's arrow queue lives outside `plots`, so
+        !! calculate_figure_data_ranges does not see those points. In
+        !! arrow-only mode that leaves the axis at its 0..1 default; in
+        !! mixed mode it can clip arrows that fall outside the other
+        !! plots' bounds. Expand x/y over the queued arrow positions
+        !! whenever they exist.
         type(figure_state_t), intent(inout) :: state
         integer, intent(in) :: plot_count
         real(wp) :: ax_min, ax_max, ay_min, ay_max
+        logical :: have_other_plots
         integer :: i
 
-        if (plot_count > 0) return
         if (.not. allocated(state%stream_arrows)) return
         if (size(state%stream_arrows) == 0) return
 
@@ -271,13 +273,24 @@ contains
             ay_max = max(ay_max, state%stream_arrows(i)%y)
         end do
 
+        have_other_plots = plot_count > 0
         if (.not. state%xlim_set) then
-            state%x_min = ax_min
-            state%x_max = ax_max
+            if (have_other_plots) then
+                state%x_min = min(state%x_min, ax_min)
+                state%x_max = max(state%x_max, ax_max)
+            else
+                state%x_min = ax_min
+                state%x_max = ax_max
+            end if
         end if
         if (.not. state%ylim_set) then
-            state%y_min = ay_min
-            state%y_max = ay_max
+            if (have_other_plots) then
+                state%y_min = min(state%y_min, ay_min)
+                state%y_max = max(state%y_max, ay_max)
+            else
+                state%y_min = ay_min
+                state%y_max = ay_max
+            end if
         end if
         state%x_min_transformed = apply_scale_transform(state%x_min, &
             state%xscale, state%symlog_threshold, &

--- a/src/figures/plot_types/fortplot_figure_streamlines.f90
+++ b/src/figures/plot_types/fortplot_figure_streamlines.f90
@@ -7,6 +7,7 @@ module fortplot_figure_streamlines
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: plot_data_t, arrow_data_t, PLOT_TYPE_LINE
     use fortplot_figure_initialization, only: figure_state_t
+    use fortplot_scales, only: apply_scale_transform
     use fortplot_streamplot_arrow_utils, only: compute_streamplot_arrows, &
                                                map_grid_index_to_coord, &
                                                replace_stream_arrows, &
@@ -120,7 +121,10 @@ contains
             return
         end if
 
-        ! Update data ranges for streamplot
+        ! Update data ranges for streamplot.
+        ! Arrow-only mode adds no plot entries, so the usual data-range update
+        ! after add_plot never runs; mirror x_min/x_max into the transformed
+        ! ranges that the rendering pipeline consumes.
         if (.not. state%xlim_set) then
             state%x_min = minval(x)
             state%x_max = maxval(x)
@@ -129,6 +133,14 @@ contains
             state%y_min = minval(y)
             state%y_max = maxval(y)
         end if
+        state%x_min_transformed = apply_scale_transform(state%x_min, &
+            state%xscale, state%symlog_threshold)
+        state%x_max_transformed = apply_scale_transform(state%x_max, &
+            state%xscale, state%symlog_threshold)
+        state%y_min_transformed = apply_scale_transform(state%y_min, &
+            state%yscale, state%symlog_threshold)
+        state%y_max_transformed = apply_scale_transform(state%y_max, &
+            state%yscale, state%symlog_threshold)
 
         ! Generate streamlines using matplotlib algorithm
         call streamplot_matplotlib(x, y, u, v, plot_density, trajectories, &

--- a/src/figures/rendering/fortplot_figure_plot_renderers.f90
+++ b/src/figures/rendering/fortplot_figure_plot_renderers.f90
@@ -224,7 +224,10 @@ contains
     end subroutine render_quiver_plot
 
     subroutine render_streamplot_arrows(backend, arrows)
-        !! Render queued streamplot arrows after plot lines are drawn
+        !! Render queued streamplot arrows after plot lines are drawn.
+        !! Uses draw_arrowhead (head-only glyph) so a normalized direction
+        !! vector does not get scaled into a data-coord shaft like draw_arrow
+        !! does for quiver.
         class(plot_context), intent(inout) :: backend
         type(arrow_data_t), intent(in) :: arrows(:)
         integer :: i
@@ -232,9 +235,9 @@ contains
         if (size(arrows) <= 0) return
 
         do i = 1, size(arrows)
-            call backend%draw_arrow(arrows(i)%x, arrows(i)%y, arrows(i)%dx, &
-                                    arrows(i)%dy, &
-                                    arrows(i)%size, arrows(i)%style)
+            call backend%draw_arrowhead(arrows(i)%x, arrows(i)%y, arrows(i)%dx, &
+                                        arrows(i)%dy, &
+                                        arrows(i)%size, arrows(i)%style)
         end do
     end subroutine render_streamplot_arrows
 

--- a/src/figures/rendering/fortplot_vector_plot_helpers.f90
+++ b/src/figures/rendering/fortplot_vector_plot_helpers.f90
@@ -80,7 +80,9 @@ contains
     end subroutine render_refline_plot
 
     subroutine render_streamplot_arrows(backend, arrows)
-        !! Render queued streamplot arrows after plot lines are drawn
+        !! Render queued streamplot arrows after plot lines are drawn.
+        !! See fortplot_figure_plot_renderers for the canonical version;
+        !! kept in sync so this helpers module stays a drop-in.
         class(plot_context), intent(inout) :: backend
         type(arrow_data_t), intent(in) :: arrows(:)
         integer :: i
@@ -88,9 +90,9 @@ contains
         if (size(arrows) <= 0) return
 
         do i = 1, size(arrows)
-            call backend%draw_arrow(arrows(i)%x, arrows(i)%y, arrows(i)%dx, &
-                                    arrows(i)%dy, &
-                                    arrows(i)%size, arrows(i)%style)
+            call backend%draw_arrowhead(arrows(i)%x, arrows(i)%y, arrows(i)%dx, &
+                                        arrows(i)%dy, &
+                                        arrows(i)%size, arrows(i)%style)
         end do
     end subroutine render_streamplot_arrows
 

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -8,6 +8,7 @@ module fortplot_streamplot_core
     use fortplot_constants, only: EPSILON_COMPARE
     use fortplot_figure_core, only: figure_t
     use fortplot_plot_data, only: arrow_data_t
+    use fortplot_scales, only: apply_scale_transform
     use fortplot_streamplot_matplotlib, only: streamplot_matplotlib
     use fortplot_streamplot_arrow_utils, only: &
         validate_streamplot_arrow_parameters, compute_streamplot_arrows, &
@@ -123,7 +124,10 @@ contains
     end subroutine setup_streamplot_parameters
 
     subroutine update_streamplot_ranges(self, x, y)
-        !! Update figure data ranges for streamplot
+        !! Update figure data ranges for streamplot.
+        !! Arrow-only mode adds no plot entries, so the usual data-range update
+        !! after add_plot never runs; mirror x_min/x_max into the transformed
+        !! ranges that the rendering pipeline consumes.
         class(figure_t), intent(inout) :: self
         real(wp), contiguous, intent(in) :: x(:), y(:)
 
@@ -135,6 +139,14 @@ contains
             self%state%y_min = minval(y)
             self%state%y_max = maxval(y)
         end if
+        self%state%x_min_transformed = apply_scale_transform(self%state%x_min, &
+            self%state%xscale, self%state%symlog_threshold)
+        self%state%x_max_transformed = apply_scale_transform(self%state%x_max, &
+            self%state%xscale, self%state%symlog_threshold)
+        self%state%y_min_transformed = apply_scale_transform(self%state%y_min, &
+            self%state%yscale, self%state%symlog_threshold)
+        self%state%y_max_transformed = apply_scale_transform(self%state%y_max, &
+            self%state%yscale, self%state%symlog_threshold)
     end subroutine update_streamplot_ranges
 
     subroutine generate_streamlines(x, y, u, v, density, trajectories, &

--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -28,6 +28,7 @@ module fortplot_spy_backend
         procedure :: set_marker_colors => spy_set_marker_colors
         procedure :: set_marker_colors_with_alpha => spy_set_marker_colors_with_alpha
         procedure :: draw_arrow => spy_draw_arrow
+        procedure :: draw_arrowhead => spy_draw_arrowhead
         procedure :: get_ascii_output => spy_get_ascii_output
         procedure :: get_width_scale => spy_get_width_scale
         procedure :: get_height_scale => spy_get_height_scale
@@ -154,6 +155,14 @@ contains
 
         this%unexpected_calls = this%unexpected_calls + 1
     end subroutine spy_draw_arrow
+
+    subroutine spy_draw_arrowhead(this, x, y, dx, dy, size, style)
+        class(spy_context_t), intent(inout) :: this
+        real(wp), intent(in) :: x, y, dx, dy, size
+        character(len=*), intent(in) :: style
+
+        this%unexpected_calls = this%unexpected_calls + 1
+    end subroutine spy_draw_arrowhead
 
     function spy_get_ascii_output(this) result(output)
         class(spy_context_t), intent(in) :: this

--- a/test/plot_types/vector/test_streamplot_arrow_data_ranges.f90
+++ b/test/plot_types/vector/test_streamplot_arrow_data_ranges.f90
@@ -1,0 +1,96 @@
+program test_streamplot_arrow_data_ranges
+    !! Verify streamplot with arrowsize>0 keeps the user's data range on the
+    !! visible axis. Regression test for the bug where arrow-only mode added
+    !! no plot entries, so calculate_figure_data_ranges fell back to its
+    !! default 0..1 range and the rendered axes collapsed away from the
+    !! actual x/y span.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, streamplot, xlabel, ylabel, title, savefig
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    integer, parameter :: nx = 20, ny = 20
+    real(wp) :: x(nx), y(ny), u(nx, ny), v(nx, ny)
+    integer :: i, j
+    character(len=*), parameter :: outfile = &
+        'build/test/output/streamplot_arrow_data_ranges.txt'
+    logical :: dir_ok, file_exists
+    integer :: file_size, unit, ios
+    character(len=512) :: line
+    logical :: has_neg_range, has_pos_range, found_content
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    do i = 1, nx
+        x(i) = -2.0_wp + 4.0_wp * real(i - 1, wp) / real(nx - 1, wp)
+    end do
+    do j = 1, ny
+        y(j) = -2.0_wp + 4.0_wp * real(j - 1, wp) / real(ny - 1, wp)
+    end do
+
+    do j = 1, ny
+        do i = 1, nx
+            u(i, j) = -y(j)
+            v(i, j) =  x(i)
+        end do
+    end do
+
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call streamplot(x, y, u, v, density=1.0_wp, arrowsize=1.5_wp, arrowstyle='->')
+    call xlabel('X')
+    call ylabel('Y')
+    call title('Streamplot Arrow Data Range Test')
+    call savefig(outfile)
+
+    inquire(file=outfile, exist=file_exists, size=file_size)
+    if (.not. file_exists) then
+        print *, "FAIL: streamplot savefig did not create ", outfile
+        stop 1
+    end if
+    if (file_size <= 0) then
+        print *, "FAIL: streamplot output file is empty"
+        stop 1
+    end if
+
+    has_neg_range = .false.
+    has_pos_range = .false.
+    found_content = .false.
+
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, "FAIL: cannot read ", outfile
+        stop 1
+    end if
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        found_content = .true.
+        if (index(line, '-2.0') > 0 .or. index(line, '-1.5') > 0 .or. &
+            index(line, '-1.0') > 0 .or. index(line, '-0.5') > 0) then
+            has_neg_range = .true.
+        end if
+        if (index(line, '2.0') > 0 .or. index(line, '1.5') > 0) then
+            has_pos_range = .true.
+        end if
+    end do
+    close(unit)
+
+    if (.not. found_content) then
+        print *, "FAIL: streamplot output has no readable content"
+        stop 1
+    end if
+    if (.not. has_neg_range) then
+        print *, "FAIL: streamplot output missing negative axis labels"
+        print *, "      Expected labels such as -2.0, -1.5, -1.0, -0.5"
+        stop 1
+    end if
+    if (.not. has_pos_range) then
+        print *, "FAIL: streamplot output missing positive axis labels"
+        print *, "      Expected labels such as 2.0, 1.5"
+        stop 1
+    end if
+
+    print *, "PASS: streamplot arrow-mode data range preserved"
+
+end program test_streamplot_arrow_data_ranges


### PR DESCRIPTION
## Summary

Streamplot in arrow mode (`arrowsize>0`) was broken on every backend: axes collapsed to the default 0..1 and each arrow drew a full-figure-spanning shaft. Both issues are visible on the live docs page (`page/examples/streamplot_demo.html`) on the *Streamline Plot Demo - With Arrows* image.

Two root causes:

1. **`draw_arrow` has quiver semantics.** It interprets `(dx,dy)` as a data-coord vector and draws a shaft of that length in pixels. `compute_streamplot_arrows` stores `(dx,dy)` as a normalised unit direction, so the shaft came out roughly one data-unit-in-pixels long — full plot width with the broken 0..1 axes. Fix: new abstract `draw_arrowhead` on `plot_context`, head-only glyph; implemented for raster, PDF, SVG, ASCII, spy. `render_streamplot_arrows` calls `draw_arrowhead`. Quiver `draw_arrow` is unchanged.

2. **Arrow-only streamplot adds no plot entries**, so the pre-render `calculate_figure_data_ranges` reset the primary axis to its 0..1 default. Fix: update the streamplot range helpers to also set the transformed ranges and fold the queued arrow positions back into the primary axis range in `compute_all_data_ranges`.

## Verification

`make build` clean. `make test` passes:

```
ALL TESTS PASSED (fpm test)
```

`make verify-artifacts`:

```
Artifact verification passed.
```

New regression test `test/plot_types/vector/test_streamplot_arrow_data_ranges.f90`:

```
PASS: streamplot arrow-mode data range preserved
```

Before/after of `output/example/fortran/streamplot_demo/streamplot_arrows.png`: before the fix the axes labelled 0.0..0.9 and arrows drew shafts spanning the figure; after the fix the axes show the user's [-2, 2] range with clean arrowhead glyphs distributed over the circular flow field. Same circular field as the existing `streamplot_demo.png` reference, just exposing direction.

## Test plan

- [x] `make build`
- [x] `make test` — all green
- [x] `make verify-artifacts` — passes
- [x] New test exercises arrow-only path on `[-2,2]^2` grid
- [x] Existing `test_streamplot.f90` / `test_streamplot_arrows.f90` still pass