### PR TITLE
fix: center bar-chart x labels in ASCII backend

### DIFF
--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -168,12 +168,16 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
             associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
                            real(plot_width - 2, wp)) + 1, &
                          sy => plot_height)
-                call add_text_element(text_elements, num_text_elements, &
-                                      real(max(1, min(sx, plot_width - 1)), wp), &
-                                      real(sy, wp), &
-                                      trim(tick_label), &
-                                      current_r, current_g, current_b, &
-                                      x_min, x_max, y_min, y_max, plot_width, plot_height)
+                ! Center the label on the tick column rather than left-anchoring it,
+                ! so labels sit under the bar/tick they name (issue #1957).
+                associate (start_col => sx - len_trim(tick_label)/2)
+                    call add_text_element(text_elements, num_text_elements, &
+                                          real(max(1, min(start_col, plot_width - 1)), wp), &
+                                          real(sy, wp), &
+                                          trim(tick_label), &
+                                          current_r, current_g, current_b, &
+                                          x_min, x_max, y_min, y_max, plot_width, plot_height)
+                end associate
             end associate
         end do
     end subroutine render_ascii_x_ticks


### PR DESCRIPTION
## Summary

In the ASCII backend, bar-chart x-tick labels were left-anchored at their tick column. The label's left edge started at the tick column, so longer labels drifted right of the bar they name, with the offset growing with label length.

`render_ascii_x_ticks` now shifts the start column left by half the label length (`sx - len_trim(label)/2`), clamped to the plot bounds, centering each label on its tick column. Custom and numeric x ticks share this path, so both are fixed. Y-tick labels are unchanged (left-aligned by design).

Closes #1957

## Verification

Commands:

```
make build            # passes
fpm test --target test_categorical_axis test_grouped_bar_ticks test_ascii   # all PASS
make verify-artifacts # Artifact verification passed.
```

Label centering from `output/example/fortran/bar_chart_demo/categorical_labels.txt`.

Before (left-anchored, from issue #1957):

```
bar cols  6-18 center 12.0 | label Apples   center 13.5 | offset +1.5
bar cols 20-32 center 26.0 | label Oranges  center 29.0 | offset +3.0
bar cols 34-48 center 41.0 | label Bananas  center 44.0 | offset +3.0
bar cols 50-62 center 56.0 | label Grapes   center 58.5 | offset +2.5
bar cols 64-76 center 70.0 | label Mangoes  center 74.0 | offset +4.0
```

After (centered):

```
Apples   bar cols  6-18 center 12.0 | label center 10.5 | offset -1.5
Oranges  bar cols 21-32 center 26.5 | label center 26.0 | offset -0.5
Bananas  bar cols 35-47 center 41.0 | label center 41.0 | offset +0.0
Grapes   bar cols 50-61 center 55.5 | label center 55.5 | offset +0.0
Mangoes  bar cols 64-76 center 70.0 | label center 71.0 | offset +1.0
```

Offsets collapse from a consistent right-drift of +1.5 to +4.0 down to the -1.5 to +1.0 range expected from integer rounding of half-widths.
