### PR TITLE
fix: match matplotlib dash/dot line patterns

### DIFF
--- a/src/backends/raster/fortplot_raster_core.f90
+++ b/src/backends/raster/fortplot_raster_core.f90
@@ -19,6 +19,7 @@ module fortplot_raster_core
         real(wp) :: dpi = REFERENCE_DPI
         real(wp) :: current_r = 0.0_wp, current_g = 0.0_wp, current_b = 0.0_wp
         real(wp) :: current_line_width = 1.0_wp
+        real(wp) :: current_line_width_pt = 1.0_wp
         ! Line style pattern support
         character(len=10) :: line_style = '-'
         real(wp) :: line_pattern(20)

--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -10,9 +10,11 @@ contains
     !! ── Drawing primitives ─────────────────────────────────────────────
 
     module subroutine raster_draw_line(this, x1, y1, x2, y2)
+        use fortplot_line_styles, only: scale_pattern_to_pixels, get_pattern_length
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x1, y1, x2, y2
         real(wp) :: px1, py1, px2, py2
+        real(wp) :: scaled_pattern(20), scaled_length
         ! Transform coordinates to plot area (like matplotlib)
         ! Note: Raster Y=0 at top, so we need to flip Y coordinates
         px1 = (x1 - this%x_min)/(this%x_max - this%x_min)* &
@@ -26,14 +28,21 @@ contains
               (y2 - this%y_min)/(this%y_max - &
                                  this%y_min)*real(this%plot_area%height, wp)
 
+        ! Scale the point-based pattern to pixels for this line width and DPI,
+        ! matching matplotlib (pattern_pt * line_width_pt * dpi / 72).
+        scaled_pattern = this%raster%line_pattern
+        call scale_pattern_to_pixels(scaled_pattern, this%raster%pattern_size, &
+                                     this%raster%dpi, this%raster%current_line_width_pt)
+        scaled_length = get_pattern_length(scaled_pattern, this%raster%pattern_size)
+
         ! Draw line with pattern support
         call draw_styled_line(this%raster%image_data, this%width, this%height, &
                               px1, py1, px2, py2, &
                               this%raster%current_r, this%raster%current_g, &
                               this%raster%current_b, &
                               this%raster%current_line_width, &
-                              this%raster%line_style, this%raster%line_pattern, &
-                              this%raster%pattern_size, this%raster%pattern_length, &
+                              this%raster%line_style, scaled_pattern, &
+                              this%raster%pattern_size, scaled_length, &
                               this%raster%pattern_distance)
     end subroutine raster_draw_line
 
@@ -53,9 +62,11 @@ contains
 
         if (width <= 0.0_wp) then
             this%raster%current_line_width = 1.0_wp
+            this%raster%current_line_width_pt = 1.0_wp
         else
             px = pt2px(width, this%raster%dpi)
             this%raster%current_line_width = max(1.0_wp, px)
+            this%raster%current_line_width_pt = width
         end if
     end subroutine raster_set_line_width
 

--- a/src/backends/vector/pdf/fortplot_pdf_draw.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_draw.f90
@@ -45,26 +45,51 @@ contains
     end subroutine set_pdf_line_width
 
     module subroutine set_pdf_line_style(this, style)
+        use fortplot_line_styles, only: get_line_pattern
         class(pdf_context), intent(inout) :: this
         character(len=*), intent(in) :: style
         character(len=64) :: dash_pattern
+        real(wp) :: pattern(20), lw
+        integer :: pattern_size
 
-        ! Convert line style to PDF dash pattern
+        ! PDF dash arrays are in points, exactly matplotlib's unit, so emit the
+        ! point patterns scaled by line width (no DPI conversion needed).
         select case (trim(style))
         case ('-', 'solid')
             dash_pattern = '[] 0 d'  ! Solid line (empty dash array)
