### PR TITLE
docs: correct misleading 'matplotlib default' on TITLE_FONT_SIZE_PT

### DIFF
--- a/src/text/fortplot_text_layout.f90
+++ b/src/text/fortplot_text_layout.f90
@@ -22,7 +22,12 @@ module fortplot_text_layout
 
     integer, parameter :: DEFAULT_FONT_SIZE = 16  ! ~12pt at 96 DPI
     integer, parameter :: TITLE_FONT_SIZE = 20     ! ~15pt at 96 DPI
-    real(wp), parameter :: TITLE_FONT_SIZE_PT = 14.0_wp  ! Title font size in points (matplotlib default)
+    real(wp), parameter :: TITLE_FONT_SIZE_PT = 14.0_wp
+        !! Title font size in points. fortplot's chosen default; matplotlib's
+        !! axes.titlesize / figure.titlesize default is "large" which
+        !! resolves to 12pt at the default font.size of 10pt. 14pt was
+        !! chosen here to give the title a more visible weight than the
+        !! axis labels rendered at DEFAULT_FONT_SIZE.
     integer, parameter :: LABEL_FONT_SIZE = 16     ! ~12pt at 96 DPI
     integer, parameter :: TICK_FONT_SIZE = 13      ! ~10pt at 96 DPI
 


### PR DESCRIPTION
TITLE_FONT_SIZE_PT = 14.0 was annotated 'Title font size in points (matplotlib default)' but matplotlib's axes.titlesize and figure.titlesize both default to 'large' which resolves to 12pt at the default font.size = 10. fortplot's 14pt is a deliberate choice for more visible weight relative to the axis labels.

Expand the docstring to record fortplot's choice and the actual matplotlib default. No code or value change.

## Verification

```
$ make build && make test-ci
[100%] Project compiled successfully.
Artifact verification passed.
CI essential test suite completed successfully
```