### PR TITLE
refactor: dedupe MAJOR_TICK_WIDTH_PT and MINOR_TICK_WIDTH_PT

### DIFF
--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -31,10 +31,12 @@ module fortplot_raster_ticks
     public :: Y_TICK_LABEL_LEFT_PAD, X_TICK_LABEL_TOP_PAD
     public :: compute_non_overlapping_mask
     public :: resolve_tick_font_px
+    public :: MAJOR_TICK_WIDTH_PT, MINOR_TICK_WIDTH_PT
 
     real(wp), parameter :: MAJOR_TICK_WIDTH_PT = 0.8_wp
-        !! matplotlib's rcParams ticks.major.width default. Converted to
-        !! pixels with pt2px(., dpi) at draw time.
+        !! matplotlib's rcParams xtick.major.width / ytick.major.width.
+    real(wp), parameter :: MINOR_TICK_WIDTH_PT = 0.6_wp
+        !! matplotlib's rcParams xtick.minor.width / ytick.minor.width.
 
 contains
 

--- a/src/backends/raster/fortplot_raster_ticks_secondary.f90
+++ b/src/backends/raster/fortplot_raster_ticks_secondary.f90
@@ -17,7 +17,8 @@ module fortplot_raster_ticks_secondary
     use fortplot_raster_line_styles, only: draw_styled_line
     use fortplot_raster_core, only: raster_image_t, scale_px, pt2px
     use fortplot_scales, only: apply_scale_transform
-    use fortplot_raster_ticks, only: resolve_tick_font_px
+    use fortplot_raster_ticks, only: resolve_tick_font_px, &
+                                     MAJOR_TICK_WIDTH_PT, MINOR_TICK_WIDTH_PT
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -32,11 +33,6 @@ module fortplot_raster_ticks_secondary
     public :: raster_draw_y_minor_ticks
 
     integer, parameter :: MINOR_TICK_LENGTH = 4
-
-    real(wp), parameter :: MAJOR_TICK_WIDTH_PT = 0.8_wp
-        !! matplotlib rcParams xtick.major.width / ytick.major.width.
-    real(wp), parameter :: MINOR_TICK_WIDTH_PT = 0.6_wp
-        !! matplotlib rcParams xtick.minor.width / ytick.minor.width.
 
 contains
 


### PR DESCRIPTION
Single source of truth for the tick-width constants from #1939 / #1941.

`fortplot_raster_ticks_secondary.f90` now imports `MAJOR_TICK_WIDTH_PT` and `MINOR_TICK_WIDTH_PT` from `fortplot_raster_ticks` instead of redeclaring them. Drift between the two definitions is now a single-edit fix.

## Verification

```
$ make build && make test-ci
[100%] Project compiled successfully.
Artifact verification passed.
CI essential test suite completed successfully
```