### PR TITLE
fix: slim colorbar outline and width to match matplotlib

### DIFF
--- a/src/figures/management/fortplot_figure_colorbar.f90
+++ b/src/figures/management/fortplot_figure_colorbar.f90
@@ -177,7 +177,7 @@ contains
 
         character(len=32) :: loc
         logical :: vertical
-        integer :: bar_px, pad_px
+        integer :: bar_px, region_px, pad_px
         integer :: long_px, shrink_px, delta_px
 
         main = orig
@@ -188,11 +188,12 @@ contains
         if (loc == 'top' .or. loc == 'bottom') vertical = .false.
 
         if (vertical) then
-            bar_px = max(1, int(max(0.01_wp, fraction)*real(orig%width, wp)))
+            ! fraction is the share of the original axes reserved for the
+            ! colorbar region (bar + pad), not the bar width itself.
+            region_px = max(1, int(max(0.01_wp, fraction)*real(orig%width, wp)))
             pad_px = max(0, int(max(0.0_wp, pad)*real(orig%width, wp)))
 
-            main%width = max(1, orig%width - bar_px - pad_px)
-            cb%width = bar_px
+            main%width = max(1, orig%width - region_px - pad_px)
 
             long_px = max(1, orig%height)
             shrink_px = max(1, int(max(0.05_wp, min(1.0_wp, shrink))*real(long_px, wp)))
@@ -200,19 +201,23 @@ contains
             cb%height = shrink_px
             cb%bottom = orig%bottom + delta_px
 
+            ! matplotlib aspect=20: the slender bar width is the bar length
+            ! divided by the aspect ratio, not the full reserved region.
+            bar_px = bar_width_from_aspect(shrink_px, region_px)
+            cb%width = bar_px
+
             if (loc == 'left') then
                 cb%left = orig%left
-                main%left = orig%left + bar_px + pad_px
+                main%left = orig%left + region_px + pad_px
             else
                 main%left = orig%left
                 cb%left = orig%left + main%width + pad_px
             end if
         else
-            bar_px = max(1, int(max(0.01_wp, fraction)*real(orig%height, wp)))
+            region_px = max(1, int(max(0.01_wp, fraction)*real(orig%height, wp)))
             pad_px = max(0, int(max(0.0_wp, pad)*real(orig%height, wp)))
 
-            main%height = max(1, orig%height - bar_px - pad_px)
-            cb%height = bar_px
+            main%height = max(1, orig%height - region_px - pad_px)
 
             long_px = max(1, orig%width)
             shrink_px = max(1, int(max(0.05_wp, min(1.0_wp, shrink))*real(long_px, wp)))
@@ -220,15 +225,29 @@ contains
             cb%width = shrink_px
             cb%left = orig%left + delta_px
 
+            bar_px = bar_width_from_aspect(shrink_px, region_px)
+            cb%height = bar_px
+
             if (loc == 'bottom') then
                 cb%bottom = orig%bottom
-                main%bottom = orig%bottom + bar_px + pad_px
+                main%bottom = orig%bottom + region_px + pad_px
             else
                 main%bottom = orig%bottom
                 cb%bottom = orig%bottom + main%height + pad_px
             end if
         end if
     end subroutine compute_colorbar_plot_areas
+
+    pure integer function bar_width_from_aspect(bar_length_px, region_px) &
+        result(bar_px)
+        !! Slender colorbar bar width from matplotlib aspect=20: width is the
+        !! bar length over the aspect ratio, clamped to the reserved region.
+        integer, intent(in) :: bar_length_px, region_px
+        integer, parameter :: aspect = 20
+
+        bar_px = max(1, nint(real(bar_length_px, wp)/real(aspect, wp)))
+        bar_px = min(bar_px, max(1, region_px))
+    end function bar_width_from_aspect
 
     subroutine get_backend_plot_area(backend, plot_area, supported)
         class(plot_context), intent(in) :: backend
@@ -322,6 +341,10 @@ contains
         logical, intent(in) :: vertical
         real(wp), intent(in) :: vmin, vmax
 
+        ! 0.8pt matches the axes frame width (matplotlib axes.linewidth
+        ! default) so the colorbar outline keeps the same stroke weight as
+        ! the surrounding axes box instead of the backend default.
+        call backend%set_line_width(0.8_wp)
         call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
         if (vertical) then
             call backend%line(0.0_wp, vmin, 1.0_wp, vmin)


### PR DESCRIPTION
## Summary

The colorbar rendered for pcolormesh/scatter/filled-contour plots was much wider than the matplotlib default and its outline was heavier than the axes frame.

- `compute_colorbar_plot_areas` set the bar width directly to `fraction * orig%width`, so the bar took the entire 15% reserved region. It now treats `fraction=0.15` as the reserved region (bar + pad) and derives the bar width from matplotlib's `aspect=20` against the bar length (`bar_width_from_aspect`), giving a slender bar. Main-area layout still reserves the full region so margins are unchanged.
- `render_colorbar_border` never set a line width, so the outline inherited the backend default (1.0 px on raster). It now calls `set_line_width(0.8_wp)` before stroking the four edges, matching the axes frame (matplotlib `axes.linewidth` default), the same value used for the legend border (#1945).

Both backends (PNG, PDF) share these routines, so one change covers both.

Closes #1958

## Verification

Commands:

```
$ make build
[100%] Project compiled successfully.

$ make verify-artifacts
Artifact verification passed.

$ make test-ci
Artifact verification passed.
CI essential test suite completed successfully

$ for t in test_colorbar_custom_ticks test_colorbar_stateful test_colorbar_fontsize \
          test_field_colorbar test_contour_filled_colorbar \
          test_pcolormesh_fast_negative test_pdf_pcolormesh_inline_image; do
    fpm test --target $t; done
# all pass (exit 0); explicit PASS lines:
PASS: colorbar label_fontsize parameter applied (issue #1497)
PASS: fast negative pcolormesh ASCII output contains negative tick labels
PASS: pcolormesh PDF contains image data
```

Pre-existing failure (not introduced here, 1 px top margin):

```
$ fpm test --target test_matplotlib_margins
FAIL: MARGINS DO NOT MATCH MATPLOTLIB   # Plot area top 428 vs expected 427
```

### Before/after measurement

`output/example/fortran/pcolormesh_demo/pcolormesh_basic.png` (640x480, scan row 240), bar measured as the rightmost non-white cluster:

| | bar total width | outline (max dark edge run) |
|---|---|---|
| before | 79 px | 4 px |
| after  | 22 px | 3 px |

The bar drops from ~15% of the plot-area width to a slender strip, and the outline now strokes at the 0.8 pt axes-frame width instead of the backend default. The PDF colorbar renders correctly too (`pdftotext` shows tick labels `1.2 1.0 0.8 0.4 0.0` and axis labels intact).
