### PR TITLE
fix: PDF backend axes / tick widths to matplotlib spec

### DIFF
--- a/src/backends/vector/pdf/fortplot_pdf_axes.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes.f90
@@ -259,9 +259,10 @@ contains
                                 plot_area_height
         real(wp) :: max_y_tick_label_width
 
-        ! Ensure axes are drawn in black independent of prior plot color state
+        ! Ensure axes are drawn in black independent of prior plot color state.
+        ! 0.8pt matches matplotlib's axes.linewidth default.
         call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
-        call ctx%set_line_width(1.0_wp)
+        call ctx%set_line_width(0.8_wp)
 
         call draw_pdf_frame_with_area(ctx, plot_area_left, plot_area_bottom, &
                                       plot_area_width, plot_area_height)

--- a/src/backends/vector/pdf/fortplot_pdf_axes_drawing.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_drawing.f90
@@ -60,9 +60,9 @@ contains
         real(wp) :: tick_length, bottom_y
 
         ! Ensure tick marks are stroked in black and solid regardless of prior
-        ! drawing state.
+        ! drawing state. 0.8pt matches matplotlib's xtick.major.width default.
         call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
-        call ctx%set_line_width(1.0_wp)
+        call ctx%set_line_width(0.8_wp)
         ctx%stream_data = ctx%stream_data//'[] 0 d'//new_line('a')
 
         tick_length = PDF_TICK_SIZE
@@ -172,8 +172,9 @@ contains
         character(len=2048) :: tick_cmd
         real(wp) :: bottom_y
 
+        ! 0.6pt matches matplotlib's xtick.minor.width default.
         call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
-        call ctx%set_line_width(0.5_wp)
+        call ctx%set_line_width(0.6_wp)
         ctx%stream_data = ctx%stream_data//'[] 0 d'//new_line('a')
 
         bottom_y = plot_bottom


### PR DESCRIPTION
## Summary

The PDF backend hardcoded \`set_line_width\` values that do not match matplotlib's \`rcParams\` defaults:

- \`fortplot_pdf_axes.f90:264\` set the frame stroke to \`1.0pt\` before drawing the plot-area rectangle. matplotlib \`axes.linewidth\` is \`0.8pt\`.
- \`fortplot_pdf_axes_drawing.f90:65\` set the major-tick stroke to \`1.0pt\`. matplotlib \`xtick.major.width\` / \`ytick.major.width\` is \`0.8pt\`.
- \`fortplot_pdf_axes_drawing.f90:176\` set the minor-tick stroke to \`0.5pt\`. matplotlib \`xtick.minor.width\` / \`ytick.minor.width\` is \`0.6pt\`.

Switch each literal to the matplotlib default. PDF \`set_line_width\` takes points directly, so no DPI conversion is needed.

Mirrors the raster-backend fixes in #1939, #1940, #1941 so the two backends produce visually equivalent output for the same input figure.

## Verification

\`\`\`
\$ make build
[100%] Project compiled successfully.

\$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully
\`\`\`

## Test plan

- [x] make build
- [x] make test-ci (includes make verify-artifacts)
- [ ] reviewer spot-checks any PDF example that uses major or minor ticks