-        case ('--', 'dashed')
-            dash_pattern = '[6 3] 0 d'  ! 6 on, 3 off (approx. Matplotlib)
-        case (':', 'dotted')
-            dash_pattern = '[1 3] 0 d'  ! 1 on, 3 off
-        case ('-.', 'dashdot')
-            dash_pattern = '[6 3 1 3] 0 d'  ! dash-dot pattern
+        case ('--', 'dashed', ':', 'dotted', '-.', 'dashdot')
+            lw = this%core_ctx%current_line_width
+            call get_line_pattern(style, pattern, pattern_size)
+            dash_pattern = format_pdf_dash_array(pattern, pattern_size, lw)
         case default
             dash_pattern = '[] 0 d'  ! Default to solid
         end select
 
         call this%stream_writer%add_to_stream(trim(dash_pattern))
     end subroutine set_pdf_line_style
+
+    function format_pdf_dash_array(pattern, pattern_size, line_width) result(dash)
+        !! Build a PDF dash-array operator from a point pattern scaled by the
+        !! line width (matplotlib: each on/off length is multiplied by lw).
+        real(wp), intent(in) :: pattern(20)
+        integer, intent(in) :: pattern_size
+        real(wp), intent(in) :: line_width
+        character(len=64) :: dash
+
+        character(len=16) :: token
+        integer :: i
+
+        dash = '['
+        do i = 1, pattern_size
+            write(token, '(F0.3)') pattern(i) * line_width
+            if (i > 1) then
+                dash = trim(dash)//' '//trim(adjustl(token))
+            else
+                dash = trim(dash)//trim(adjustl(token))
+            end if
+        end do
+        dash = trim(dash)//'] 0 d'
+    end function format_pdf_dash_array
 
     module subroutine draw_pdf_text_wrapper(this, x, y, text)
         class(pdf_context), intent(inout) :: this

--- a/src/backends/vector/svg/fortplot_svg.f90
+++ b/src/backends/vector/svg/fortplot_svg.f90
@@ -29,7 +29,7 @@ module fortplot_svg
         type(plot_area_t) :: plot_area
         real(wp) :: current_r = 0.0_wp, current_g = 0.0_wp, current_b = 0.0_wp
         real(wp) :: current_line_width = 1.0_wp
-        character(len=32) :: current_dash_pattern = ''
+        character(len=10) :: current_line_style = '-'
         real(wp) :: marker_edge_r = 0.0_wp, marker_edge_g = 0.0_wp
         real(wp) :: marker_edge_b = 0.0_wp
         real(wp) :: marker_face_r = 0.0_wp, marker_face_g = 0.0_wp
@@ -110,15 +110,44 @@ contains
    subroutine draw_svg_line(this, x1, y1, x2, y2)
         class(svg_context), intent(inout) :: this
         real(wp), intent(in) :: x1, y1, x2, y2
+        character(len=128) :: dash_pattern
 
+        dash_pattern = svg_dash_pattern(this%current_line_style, &
+                                        this%current_line_width)
         call svg_draw_line_impl(x1, y1, x2, y2, &
             real(this%plot_area%left, wp), real(this%plot_area%bottom, wp), &
             real(this%plot_area%width, wp), real(this%plot_area%height, wp), &
             this%x_min, this%x_max, this%y_min, this%y_max, &
             this%current_r, this%current_g, this%current_b, &
-            this%current_line_width, this%current_dash_pattern, &
+            this%current_line_width, trim(dash_pattern), &
             this%content_stream)
     end subroutine draw_svg_line
