### PR TITLE
fix: PDF secondary axes tick width to matplotlib 0.8pt

### DIFF
--- a/src/backends/vector/pdf/fortplot_pdf_secondary_axes.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_secondary_axes.f90
@@ -59,8 +59,10 @@ contains
 
         right_edge = plot_area_left + plot_area_width
 
+        ! 0.8pt matches matplotlib's xtick.major.width / ytick.major.width
+        ! default for secondary-axis tick marks.
         call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
-        call ctx%set_line_width(1.0_wp)
+        call ctx%set_line_width(0.8_wp)
         ctx%stream_data = ctx%stream_data//'[] 0 d'//new_line('a')
 
         do i = 1, num_y_ticks
@@ -134,8 +136,10 @@ contains
 
         top_edge = plot_area_bottom + plot_area_height
 
+        ! 0.8pt matches matplotlib's xtick.major.width / ytick.major.width
+        ! default for secondary-axis tick marks.
         call ctx%set_color(0.0_wp, 0.0_wp, 0.0_wp)
-        call ctx%set_line_width(1.0_wp)
+        call ctx%set_line_width(0.8_wp)
         ctx%stream_data = ctx%stream_data//'[] 0 d'//new_line('a')
 
         do i = 1, num_x_ticks


### PR DESCRIPTION
## Summary

\`fortplot_pdf_secondary_axes.f90\` had two more \`set_line_width(1.0_wp)\` calls (lines 63 and 138) for the right-axis and top-axis tick marks. Switch to \`0.8_wp\` to match matplotlib's \`xtick.major.width\` / \`ytick.major.width\` default and keep the PDF backend's primary and secondary axes consistent with each other and with the raster backend.

Mirrors #1939, #1940, #1941, #1942.

## Verification

\`\`\`
\$ make build
[100%] Project compiled successfully.

\$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully
\`\`\`