### PR TITLE
fix: round plot-area edges to match matplotlib (1px)

### DIFF
--- a/src/core/fortplot_layout.f90
+++ b/src/core/fortplot_layout.f90
@@ -36,17 +36,17 @@ contains
         type(plot_area_t), intent(out) :: plot_area
         
         integer :: right_edge, top_edge
-        
-        ! Calculate positions exactly like matplotlib
-        ! floor() for top-left, ceil() for bottom-right (bbox.union semantics)
-        plot_area%left = int(floor(margins%left * real(canvas_width, wp)))
-        right_edge = int(ceiling(margins%right * real(canvas_width, wp)))
+
+        ! Round each edge to the nearest pixel, matching matplotlib's axes bbox
+        ! rounding. ceiling()/floor() biased the top edge up by one pixel
+        ! (427.2 -> 428 instead of 427) for the default 640x480 canvas.
+        plot_area%left = nint(margins%left * real(canvas_width, wp))
+        right_edge = nint(margins%right * real(canvas_width, wp))
         plot_area%width = right_edge - plot_area%left
-        
-        ! For image coordinates (Y=0 at top), we need to flip
-        ! floor() for top-left, ceil() for bottom-right (bbox.union semantics)
-        plot_area%bottom = int(ceiling((1.0_wp - margins%top) * real(canvas_height, wp)))
-        top_edge = int(ceiling((1.0_wp - margins%bottom) * real(canvas_height, wp)))
+
+        ! Image coordinates have Y=0 at the top, so the edges are flipped.
+        plot_area%bottom = nint((1.0_wp - margins%top) * real(canvas_height, wp))
+        top_edge = nint((1.0_wp - margins%bottom) * real(canvas_height, wp))
         plot_area%height = top_edge - plot_area%bottom
     end subroutine calculate_plot_area
 


### PR DESCRIPTION
## Summary

`calculate_plot_area` placed the axes bbox edges with `ceiling()`/`floor()`. For the default 640x480 canvas the top edge sits at the subpixel position `(1.0 - 0.11) * 480 = 427.2`; `ceiling()` rounded it up to 428 while matplotlib rounds to 427, shifting every plot's top edge up by one pixel across all backends.

This change rounds each of the four edges with `nint()` so they match matplotlib's bbox rounding. The left/right/bottom edges were already exact (80, 576, 58) and remain so; the top edge now resolves to 427.

Closes #1952

## Verification

`fpm test --target test_matplotlib_margins` — before (ceiling):

```
 Plot area top:         428
 === Expected (matplotlib) ===
 Y range: 58 to 427
 FAIL: MARGINS DO NOT MATCH MATPLOTLIB
```

After (nint):

```
 Plot area left:          80
 Plot area right:         576
 Plot area bottom:          58
 Plot area top:         427
 PASS: MARGINS MATCH MATPLOTLIB
```

`make build` — passes.

`make verify-artifacts` — passes:

```
Artifact verification passed.
```

Full `make test` — no test reports a failure (`Failed: [1-9]` and `FAIL:` scans both empty); the only nonzero make exit was the suite's overall wall-clock timeout, not a failing test. No test hardcodes the old geometry except `test_matplotlib_margins`, which now passes.