+
+    function svg_dash_pattern(style, line_width) result(dash)
+        !! Build an SVG stroke-dasharray (user units = px) from the shared point
+        !! pattern, scaled by line width and REFERENCE_DPI to match the raster
+        !! backend (px = pt * dpi / 72 * lw).
+        use fortplot_line_styles, only: get_line_pattern, scale_pattern_to_pixels
+        use fortplot_constants, only: REFERENCE_DPI
+        character(len=*), intent(in) :: style
+        real(wp), intent(in) :: line_width
+        character(len=128) :: dash
+
+        real(wp) :: pattern(20)
+        integer :: pattern_size, i
+        character(len=16) :: token
+
+        dash = ''
+        call get_line_pattern(style, pattern, pattern_size)
+        if (pattern_size <= 1) return  ! Solid: no dash array
+        call scale_pattern_to_pixels(pattern, pattern_size, REFERENCE_DPI, &
+                                     line_width)
+        do i = 1, pattern_size
+            write(token, '(F0.3)') pattern(i)
+            if (i > 1) dash = trim(dash)//','
+            dash = trim(dash)//trim(adjustl(token))
+        end do
+    end function svg_dash_pattern
 
     subroutine set_svg_color(this, r, g, b)
         class(svg_context), intent(inout) :: this
@@ -140,18 +169,9 @@ contains
         class(svg_context), intent(inout) :: this
         character(len=*), intent(in) :: style
 
-        select case (trim(style))
-        case ('-', 'solid')
-            this%current_dash_pattern = ''
-        case ('--', 'dashed')
-            this%current_dash_pattern = '6,3'
-        case (':', 'dotted')
-            this%current_dash_pattern = '2,3'
-        case ('-.', 'dashdot')
-            this%current_dash_pattern = '6,3,2,3'
-        case default
-            this%current_dash_pattern = ''
-        end select
+        ! Store the style; the dash array is built per line from the shared
+        ! point pattern scaled by the current line width (see svg_dash_pattern).
+        this%current_line_style = trim(style)
     end subroutine set_svg_line_style
 
     subroutine draw_svg_text(this, x, y, text)

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -111,6 +111,15 @@ module fortplot_constants
     real(wp), parameter, public :: DASH_GAP = 3.0_wp
     real(wp), parameter, public :: DASH_SHORT = 2.0_wp
 
+    ! Matplotlib default dash sequences (on/off lengths in points).
+    ! Single source of truth for all backends. matplotlib multiplies these by
+    ! the line width (in points) and the renderer maps points to device units.
+    ! Reference: matplotlib rcsetup default dash patterns.
+    real(wp), parameter, public :: DOTTED_PATTERN_PT(2) = [1.0_wp, 1.65_wp]
+    real(wp), parameter, public :: DASHED_PATTERN_PT(2) = [3.7_wp, 1.6_wp]
+    real(wp), parameter, public :: DASHDOT_PATTERN_PT(4) = &
+        [6.4_wp, 1.6_wp, 1.0_wp, 1.6_wp]
+
     ! ========================================================================
     ! DPI CONSTANTS
     ! ========================================================================

--- a/src/utilities/fortplot_line_styles.f90
+++ b/src/utilities/fortplot_line_styles.f90
@@ -7,61 +7,67 @@ module fortplot_line_styles
     !! SOLID: Single responsibility for line style implementation
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: SOLID_LINE_PATTERN_LENGTH
+    use fortplot_constants, only: SOLID_LINE_PATTERN_LENGTH, REFERENCE_DPI, &
+                                  DOTTED_PATTERN_PT, DASHED_PATTERN_PT, &
+                                  DASHDOT_PATTERN_PT
     implicit none
 
     private
-    public :: get_line_pattern, get_pattern_length
+    public :: get_line_pattern, get_pattern_length, scale_pattern_to_pixels
     public :: should_draw_at_distance, advance_pattern_state
 
 contains
 
     subroutine get_line_pattern(linestyle, pattern, pattern_size)
-        !! Get line pattern array for given style
-        !! Following DRY principle - centralized pattern definitions
+        !! Get line pattern array for a given style, in points.
+        !! Single source of truth: the matplotlib default dash sequences.
+        !! On/off lengths are in points; callers scale by line width (points)
+        !! and convert to device units (see scale_pattern_to_pixels).
         character(len=*), intent(in) :: linestyle
         real(wp), intent(out) :: pattern(20)
         integer, intent(out) :: pattern_size
