### PR TITLE
fix: apply ASCII char-cell aspect once (pie/streamplot)

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -2,6 +2,7 @@ module fortplot_ascii
     !! ASCII terminal plotting backend
 
     use fortplot_context, only: plot_context, setup_canvas
+    use fortplot_constants, only: ASCII_CHAR_ASPECT
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_ascii_utils, only: text_element_t
     use fortplot_ascii_elements, only: draw_ascii_marker, fill_ascii_heatmap, &
@@ -24,8 +25,6 @@ module fortplot_ascii
 
     private
     public :: ascii_context, create_ascii_canvas, ASCII_CHAR_ASPECT
-
-    real(wp), parameter :: ASCII_CHAR_ASPECT = 2.0_wp
 
     type, extends(plot_context) :: ascii_context
         character(len=1), allocatable :: canvas(:, :)

--- a/src/backends/ascii/fortplot_ascii_drawing.f90
+++ b/src/backends/ascii/fortplot_ascii_drawing.f90
@@ -6,7 +6,7 @@ module fortplot_ascii_drawing
     !!
     !! Author: fortplot contributors
 
-    use fortplot_constants, only: EPSILON_COMPARE
+    use fortplot_constants, only: EPSILON_COMPARE, ASCII_CHAR_ASPECT
     use fortplot_ascii_utils, only: get_char_density, ASCII_CHARS
     use fortplot_ascii_utils, only: get_blend_char
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -141,8 +141,11 @@ contains
         ! Ensure coordinates stay inside the frame border (1-char margin)
         if (px < 2 .or. px > width - 1 .or. py < 2 .or. py > height - 1) return
 
