### PR TITLE
fix: streamplot draws trajectory lines AND arrowheads

### DIFF
--- a/src/figures/plot_types/fortplot_figure_streamlines.f90
+++ b/src/figures/plot_types/fortplot_figure_streamlines.f90
@@ -155,37 +155,36 @@ contains
             call replace_stream_arrows(state, computed_arrows)
         end if
 
-        ! Add trajectories to figure only when no arrows are present
-        ! (arrows replace trajectory lines, not supplement them)
-        if (arrow_size_val <= 0.0_wp) then
-            line_width_val = -1.0_wp
-            if (present(linewidth)) line_width_val = linewidth
-            line_color = [0.0_wp, 0.447_wp, 0.698_wp]
-            if (present(color)) line_color = color
+        ! Always draw trajectory lines; matplotlib's streamplot shows the
+        ! lines and decorates them with arrowheads, it does not swap one
+        ! for the other.
+        line_width_val = -1.0_wp
+        if (present(linewidth)) line_width_val = linewidth
+        line_color = [0.0_wp, 0.447_wp, 0.698_wp]
+        if (present(color)) line_color = color
 
-            do i = 1, n_trajectories
-                if (trajectory_lengths(i) <= 1) cycle
+        do i = 1, n_trajectories
+            if (trajectory_lengths(i) <= 1) cycle
 
-                plot_count = plot_count + 1
-                traj_idx = plot_count
+            plot_count = plot_count + 1
+            traj_idx = plot_count
 
-                if (traj_idx > size(plots)) exit
+            if (traj_idx > size(plots)) exit
 
-                plots(traj_idx)%plot_type = PLOT_TYPE_LINE
+            plots(traj_idx)%plot_type = PLOT_TYPE_LINE
 
-                allocate (plots(traj_idx)%x(trajectory_lengths(i)))
-                allocate (plots(traj_idx)%y(trajectory_lengths(i)))
-                do j = 1, trajectory_lengths(i)
-                    plots(traj_idx)%x(j) = map_grid_index_to_coord(trajectories(i, j, 1), x)
-                    plots(traj_idx)%y(j) = map_grid_index_to_coord(trajectories(i, j, 2), y)
-                end do
-
-                plots(traj_idx)%linestyle = '-'
-                plots(traj_idx)%marker = ''
-                plots(traj_idx)%color = line_color
-                plots(traj_idx)%line_width = line_width_val
+            allocate (plots(traj_idx)%x(trajectory_lengths(i)))
+            allocate (plots(traj_idx)%y(trajectory_lengths(i)))
+            do j = 1, trajectory_lengths(i)
+                plots(traj_idx)%x(j) = map_grid_index_to_coord(trajectories(i, j, 1), x)
+                plots(traj_idx)%y(j) = map_grid_index_to_coord(trajectories(i, j, 2), y)
             end do
-        end if
+
+            plots(traj_idx)%linestyle = '-'
+            plots(traj_idx)%marker = ''
+            plots(traj_idx)%color = line_color
+            plots(traj_idx)%line_width = line_width_val
+        end do
     end subroutine streamplot_figure
 
 end module fortplot_figure_streamlines

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -107,19 +107,17 @@ contains
         ! Always clear queued arrows before recalculating
         call self%clear_backend_arrows()
 
-        ! Generate arrows if requested
+        ! Always draw trajectory lines; matplotlib's streamplot shows the
+        ! lines and decorates them with arrowheads, it does not swap one
+        ! for the other.
+        call add_trajectories_to_figure(self, trajectories, n_trajectories, &
+                                        trajectory_lengths, color, x, y, &
+                                        line_width_val)
+
         if (arrow_size_val > 0.0_wp .and. n_trajectories > 0) then
             call generate_streamplot_arrows(self, trajectories, n_trajectories, &
                                             trajectory_lengths, x, y, arrow_size_val, &
                                             arrow_style_val)
-        end if
-
-        ! Add trajectories to figure only when no arrows are present
-        ! (arrows replace trajectory lines, not supplement them)
-        if (arrow_size_val <= 0.0_wp) then
-            call add_trajectories_to_figure(self, trajectories, n_trajectories, &
-                                            trajectory_lengths, color, x, y, &
-                                            line_width_val)
         end if
     end subroutine setup_streamplot_parameters
 

--- a/test/plot_types/vector/test_streamplot.f90
+++ b/test/plot_types/vector/test_streamplot.f90
@@ -110,11 +110,12 @@ contains
             stop 1
         end if
 
-        ! Default streamplot (with arrows) should not have trajectory plots
+        ! Default streamplot draws trajectory lines decorated with
+        ! arrowheads, matching matplotlib.
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v)
-        if (fig%plot_count > 0) then
-            print *, "ERROR: Expected streamplot with arrows to not generate plots"
+        if (fig%plot_count <= 0) then
+            print *, "ERROR: Expected default streamplot to draw trajectory lines"
             stop 1
         end if
     end subroutine test_streamplot_linewidth_parameter

--- a/test/plot_types/vector/test_streamplot_interface_color.f90
+++ b/test/plot_types/vector/test_streamplot_interface_color.f90
@@ -232,13 +232,13 @@ contains
 
         fig => get_global_figure()
 
-        ! Default streamplot should have arrows, not trajectory plots
-        if (fig%get_plot_count() > 0) then
-            print *, "ERROR: Default streamplot should not generate trajectory plots"
+        ! Default streamplot draws trajectory lines AND arrowheads.
+        if (fig%get_plot_count() <= 0) then
+            print *, "ERROR: Default streamplot should generate trajectory plots"
             stop 1
         end if
 
-        ! But should have stream arrows
+        ! And queues stream arrows
         if (.not. allocated(fig%state%stream_arrows)) then
             print *, "ERROR: Default streamplot should generate stream arrows"
             stop 1


### PR DESCRIPTION
## Summary

Matplotlib's streamplot always draws the streamline curves and decorates them with arrowheads — arrows do not replace lines. PR #1915 misread issue #1913 (which was about the giant `draw_arrow` shafts, fixed independently in #1936) and stripped trajectory rendering whenever `arrowsize>0`. The default streamplot has been arrow-dots-only ever since.

Drop the `arrow_size_val <= 0` gate in both `setup_streamplot_parameters` (procedural path) and `streamplot_figure` (OO path). Update the two tests that codified the wrong "arrows replace plots" invariant.

## Verification

`make test` — `ALL TESTS PASSED (fpm test)`. `make verify-artifacts` — `Artifact verification passed.`

`output/example/fortran/streamplot_demo/streamplot_arrows.png`: now shows the circular flow as concentric streamlines with arrowheads tangent to them, matching matplotlib's `streamplot(..., arrowsize=1.5)`.

## Test plan

- [x] `make build`
- [x] `make test`
- [x] `make verify-artifacts`
- [x] `output/example/fortran/streamplot_demo/streamplot_arrows.png` shows lines + arrowheads on the circular field
- [x] `output/example/fortran/streamplot_demo/streamplot_demo.png` (arrowsize=0) still lines-only