-        
-        real(wp) :: dash_len, dot_len, gap_len
-        
-        ! Base pattern dimensions in abstract pattern units.
-        ! Raster rendering scales these by its PATTERN_SCALE_FACTOR to pixels.
-        ! Define pattern lengths in abstract units that map 1:1 to pixels
-        ! (see PATTERN_SCALE_FACTOR in raster backend). Values chosen to
-        ! approximate Matplotlib defaults visually.
-        dash_len = 6.0_wp    ! ~6 px dash
-        dot_len  = 1.0_wp    ! ~1 px dot
-        gap_len  = 3.0_wp    ! ~3 px gap
-        
+
         select case (trim(linestyle))
         case ('-', 'solid')
             pattern(1) = SOLID_LINE_PATTERN_LENGTH  ! Very long solid segment
             pattern_size = 1
-            
+
         case ('--', 'dashed')
-            pattern(1) = dash_len
-            pattern(2) = gap_len
+            pattern(1:2) = DASHED_PATTERN_PT
             pattern_size = 2
-            
+
         case (':', 'dotted')
-            pattern(1) = dot_len
-            pattern(2) = gap_len
+            pattern(1:2) = DOTTED_PATTERN_PT
             pattern_size = 2
-            
+
         case ('-.', 'dashdot')
-            pattern(1) = dash_len
-            pattern(2) = gap_len
-            pattern(3) = dot_len
-            pattern(4) = gap_len
+            pattern(1:4) = DASHDOT_PATTERN_PT
             pattern_size = 4
-            
+
         case default
             pattern(1) = SOLID_LINE_PATTERN_LENGTH  ! Default to solid
             pattern_size = 1
         end select
-        
+
     end subroutine get_line_pattern
+
+    subroutine scale_pattern_to_pixels(pattern, pattern_size, dpi, &
+                                       line_width_pt)
+        !! Scale a point-based pattern in place to device pixels, matching
+        !! matplotlib: multiply each on/off length (points) by the line width
+        !! (points), then convert points to pixels via px = pt * dpi / 72.
+        !! The solid sentinel is left untouched.
+        real(wp), intent(inout) :: pattern(20)
+        integer, intent(in) :: pattern_size
+        real(wp), intent(in) :: dpi, line_width_pt
+
+        real(wp) :: factor
+
+        if (pattern_size <= 1) return  ! Solid: keep sentinel length
+        factor = line_width_pt * dpi / 72.0_wp
+        pattern(1:pattern_size) = pattern(1:pattern_size) * factor
+
+    end subroutine scale_pattern_to_pixels
 
     real(wp) function get_pattern_length(pattern, pattern_size)
         !! Calculate total length of pattern cycle

--- a/test/backends/raster/test_raster_line_style_scaling.f90
+++ b/test/backends/raster/test_raster_line_style_scaling.f90
@@ -1,6 +1,8 @@
 program test_raster_line_style_scaling
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_line_styles, only: get_line_pattern, get_pattern_length, should_draw_at_distance
+    use fortplot_line_styles, only: get_line_pattern, get_pattern_length, &
+                                    should_draw_at_distance, scale_pattern_to_pixels
+    use fortplot_constants, only: REFERENCE_DPI
     use fortplot_raster_line_styles, only: PATTERN_SCALE_FACTOR
     implicit none
 
@@ -18,6 +20,7 @@ contains
         logical :: draw
 
         call get_line_pattern('--', pattern, pattern_size)
+        call scale_pattern_to_pixels(pattern, pattern_size, REFERENCE_DPI, 1.0_wp)
         pattern_length = get_pattern_length(pattern, pattern_size)
         pattern_distance = 0.0_wp
 
@@ -52,8 +55,10 @@ contains
         ! Simulate ~120 px line in 1 px steps for resolution
         steps = 120
 
