### PR TITLE
fix: honor scatter s=/markersize in marker rendering

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -226,10 +226,16 @@ contains
                             this%legend_lines, this%num_legend_lines, unit)
     end subroutine ascii_save_to_unit
 
-    subroutine ascii_draw_marker(this, x, y, style)
+    subroutine ascii_draw_marker(this, x, y, style, size)
         class(ascii_context), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
+        real(wp), intent(in), optional :: size
+
+        ! ASCII markers are single glyphs; per-point size has no raster meaning.
+        if (present(size)) then
+            associate (unused => size); end associate
+        end if
 
         call draw_ascii_marker(this%canvas, x, y, style, &
                                this%x_min, this%x_max, this%y_min, this%y_max, &

--- a/src/backends/memory/fortplot_marker_rendering.f90
+++ b/src/backends/memory/fortplot_marker_rendering.f90
@@ -26,10 +26,10 @@ contains
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
 
-        real(wp) :: x_scaled, y_scaled
+        real(wp) :: x_scaled, y_scaled, marker_area
         real(wp) :: marker_rgb(3)
         real(wp) :: edge_rgb(3), face_rgb(3)
-        logical :: has_point_edgecolors, has_point_linewidths
+        logical :: has_point_edgecolors, has_point_linewidths, has_point_sizes
         integer :: i
 
         associate (dxmin => x_min_t, dxmax => x_max_t, dymin => y_min_t, &
@@ -55,6 +55,7 @@ contains
         if (plot_data%marker_facecolor_set) face_rgb = plot_data%marker_facecolor
         has_point_edgecolors = allocated(plot_data%scatter_edgecolors)
         has_point_linewidths = allocated(plot_data%scatter_linewidths)
+        has_point_sizes = allocated(plot_data%scatter_sizes)
 
         if (plot_data%marker_linewidth >= 0.0_wp) then
             call backend%set_line_width(plot_data%marker_linewidth)
@@ -86,10 +87,16 @@ contains
                         plot_data%marker_face_alpha)
                 end if
             end if
+            marker_area = plot_data%scatter_size_default
+            if (has_point_sizes) then
+                if (i <= size(plot_data%scatter_sizes)) then
+                    marker_area = plot_data%scatter_sizes(i)
+                end if
+            end if
             x_scaled = apply_scale_transform(plot_data%x(i), xscale, &
                                              symlog_threshold)
             y_scaled = apply_scale_transform(plot_data%y(i), yscale, symlog_threshold)
-            call backend%draw_marker(x_scaled, y_scaled, plot_data%marker)
+            call backend%draw_marker(x_scaled, y_scaled, plot_data%marker, marker_area)
         end do
     end subroutine render_markers
 

--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -20,7 +20,8 @@ module fortplot_raster
     use fortplot_logging, only: log_error
     use fortplot_errors, only: fortplot_error_t, ERROR_INTERNAL
     use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, &
+    use fortplot_markers, only: get_marker_size, marker_size_scale, &
+                                MARKER_CIRCLE, MARKER_SQUARE, &
                                 MARKER_DIAMOND, MARKER_CROSS
     use fortplot_raster_drawing, only: draw_line_distance_aa, blend_pixel, &
                                        distance_point_to_line_segment, &
@@ -150,16 +151,18 @@ module fortplot_raster
             character(len=*), intent(in) :: filename
         end subroutine raster_save_dummy
 
-        module subroutine raster_draw_marker(this, x, y, style)
+        module subroutine raster_draw_marker(this, x, y, style, size)
             class(raster_context), intent(inout) :: this
             real(wp), intent(in) :: x, y
             character(len=*), intent(in) :: style
+            real(wp), intent(in), optional :: size
         end subroutine raster_draw_marker
 
-        module subroutine draw_raster_marker_by_style(this, px, py, style)
+        module subroutine draw_raster_marker_by_style(this, px, py, style, scale)
             class(raster_context), intent(inout) :: this
             real(wp), intent(in) :: px, py
             character(len=*), intent(in) :: style
+            real(wp), intent(in) :: scale
         end subroutine draw_raster_marker_by_style
 
         module subroutine raster_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, &

--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -69,13 +69,17 @@ contains
 
     !! ── Marker drawing ─────────────────────────────────────────────────
 
-    module subroutine raster_draw_marker(this, x, y, style)
+    module subroutine raster_draw_marker(this, x, y, style, size)
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
-        real(wp) :: px, py
+        real(wp), intent(in), optional :: size
+        real(wp) :: px, py, scale
         integer(1) :: r, g, b
         associate (dsl => len_trim(style)); end associate
+
+        scale = 1.0_wp
+        if (present(size)) scale = marker_size_scale(size)
 
         ! Transform coordinates to plot area
         px = (x - this%x_min)/(this%x_max - this%x_min)*real(this%plot_area%width, wp) &
@@ -87,17 +91,18 @@ contains
 
         ! Fixed marker centering for Issue #333: align markers with line centers
         ! Apply sub-pixel adjustment to match line drawing coordinate conventions
-        call draw_raster_marker_by_style(this, px - 0.5_wp, py - 0.5_wp, style)
+        call draw_raster_marker_by_style(this, px - 0.5_wp, py - 0.5_wp, style, scale)
     end subroutine raster_draw_marker
 
-    module subroutine draw_raster_marker_by_style(this, px, py, style)
+    module subroutine draw_raster_marker_by_style(this, px, py, style, scale)
         !! Draw marker using shared style dispatch logic (DRY compliance)
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: px, py
         character(len=*), intent(in) :: style
+        real(wp), intent(in) :: scale
         real(wp) :: marker_size
 
-        marker_size = get_marker_size(style) * this%raster%dpi / REFERENCE_DPI
+        marker_size = get_marker_size(style) * scale * this%raster%dpi / REFERENCE_DPI
 
         select case (trim(style))
         case (MARKER_CIRCLE)

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -136,10 +136,11 @@ module fortplot_pdf
             type(pdf_context_handle) :: ctx
         end function make_coord_context
 
-        module subroutine draw_pdf_marker_wrapper(this, x, y, style)
+        module subroutine draw_pdf_marker_wrapper(this, x, y, style, size)
             class(pdf_context), intent(inout) :: this
             real(wp), intent(in) :: x, y
             character(len=*), intent(in) :: style
+            real(wp), intent(in), optional :: size
         end subroutine draw_pdf_marker_wrapper
 
         module subroutine set_marker_colors_wrapper(this, edge_r, edge_g, edge_b, face_r, &

--- a/src/backends/vector/pdf/fortplot_pdf_draw.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_draw.f90
@@ -323,13 +323,15 @@ contains
         call this%stream_writer%add_to_stream('Q')
     end subroutine fill_heatmap_wrapper
 
-    module subroutine draw_pdf_marker_wrapper(this, x, y, style)
+    module subroutine draw_pdf_marker_wrapper(this, x, y, style, size)
         class(pdf_context), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
+        real(wp), intent(in), optional :: size
 
         call this%update_coord_context()
-        call draw_pdf_marker_at_coords(this%coord_ctx, this%stream_writer, x, y, style)
+        call draw_pdf_marker_at_coords(this%coord_ctx, this%stream_writer, x, y, &
+                                       style, size)
     end subroutine draw_pdf_marker_wrapper
 
     module subroutine set_marker_colors_wrapper(this, edge_r, edge_g, edge_b, face_r, &

--- a/src/backends/vector/pdf/fortplot_pdf_markers.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_markers.f90
@@ -10,6 +10,7 @@ module fortplot_pdf_markers
                                     draw_pdf_square_with_outline, &
                                     draw_pdf_diamond_with_outline, draw_pdf_x_marker
     use fortplot_pdf_coordinate, only: pdf_context_handle, normalize_to_pdf_coords
+    use fortplot_markers, only: marker_size_scale
     implicit none
 
     private
@@ -20,15 +21,17 @@ module fortplot_pdf_markers
 
 contains
 
-    subroutine draw_pdf_marker_at_coords(ctx_handle, stream_writer, x, y, style)
+    subroutine draw_pdf_marker_at_coords(ctx_handle, stream_writer, x, y, style, area)
         type(pdf_context_handle), intent(in) :: ctx_handle
         type(pdf_stream_writer), intent(inout) :: stream_writer
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
+        real(wp), intent(in), optional :: area
         real(wp) :: pdf_x, pdf_y
         real(wp) :: size
 
         size = 5.0_wp
+        if (present(area)) size = size*marker_size_scale(area)
         call normalize_to_pdf_coords(ctx_handle, x, y, pdf_x, pdf_y)
 
         ! Save state for marker drawing

--- a/src/backends/vector/svg/fortplot_svg.f90
+++ b/src/backends/vector/svg/fortplot_svg.f90
@@ -10,6 +10,7 @@ module fortplot_svg
     use fortplot_legend, only: legend_entry_t
     use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
     use fortplot_svg_markers, only: svg_draw_marker_impl
+    use fortplot_markers, only: marker_size_scale
     use fortplot_svg_legend, only: svg_render_legend_impl, svg_calc_legend_dims_impl, &
                                     svg_set_legend_border_impl, svg_calc_legend_pos_impl
     use fortplot_svg_axes, only: svg_render_ylabel_impl, svg_draw_axes_labels_impl
@@ -168,14 +169,18 @@ contains
         call this%add_to_stream(trim(text_elem))
     end subroutine draw_svg_text
 
-    subroutine draw_svg_marker(this, x, y, style)
+    subroutine draw_svg_marker(this, x, y, style, size)
         class(svg_context), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
-        real(wp) :: sx, sy
+        real(wp), intent(in), optional :: size
+        real(wp) :: sx, sy, scale
         character(len=:), allocatable :: elem
         character(len=64) :: fill_color, edge_color
         character(len=64) :: fill_opacity, stroke_opacity, stroke_width
+
+        scale = 1.0_wp
+        if (present(size)) scale = marker_size_scale(size)
 
         call this%normalize_to_svg(x, y, sx, sy)
 
@@ -196,7 +201,8 @@ contains
             max(0.0_wp, this%current_line_width), '"'
 
         call svg_draw_marker_impl(sx, sy, style, fill_color, edge_color, &
-                                  fill_opacity, stroke_opacity, stroke_width, elem)
+                                  fill_opacity, stroke_opacity, stroke_width, elem, &
+                                  scale)
         call this%add_to_stream(trim(elem))
     end subroutine draw_svg_marker
 

--- a/src/backends/vector/svg/fortplot_svg_markers.f90
+++ b/src/backends/vector/svg/fortplot_svg_markers.f90
@@ -11,16 +11,18 @@ contains
 
     subroutine svg_draw_marker_impl(sx, sy, style, fill_color, edge_color, &
                                     fill_opacity, stroke_opacity, stroke_width, &
-                                    svg_elem)
+                                    svg_elem, scale)
         real(wp), intent(in) :: sx, sy
         character(len=*), intent(in) :: style
         character(len=*), intent(in) :: fill_color, edge_color
         character(len=*), intent(in) :: fill_opacity, stroke_opacity, stroke_width
         character(len=:), allocatable, intent(out) :: svg_elem
+        real(wp), intent(in), optional :: scale
         real(wp) :: r, half
         character(len=512) :: local_elem
 
         r = 4.0_wp
+        if (present(scale)) r = r*scale
 
         select case (trim(style))
         case ('o', 'circle')

--- a/src/core/fortplot_context.f90
+++ b/src/core/fortplot_context.f90
@@ -89,11 +89,12 @@ module fortplot_context
             character(len=*), intent(in) :: style
         end subroutine line_style_interface
 
-        subroutine marker_interface(this, x, y, style)
+        subroutine marker_interface(this, x, y, style, size)
             import :: plot_context, wp
             class(plot_context), intent(inout) :: this
             real(wp), intent(in) :: x, y
             character(len=*), intent(in) :: style
+            real(wp), intent(in), optional :: size
         end subroutine marker_interface
 
         subroutine marker_colors_interface(this, edge_r, edge_g, edge_b, face_r, &

--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -121,11 +121,15 @@ contains
         this%unexpected_calls = this%unexpected_calls + 1
     end subroutine spy_set_line_style
 
-    subroutine spy_draw_marker(this, x, y, style)
+    subroutine spy_draw_marker(this, x, y, style, size)
         class(spy_context_t), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
+        real(wp), intent(in), optional :: size
 
+        if (present(size)) then
+            associate (unused => size); end associate
+        end if
         this%unexpected_calls = this%unexpected_calls + 1
     end subroutine spy_draw_marker
 

--- a/src/utilities/fortplot_markers.f90
+++ b/src/utilities/fortplot_markers.f90
@@ -6,6 +6,7 @@ module fortplot_markers
     
     private
     public :: get_marker_size, validate_marker_style, get_default_marker
+    public :: marker_size_scale, DEFAULT_SCATTER_AREA
     public :: MARKER_CIRCLE, MARKER_SQUARE, MARKER_DIAMOND, MARKER_CROSS, MARKER_PLUS, MARKER_STAR
     public :: MARKER_TRIANGLE_UP, MARKER_TRIANGLE_DOWN, MARKER_PENTAGON, MARKER_HEXAGON
     public :: MARKER_DIAMOND_SMALL
@@ -37,7 +38,26 @@ module fortplot_markers
     real(wp), parameter :: SIZE_PENTAGON = 5.2_wp
     real(wp), parameter :: SIZE_HEXAGON = 5.2_wp
 
+    ! matplotlib's default scatter area s (points^2). The fixed marker sizes
+    ! above reproduce this area, so an explicit s == DEFAULT_SCATTER_AREA leaves
+    ! the rendered size unchanged. Marker radius scales with sqrt(s).
+    real(wp), parameter :: DEFAULT_SCATTER_AREA = 20.0_wp
+
 contains
+
+    pure function marker_size_scale(area) result(scale)
+        !! Linear radius scale factor for a matplotlib scatter area `s`.
+        !! s is an area (points^2); radius scales with sqrt(s). Normalized so
+        !! that area == DEFAULT_SCATTER_AREA returns 1 (today's default size).
+        real(wp), intent(in) :: area
+        real(wp) :: scale
+
+        if (area <= 0.0_wp) then
+            scale = 1.0_wp
+        else
+            scale = sqrt(area/DEFAULT_SCATTER_AREA)
+        end if
+    end function marker_size_scale
 
     pure function get_marker_size(style) result(size)
         !! Get standardized marker size for given style


### PR DESCRIPTION
## Summary

`scatter` accepted per-point sizes via `s=` (`scatter_sizes`) and a fallback `scatter_size_default` (from `markersize` or the default 20), but raster rendering never read them, so every marker drew at a fixed per-style size and `s=`/`markersize` had no visible effect.

## Changes

- Extend `marker_interface` (`src/core/fortplot_context.f90`) with an optional per-point `size` (the matplotlib `s` area in points^2). Backward compatible: absent => current default.
- Update all backend `draw_marker` implementations: raster, PDF, SVG, ASCII, spy.
- `render_markers` (`src/backends/memory/fortplot_marker_rendering.f90`) now selects `scatter_sizes(i)` when allocated, else `scatter_size_default`, and passes it to `draw_marker`.
- Add `marker_size_scale` + `DEFAULT_SCATTER_AREA` (`src/utilities/fortplot_markers.f90`): radius scales with `sqrt(s)`, normalized so the default area (20) yields scale `1.0`. `SIZE_*` constants are untouched.

The default appearance is unchanged: `marker_size_scale(20.0) = sqrt(20/20) = 1.0` exactly, applied as a no-op multiply, and the new arg is optional.

## Verification

Before: markers ignored `s=`/`markersize` entirely (root cause documented in #1954: `draw_marker` had no size parameter; `render_markers` never referenced `scatter_sizes`/`scatter_size_default`).

After:

```
make build
[100%] Project compiled successfully.

# scatter + marker tests
fpm test --target test_scatter                  -> Tests passed: 13/13, All scatter tests PASSED!
fpm test --target test_scatter_style_options_1534 -> PASS
fpm test --target test_scatter_wrapper_styles_1544 -> PASS
fpm test --target test_marker_boundary_clipping   -> PASS
fpm test --target test_marker_example_guard       -> PASS
fpm test --target test_markercolor_line_markers   -> PASS
fpm test --target test_missing_markers_986        -> generated
fpm test --target test_svg_backend                -> All SVG backend tests passed
fpm test --target test_matplotlib_api_alignment   -> All matplotlib API alignment tests passed.

make verify-artifacts -> Artifact verification passed.
make test-ci          -> CI essential test suite completed successfully
```

Size-effect measurement (single 'o' marker, 200x200 px, blue marker pixel count via PIL):

```
default scatter         -> 86 marker px
scatter(..., s=[200.0]) -> 558 marker px   (radius ratio ~2.5; sqrt(200/20)=3.16, under-resolved at small pixel counts)
```

`s=` now scales the marker; the default render is a mathematical no-op (scale exactly 1.0), confirmed by the rendering gate passing on the scatter/marker examples.

Closes #1954
