### PR TITLE
fix: secondary raster axes use matplotlib 0.8/0.6pt tick widths

### DIFF
--- a/src/backends/raster/fortplot_raster_ticks_secondary.f90
+++ b/src/backends/raster/fortplot_raster_ticks_secondary.f90
@@ -15,7 +15,7 @@ module fortplot_raster_ticks_secondary
                                   MIN_TICK_LABEL_GAP_PX
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_line_styles, only: draw_styled_line
-    use fortplot_raster_core, only: raster_image_t, scale_px
+    use fortplot_raster_core, only: raster_image_t, scale_px, pt2px
     use fortplot_scales, only: apply_scale_transform
     use fortplot_raster_ticks, only: resolve_tick_font_px
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -32,6 +32,11 @@ module fortplot_raster_ticks_secondary
     public :: raster_draw_y_minor_ticks
 
     integer, parameter :: MINOR_TICK_LENGTH = 4
+
+    real(wp), parameter :: MAJOR_TICK_WIDTH_PT = 0.8_wp
+        !! matplotlib rcParams xtick.major.width / ytick.major.width.
+    real(wp), parameter :: MINOR_TICK_WIDTH_PT = 0.6_wp
+        !! matplotlib rcParams xtick.minor.width / ytick.minor.width.
 
 contains
 
@@ -85,12 +90,14 @@ contains
         integer :: tick_y, tick_left, tick_right, j
         real(wp) :: min_t, max_t, tick_t
         real(wp) :: dummy_pattern(1), pattern_dist
+        real(wp) :: tick_w
 
         min_t = apply_scale_transform(y_min, yscale, symlog_threshold)
         max_t = apply_scale_transform(y_max, yscale, symlog_threshold)
 
         dummy_pattern = 0.0_wp
         pattern_dist = 0.0_wp
+        tick_w = pt2px(MAJOR_TICK_WIDTH_PT, raster%dpi)
 
         do j = 1, size(yticks)
             tick_t = apply_scale_transform(yticks(j), yscale, symlog_threshold)
@@ -112,7 +119,7 @@ contains
                                   real(ytick_colors(1, j), wp)/255.0_wp, &
                                   real(ytick_colors(2, j), &
                                        wp)/255.0_wp, &
-                                  real(ytick_colors(3, j), wp)/255.0_wp, 1.0_wp, &
+                                  real(ytick_colors(3, j), wp)/255.0_wp, tick_w, &
                                   'solid', dummy_pattern, &
                                   0, 0.0_wp, pattern_dist)
         end do
@@ -214,12 +221,14 @@ contains
         integer :: tick_x, tick_top, tick_bottom, j
         real(wp) :: min_t, max_t, tick_t
         real(wp) :: dummy_pattern(1), pattern_dist
+        real(wp) :: tick_w
 
         min_t = apply_scale_transform(x_min, xscale, symlog_threshold)
         max_t = apply_scale_transform(x_max, xscale, symlog_threshold)
 
         dummy_pattern = 0.0_wp
         pattern_dist = 0.0_wp
+        tick_w = pt2px(MAJOR_TICK_WIDTH_PT, raster%dpi)
 
         do j = 1, size(xticks)
             tick_t = apply_scale_transform(xticks(j), xscale, symlog_threshold)
@@ -239,7 +248,7 @@ contains
                                   real(xtick_colors(1, j), wp)/255.0_wp, &
                                   real(xtick_colors(2, j), &
                                        wp)/255.0_wp, &
-                                  real(xtick_colors(3, j), wp)/255.0_wp, 1.0_wp, &
+                                  real(xtick_colors(3, j), wp)/255.0_wp, tick_w, &
                                   'solid', dummy_pattern, &
                                   0, 0.0_wp, pattern_dist)
         end do
@@ -329,7 +338,8 @@ contains
                                   real(tick_x, wp), real(tick_top, wp), &
                                   real(tick_x, wp), real(tick_bottom, wp), &
                                   0.0_wp, 0.0_wp, 0.0_wp, &
-                                  1.0_wp, 'solid', dummy_pattern, 0, 0.0_wp, &
+                                  pt2px(MINOR_TICK_WIDTH_PT, raster%dpi), &
+                                  'solid', dummy_pattern, 0, 0.0_wp, &
                                   pattern_dist)
         end do
     end subroutine raster_draw_x_minor_ticks
@@ -370,7 +380,8 @@ contains
                                   real(tick_left, wp), real(tick_y, wp), &
                                   real(tick_right, wp), real(tick_y, wp), &
                                   0.0_wp, 0.0_wp, 0.0_wp, &
-                                  1.0_wp, 'solid', dummy_pattern, 0, 0.0_wp, &
+                                  pt2px(MINOR_TICK_WIDTH_PT, raster%dpi), &
+                                  'solid', dummy_pattern, 0, 0.0_wp, &
                                   pattern_dist)
         end do
     end subroutine raster_draw_y_minor_ticks


### PR DESCRIPTION
## Summary

\`src/backends/raster/fortplot_raster_ticks_secondary.f90\` hardcoded \`1.0_wp\` at four tick-mark call sites:

- \`raster_draw_y_axis_tick_marks_only_right\` (right-side y ticks)
- \`raster_draw_x_axis_tick_marks_only_top\` (top-side x ticks)
- \`raster_draw_x_minor_ticks\` (minor x ticks)
- \`raster_draw_y_minor_ticks\` (minor y ticks)

Mirror the primary-axis fix from #1939 and #1940. Add two module-level constants:

- \`MAJOR_TICK_WIDTH_PT = 0.8_wp\` (matplotlib \`xtick.major.width\` / \`ytick.major.width\`).
- \`MINOR_TICK_WIDTH_PT = 0.6_wp\` (matplotlib \`xtick.minor.width\` / \`ytick.minor.width\`).

Both convert to pixels via the existing \`pt2px(., raster%dpi)\` helper at draw time, so the ticks scale correctly at non-100 dpi.

## Verification

\`\`\`
\$ make build
[100%] Project compiled successfully.

\$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully
\`\`\`

basic_plots does not exercise secondary or minor ticks, so the composite loss is unchanged. This change is correctness-oriented for plots that use \`secondary_xaxis\`, \`secondary_yaxis\`, or \`minorticks_on\`.

## Test plan

- [x] make build
- [x] make test-ci (includes make verify-artifacts)
- [ ] reviewer spot-checks secondary-axis examples if any are part of the doc suite