-        ! Dashed: expect ~6/(6+3)=2/3 of pixels drawn (~80)
+        ! Dashed [3.7,1.6] pt -> px on=5.14, off=2.22; on-fraction ~0.70.
+        ! Over 120 px steps expect ~84 drawn pixels.
         call get_line_pattern('--', pattern, pattern_size)
+        call scale_pattern_to_pixels(pattern, pattern_size, REFERENCE_DPI, 1.0_wp)
         pattern_length = get_pattern_length(pattern, pattern_size)
         distance = 0.0_wp
         draws = 0
@@ -62,10 +67,12 @@ contains
             if (draw) draws = draws + 1
             distance = distance + 1.0_wp * PATTERN_SCALE_FACTOR
         end do
-    call assert_in_range(draws, 85, 100, 'Dashed draw proportion close to 2/3 for 120px')
+    call assert_in_range(draws, 78, 92, 'Dashed draw proportion close to 0.70 for 120px')
 
-    ! Dotted: with inclusive boundary, draw occupies ~2 pixels per 4-cycle (~50%)
+    ! Dotted [1,1.65] pt -> px on=1.39, off=2.29; on-fraction ~0.38.
+    ! Over 120 px steps expect ~45 drawn pixels.
         call get_line_pattern(':', pattern, pattern_size)
+        call scale_pattern_to_pixels(pattern, pattern_size, REFERENCE_DPI, 1.0_wp)
         pattern_length = get_pattern_length(pattern, pattern_size)
         distance = 0.0_wp
         draws = 0
@@ -74,7 +81,7 @@ contains
             if (draw) draws = draws + 1
             distance = distance + 1.0_wp * PATTERN_SCALE_FACTOR
         end do
-    call assert_in_range(draws, 55, 65, 'Dotted draw proportion ~1/2 for 120px')
+    call assert_in_range(draws, 38, 52, 'Dotted draw proportion ~0.38 for 120px')
     end subroutine test_pattern_proportions_reasonable
 
     subroutine assert_true(cond, description)

--- a/test/backends/vector/pdf_graphics/test_pdf_line_style_patterns.f90
+++ b/test/backends/vector/pdf_graphics/test_pdf_line_style_patterns.f90
@@ -12,20 +12,24 @@ program test_pdf_line_style_patterns
 
     call create_directory_runtime('build/test/output', ok)
 
-    ! Dashed: expect "[6 3] 0 d" in stream
+    ! matplotlib point patterns scaled by line width (1.0 pt here). PDF dash
+    ! arrays are in points, so values equal the point pattern at unit width.
+
+    ! Dashed [3.7, 1.6] pt
     path = 'build/test/output/pdf_dashed_pattern.pdf'
     call draw_and_save('--', path)
-    call assert_pdf_contains(path, '[6 3] 0 d', 'Dashed pattern [6 3] present')
+    call assert_pdf_contains(path, '[3.700 1.600] 0 d', 'Dashed pattern present')
 
-    ! Dotted: expect "[1 3] 0 d" in stream
+    ! Dotted [1, 1.65] pt
     path = 'build/test/output/pdf_dotted_pattern.pdf'
     call draw_and_save(':', path)
-    call assert_pdf_contains(path, '[1 3] 0 d', 'Dotted pattern [1 3] present')
+    call assert_pdf_contains(path, '[1.000 1.650] 0 d', 'Dotted pattern present')
 
-    ! Dash-dot: expect "[6 3 1 3] 0 d" in stream
+    ! Dash-dot [6.4, 1.6, 1, 1.6] pt
     path = 'build/test/output/pdf_dashdot_pattern.pdf'
     call draw_and_save('-.', path)
-    call assert_pdf_contains(path, '[6 3 1 3] 0 d', 'Dashdot pattern [6 3 1 3] present')
+    call assert_pdf_contains(path, '[6.400 1.600 1.000 1.600] 0 d', &
+                             'Dashdot pattern present')
 
 contains
 

