### PR TITLE
fix: use matplotlib 0.8pt for raster axes-spine width instead of hardcoded 1px

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -3,7 +3,7 @@ module fortplot_raster_axes
     !! Orchestrates tick and label rendering through specialized modules
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_line_styles, only: draw_styled_line
-    use fortplot_raster_core, only: raster_image_t
+    use fortplot_raster_core, only: raster_image_t, pt2px
     use fortplot_raster_ticks
     use fortplot_raster_ticks_secondary
     use fortplot_raster_axes_secondary
@@ -32,6 +32,10 @@ module fortplot_raster_axes
     implicit none
 
     private
+
+    real(wp), parameter :: SPINE_WIDTH_PT = 0.8_wp
+        !! matplotlib's rcParams axes.linewidth default. Converted to
+        !! pixels with pt2px(., dpi) at draw time.
 
     ! Primary public interfaces
     public :: raster_draw_axes_and_labels
@@ -233,10 +237,12 @@ contains
         real(wp) :: dummy_pattern(1), pattern_dist
         real(wp) :: x_bottom_left, y_bottom_left, x_bottom_right, y_bottom_right
         real(wp) :: x_top_left, y_top_left
+        real(wp) :: spine_w
 
         line_r = 0.0_wp; line_g = 0.0_wp; line_b = 0.0_wp
         dummy_pattern = 0.0_wp
         pattern_dist = 0.0_wp
+        spine_w = pt2px(SPINE_WIDTH_PT, raster%dpi)
 
         x_bottom_left = real(plot_area%left, wp)
         y_bottom_left = real(plot_area%bottom + plot_area%height, wp)
@@ -248,23 +254,23 @@ contains
         call draw_styled_line(raster%image_data, width, height, &
                               x_bottom_left, y_bottom_left, x_bottom_right, &
                               y_bottom_right, &
-                              line_r, line_g, line_b, 1.0_wp, 'solid', dummy_pattern, &
+                              line_r, line_g, line_b, spine_w, 'solid', dummy_pattern, &
                               0, 0.0_wp, pattern_dist)
 
         call draw_styled_line(raster%image_data, width, height, &
                               x_bottom_left, y_bottom_left, x_top_left, y_top_left, &
-                              line_r, line_g, line_b, 1.0_wp, 'solid', dummy_pattern, &
+                              line_r, line_g, line_b, spine_w, 'solid', dummy_pattern, &
                               0, 0.0_wp, pattern_dist)
 
         call draw_styled_line(raster%image_data, width, height, &
                               x_top_left, y_top_left, x_bottom_right, y_top_left, &
-                              line_r, line_g, line_b, 1.0_wp, 'solid', dummy_pattern, &
+                              line_r, line_g, line_b, spine_w, 'solid', dummy_pattern, &
                               0, 0.0_wp, pattern_dist)
 
         call draw_styled_line(raster%image_data, width, height, &
                               x_bottom_right, y_top_left, x_bottom_right, &
                               y_bottom_right, &
-                              line_r, line_g, line_b, 1.0_wp, 'solid', dummy_pattern, &
+                              line_r, line_g, line_b, spine_w, 'solid', dummy_pattern, &
                               0, 0.0_wp, pattern_dist)
     end subroutine draw_raster_axes_lines
 


### PR DESCRIPTION
## Summary

`draw_raster_axes_lines` in `src/backends/raster/fortplot_raster_axes.f90` drew all four plot-area spines with a hardcoded `1.0_wp` stroke width. matplotlib's `rcParams['axes.linewidth']` default is `0.8pt`, which the existing config layer at `src/spec/fortplot_spec_config_defaults.f90:57` already encodes as `cfg%view%stroke_width = pts_to_px(0.8_wp, dpi)`. The raster path bypassed it.

Mirror the tick-width fix from #1939: add `SPINE_WIDTH_PT = 0.8_wp` and convert with `pt2px(., raster%dpi)` at draw time. At 100 dpi the spines now render at ~1.11 px; at higher dpi they scale instead of staying locked to 1 absolute pixel.

## Verification

```
$ make build
[100%] Project compiled successfully.

$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully
```

Composite loss vs matplotlib reference (basic_plots/simple_plot.png, 100 dpi):

| component | before | after |
|---|---|---|
| pixel | 0.13823 | 0.13854 |
| 1 - SSIM | 0.20854 | 0.20773 |
| KL | 0.03590 | 0.03729 |
| **total** | **0.36472** | **0.36492** |

Loss drifts by +0.00020 (0.05%). SSIM improves; KL gets slightly worse because the slightly heavier dark spines shift the intensity histogram. The change is correctness-oriented (matching the documented matplotlib spec the config already encodes) rather than loss-driven.

## Test plan

- [x] make build
- [x] make test-ci (includes make verify-artifacts)
- [ ] reviewer spot-checks output/example/fortran/basic_plots/simple_plot.png against matplotlib reference