-        ! Calculate angle for direction
-        angle = atan2(dy, dx)
+        ! Calculate angle for direction in screen space. The canvas compresses y
+        ! by ASCII_CHAR_ASPECT relative to x (a cell is that many times taller
+        ! than wide), so scale dy by 1/ASCII_CHAR_ASPECT before atan2 to pick the
+        ! glyph that matches the visible flow direction (#1965).
+        angle = atan2(dy / ASCII_CHAR_ASPECT, dx)
 
         ! Choose ASCII-compatible arrow character based on direction
         if (abs(angle) < 0.393_wp) then          ! 0 ± 22.5 degrees (right)

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -157,6 +157,15 @@ module fortplot_constants
     !! Used by backend validation to ensure reasonable memory usage.
     integer, parameter, public :: MAX_SAFE_PIXELS = 10000
 
+    !! Terminal character-cell aspect ratio (cell height / cell width)
+    !!
+    !! A monospace terminal cell is about twice as tall as it is wide. The ASCII
+    !! backend compensates for this once, in ascii_set_coord_impl, by scaling the
+    !! y data range by this factor. Re-export through fortplot_ascii preserves the
+    !! historical public location while keeping the value usable by lower-level
+    !! drawing modules (e.g. arrow-glyph direction) without a circular dependency.
+    real(wp), parameter, public :: ASCII_CHAR_ASPECT = 2.0_wp
+
     ! ========================================================================
     ! TIME CONVERSION CONSTANTS
     ! ========================================================================

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -18,7 +18,7 @@ module fortplot_figure_render_engine
     use fortplot_subplot_rendering, only: render_subplots
     use fortplot_png, only: png_context
     use fortplot_pdf, only: pdf_context
-    use fortplot_ascii, only: ascii_context, ASCII_CHAR_ASPECT
+    use fortplot_ascii, only: ascii_context
     use fortplot_figure_render_steps, only: &
         render_background_and_grid, render_axes_and_plots, &
         render_labels_overlay, render_decorations, &
@@ -342,8 +342,11 @@ contains
                 ph = real(max(1, bk%plot_area%height), wp)
                 have_pie_px = .true.
             class is (ascii_context)
+                ! Pass the raw cell-row count. The ASCII backend already scales
+                ! y by ASCII_CHAR_ASPECT in ascii_set_coord_impl, so applying the
+                ! cell-aspect factor here too would double-count it (#1965).
                 pw = real(max(1, bk%plot_width - 3), wp)
-                ph = real(max(1, bk%plot_height - 3), wp) * ASCII_CHAR_ASPECT
+                ph = real(max(1, bk%plot_height - 3), wp)
                 have_pie_px = .true.; ascii_bk = .true.
             class default
             end select


### PR DESCRIPTION
## Summary

ASCII output applied the terminal character-cell aspect factor (`ASCII_CHAR_ASPECT = 2.0`) inconsistently: twice for pie charts and never for streamplot arrow glyphs. Pie discs rendered as wide ellipses (~4:1 in cells) instead of round, and streamline arrowheads pointed in the data-space direction rather than the direction the eye sees on the canvas.

This makes the backend y-scaling in `ascii_set_coord_impl` the single source of truth for cell compensation, and applies it exactly once across plot types.

- `resolve_pie_and_aspect` now passes the raw cell-row count to `enforce_pie_axis_equal` instead of pre-multiplying by `ASCII_CHAR_ASPECT`. The backend already scales the y data range by 2.0, so the previous code counted the factor twice.
- `draw_ascii_arrow` computes the glyph angle from screen-space deltas (`dy` scaled by `1/ASCII_CHAR_ASPECT` before `atan2`), so the chosen glyph follows the visible flow direction.
- Streamplots in `auto` mode now rely on that same single compensation (no second, axis-level adjustment is introduced).

`ASCII_CHAR_ASPECT` moves to `fortplot_constants` and is re-exported from `fortplot_ascii`, preserving its public location while letting the lower-level `fortplot_ascii_drawing` module reach it without a circular dependency.

Closes #1965

## Verification

Commands:

```
make build                       # Project compiled successfully
fpm test --target test_pie_axis_equal      # PASS
fpm test --target test_pie_axis_equal_oo   # PASS
fpm test --target test_pie_chart           # PASS (exit 0)
fpm test --target test_ascii               # PASS
fpm test --target test_streamplot          # PASS (exit 0)
fpm test --target test_streamplot_arrows   # PASS (exit 0)
fpm test --target test_streamplot_arrow_data_ranges  # PASS
make test-ci                     # CI essential test suite completed successfully
make verify-artifacts            # Artifact verification passed.
```

### Pie disc: before vs after

Artifact: `output/example/fortran/pie_chart_demo/oo_energy.txt`

Before (disc spans ~40 cols x ~10 rows = ~4:1 in cells, a wide ellipse):

```
|                         Solar                                                  |
|                                                  12%                           |
|                            ----42%--------  -----                              |
|                      --------------------  ------------                        |
|                   ----------------------  -------------=-                      |
|                  ----------------------  ---------========         - Solar     |
|                 ----------------------  ----=========18%===  Hydro = Wind      |
|                 --------------------- +====================        % Hydro     |
|                  ---------------   +++++++++===============        # Storage   |
|                   ---------    +++++++++++++++++++========                     |
|                     ---     ++++++++++++++++++++++++++++                       |
|                         +++++++++++++++++++28%+++++++                          |
|                               +++++++++++++++++                                |
```

After (disc spans ~22 cols x ~10 rows = ~2.2:1 in cells, round on a 2:1 cell):

```
|                                  Solar                                         |
|                                              12%                               |
|                                 -----42%----                                   |
|                               ---------- ------                                |
|                             ----------- ------=-                               |
|                             ----------- ----====                   - Solar     |
|                            ----------- --======18%  Hydro          = Wind      |
|                            -----------+==========                  % Hydro     |
|                            --------  ++++========                  # Storage   |
|                             -----  +++++++++=====                              |
|                              --  ++++++++++++++                                |
|                                ++++++++++++28%                                 |
|                                   +++++++++                                    |
```

The slice width collapses from ~4:1 toward ~2:1, which is round on a cell that is twice as tall as wide.

### Streamplot arrows

Artifact: `output/example/fortran/streamplot_demo/streamplot_arrows.txt`

After the fix the arrow glyphs follow the circular flow direction (`>` along the top, `<`/`v` on the sides, `^` and the diagonals `/` `\` where the field turns) instead of being dominated by `-`/`/` glyphs that did not match the visible slope:

```
| 1.0 \ \                                >   >                         /  /      |
...
| v--   ---- --- ---- - --- -- ----- - ------------ - -- ---- --^-- -- --- ---   |
| | -  - -v -  v--  ---- ---------------<-- ---- ------- -^--- --- --^-- -- -^-  |
```