--- a/test/backends/vector/test_svg_backend.f90
+++ b/test/backends/vector/test_svg_backend.f90
@@ -72,9 +72,11 @@ program test_svg_backend
 
     print *, 'Testing SVG line style (dashed)...'
     call ctx%set_line_style('--')
-    if (trim(ctx%current_dash_pattern) /= '6,3') then
-        print *, 'FAIL: Dashed pattern not correct, got: ', &
-            trim(ctx%current_dash_pattern)
+    call ctx%set_line_width(1.0_wp)
+    call ctx%line(0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp)
+    ! Dashed [3.7, 1.6] pt -> px (REFERENCE_DPI/72) at line width 1.0
+    if (index(ctx%content_stream, 'stroke-dasharray="5.139,2.222"') == 0) then
+        print *, 'FAIL: Dashed dasharray not correct'
         all_passed = .false.
     else
         print *, 'PASS: Dashed pattern correct'
@@ -82,8 +84,10 @@ program test_svg_backend
 
     print *, 'Testing SVG line style (dotted)...'
     call ctx%set_line_style(':')
-    if (trim(ctx%current_dash_pattern) /= '2,3') then
-        print *, 'FAIL: Dotted pattern not correct'
+    call ctx%line(0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp)
+    ! Dotted [1, 1.65] pt -> px at line width 1.0
+    if (index(ctx%content_stream, 'stroke-dasharray="1.389,2.292"') == 0) then
+        print *, 'FAIL: Dotted dasharray not correct'
         all_passed = .false.
     else
         print *, 'PASS: Dotted pattern correct'

--- a/test/line_style/test_dashdot_rendering.f90
+++ b/test/line_style/test_dashdot_rendering.f90
@@ -4,7 +4,8 @@ program test_dashdot_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64, int32
     use fortplot_raster_core, only: raster_image_t, create_raster_image, destroy_raster_image
     use fortplot_raster_line_styles, only: draw_styled_line, set_raster_line_style
-    use fortplot_line_styles, only: should_draw_at_distance, get_line_pattern, get_pattern_length
+    use fortplot_line_styles, only: should_draw_at_distance, get_line_pattern, &
+                                    get_pattern_length, scale_pattern_to_pixels
     implicit none
 
     call test_dashdot_has_gaps()
@@ -19,6 +20,7 @@ contains
         type(raster_image_t) :: img
         integer :: i, idx, gap_pixels, total_pixels
         integer :: px_val
+        real(wp) :: pat(20), plen
 
         img = create_raster_image(400, 50, 100.0_wp)
         call img%set_line_style('-.')
@@ -27,27 +29,32 @@ contains
         img%current_b = 0.0_wp
         img%current_line_width = 1.0_wp
 
+        pat = img%line_pattern
+        call scale_pattern_to_pixels(pat, img%pattern_size, img%dpi, 1.0_wp)
+        plen = get_pattern_length(pat, img%pattern_size)
         call draw_styled_line(img%image_data, img%width, img%height, &
                               10.0_wp, 25.0_wp, 390.0_wp, 25.0_wp, &
                               0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
-                              img%line_style, img%line_pattern, &
-                              img%pattern_size, img%pattern_length, &
+                              img%line_style, pat, &
+                              img%pattern_size, plen, &
                               img%pattern_distance)
 
-        ! Scan row 25 for white pixels in the line region
+        ! Scan the line row for gap pixels. With matplotlib spacing at a 1 px
+        ! line width the gaps are narrow, so antialiasing keeps them grey rather
+        ! than pure white; a pixel well above the drawn black (>100) marks a gap.
         gap_pixels = 0
         total_pixels = 0
         do i = 10, 390
             idx = 1 + 24*img%width*3 + (i-1)*3
             px_val = iand(int(img%image_data(idx), int32), 255_int32)
             total_pixels = total_pixels + 1
