### PR TITLE
fix: legend border width matches axes frame (0.5 -> 0.8 pt)

### DIFF
--- a/src/ui/fortplot_legend_drawing.f90
+++ b/src/ui/fortplot_legend_drawing.f90
@@ -340,7 +340,10 @@ contains
         real(wp), intent(in) :: x1, y1, x2, y2
 
         if (backend%width > 80 .or. backend%height > 24) then
-            call backend%set_line_width(0.5_wp)
+            ! 0.8pt matches the axes frame width (matplotlib axes.linewidth
+            ! default) so the legend border keeps the same stroke weight as
+            ! the surrounding axes box.
+            call backend%set_line_width(0.8_wp)
         end if
         call backend%set_line_style('-')
         call backend%color(0.0_wp, 0.0_wp, 0.0_wp)


### PR DESCRIPTION
draw_legend_border in fortplot_legend_drawing.f90 has a comment saying the border 'matches axes frame style' but called set_line_width(0.5_wp) while the axes frame now draws at 0.8pt after #1939 / #1940 / #1942 / #1943.

Switch the legend border to 0.8_wp so the comment is true again.

## Verification

```
$ make build && make test-ci
[100%] Project compiled successfully.
Artifact verification passed.
CI essential test suite completed successfully
```