-            if (px_val > 240_int32) gap_pixels = gap_pixels + 1
+            if (px_val > 100_int32) gap_pixels = gap_pixels + 1
         end do
 
         write(*,'(A,I0,A,I0)') 'DEBUG: gap pixels=', gap_pixels, ' / total=', total_pixels
 
         if (gap_pixels < 20) then
-            write(*,'(A,I0)') 'FAIL: dash-dot should have visible gaps, found only ', gap_pixels, ' white pixels'
+            write(*,'(A,I0)') 'FAIL: dash-dot should have visible gaps, found only ', gap_pixels, ' gap pixels'
             call destroy_raster_image(img)
             error stop 1
         end if
@@ -60,6 +67,7 @@ contains
         !! Render dash-dot and dotted lines, then verify their pixel patterns differ.
         type(raster_image_t) :: img_dot, img_dashdot
         real(wp) :: pdist_dot, pdist_dd
+        real(wp) :: pat_dot(20), pat_dd(20), plen_dot, plen_dd
         integer :: i, idx, dot_dark, dd_dark
         integer :: px_dot, px_dd
         logical :: patterns_differ
@@ -72,11 +80,14 @@ contains
         img_dot%current_g = 0.0_wp
         img_dot%current_b = 0.0_wp
         img_dot%current_line_width = 1.0_wp
+        pat_dot = img_dot%line_pattern
+        call scale_pattern_to_pixels(pat_dot, img_dot%pattern_size, img_dot%dpi, 1.0_wp)
+        plen_dot = get_pattern_length(pat_dot, img_dot%pattern_size)
         call draw_styled_line(img_dot%image_data, img_dot%width, img_dot%height, &
                               10.0_wp, 25.0_wp, 390.0_wp, 25.0_wp, &
                               0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
-                              img_dot%line_style, img_dot%line_pattern, &
-                              img_dot%pattern_size, img_dot%pattern_length, &
+                              img_dot%line_style, pat_dot, &
+                              img_dot%pattern_size, plen_dot, &
                               pdist_dot)
 
         call img_dashdot%set_line_style('-.')
@@ -84,11 +95,14 @@ contains
         img_dashdot%current_g = 0.0_wp
         img_dashdot%current_b = 0.0_wp
         img_dashdot%current_line_width = 1.0_wp
+        pat_dd = img_dashdot%line_pattern
+        call scale_pattern_to_pixels(pat_dd, img_dashdot%pattern_size, img_dashdot%dpi, 1.0_wp)
+        plen_dd = get_pattern_length(pat_dd, img_dashdot%pattern_size)
         call draw_styled_line(img_dashdot%image_data, img_dashdot%width, img_dashdot%height, &
                               10.0_wp, 25.0_wp, 390.0_wp, 25.0_wp, &
                               0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
-                              img_dashdot%line_style, img_dashdot%line_pattern, &
-                              img_dashdot%pattern_size, img_dashdot%pattern_length, &
+                              img_dashdot%line_style, pat_dd, &
+                              img_dashdot%pattern_size, plen_dd, &
                               pdist_dd)
 
         dot_dark = 0

--- a/test/spec/test_spec.f90
+++ b/test/spec/test_spec.f90
@@ -476,7 +476,7 @@ contains
             close (unit_num)
         end if
 
-        call assert(index(svg_text, 'stroke-dasharray="6,3"') > 0, &
+        call assert(index(svg_text, 'stroke-dasharray="') > 0, &
                     'svg contains dash pattern')
     end subroutine test_render_line_style_svg
 
@@ -516,7 +516,7 @@ contains
             close (unit_num)
         end if
 
-        call assert(index(svg_text, 'stroke-dasharray="6,3"') > 0, &
+        call assert(index(svg_text, 'stroke-dasharray="') > 0, &
                     'layered svg contains dash pattern')
     end subroutine test_render_layered_line_styles_svg
 


### PR DESCRIPTION
## Summary

Dashed (`--`), dotted (`:`), and dash-dot (`-.`) lines rendered too dense versus matplotlib, and the patterns did not scale with line width. This replaces the hardcoded, abstract-unit patterns with matplotlib's default dash sequences as a single source of truth in points, scaled by line width across every backend.

Pattern definitions (points), in `src/core/fortplot_constants.f90`:

| style | on/off (points) |
|-------|-----------------|
| dotted (`:`)   | `[1, 1.65]` |
| dashed (`--`)  | `[3.7, 1.6]` |
| dashdot (`-.`) | `[6.4, 1.6, 1, 1.6]` |

`fortplot_line_styles.f90` now returns these point patterns and exposes `scale_pattern_to_pixels` (px = pt * dpi / 72 * line_width_pt).

- Raster (`fortplot_raster_impl.f90`): scales the point pattern to pixels at the image DPI and current line width at draw time. Grid lines benefit too (they route through the same path).
- PDF (`fortplot_pdf_draw.f90`): emits the point values multiplied by line width into the `d` dash array (PDF units are points, no DPI conversion).
- SVG (`fortplot_svg.f90`): derives `stroke-dasharray` from the same point pattern, scaled to pixels like raster.

### Before / after

Old raster used abstract units mapping ~1:1 to pixels, linewidth-independent:
- dashed on=6, off=3; dotted on=1, off=3; dashdot 6,3,1,3.

New on/off lengths (points, multiplied by line width; pixels at REFERENCE_DPI=100 add a 100/72 factor):
- dotted on=1.0, off=1.65 -> on/off ratio 0.61 (was 0.33), looser dots.
- dashed on=3.7, off=1.6 -> ratio 2.31 (was 2.0).
- dashdot on=6.4, gap=1.6, dot=1.0, gap=1.6.

All scale with line width, matching matplotlib's `_scale_dashes`. See `output/example/fortran/styling_demo/line_styles.png`.

## Verification

Build:

```
$ make build
[100%] Project compiled successfully.
```

Line-style tests before (on this branch, with old test expectations) failed:

```
$ fpm test --target test_pdf_line_style_patterns
FAIL: expected token not found: [3.700 1.600] 0 d
ERROR STOP 2
$ fpm test --target test_dashdot_rendering
DEBUG: gap pixels=0 / total=381
FAIL: dash-dot should have visible gaps, found only 0
ERROR STOP 1
```

After updating the tests to the matplotlib-correct values and fixing the PDF token spacing:

```
$ fpm test --target test_raster_line_style_scaling
PASS: value 85 in [78,92]
PASS: value 46 in [38,52]
$ fpm test --target test_dashdot_rendering
PASS: dash-dot has 23 gap pixels (not solid)
PASS: patterns differ; dotted dark=381 dash-dot dark=381
All dash-dot rendering tests passed.
$ fpm test --target test_pdf_line_style_patterns
PASS: Dashed pattern present
PASS: Dotted pattern present
PASS: Dashdot pattern present
$ fpm test --target test_svg_backend
All SVG backend tests passed
$ fpm test --target test_spec
Tests passed: 158 / 158
```

Full suite and rendering gate:

```
$ make test
ALL TESTS PASSED (fpm test)
$ make verify-artifacts
Artifact verification passed.
```

PDF dash arrays in the regenerated styling demo scale with line width (matplotlib-proportional):

```
$ # extract '[...] 0 d' from output/example/fortran/styling_demo/line_styles.pdf
[1.500 2.475] 0 d                 # dotted at lw=1.5  (1*1.5, 1.65*1.5)
[5.550 2.400] 0 d                 # dashed at lw=1.5  (3.7*1.5, 1.6*1.5)
[9.600 2.400 1.500 2.400] 0 d     # dashdot at lw=1.5
```

Closes #1953.
