### PR TITLE
fix: add matplotlib-style labelpad between ticks and axis labels

### DIFF
--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -1,10 +1,11 @@
 module fortplot_raster_labels
     !! Raster axis labels (title, xlabel, ylabel) rendering functionality
     !! Extracted from fortplot_raster_axes.f90 for single responsibility principle
-    use fortplot_constants, only: XLABEL_VERTICAL_OFFSET, TICK_MARK_LENGTH, &
+    use fortplot_constants, only: TICK_MARK_LENGTH, &
                                   YLABEL_EXTRA_GAP, TITLE_VERTICAL_OFFSET, &
                                   REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
-                                   MIN_LABEL_MARGIN_PX, CANVAS_EDGE_PADDING_PX
+                                   MIN_LABEL_MARGIN_PX, CANVAS_EDGE_PADDING_PX, &
+                                   AXIS_LABEL_PAD_PT
    use fortplot_text_rendering, only: calculate_text_descent, &
                                          calculate_text_width_with_size, &
                                          calculate_text_height_with_size, &
@@ -12,7 +13,7 @@ module fortplot_raster_labels
                                          DEFAULT_FONT_SIZE
     use fortplot_text_helpers, only: prepare_text_for_raster
     use fortplot_margins, only: plot_area_t
-    use fortplot_raster_core, only: raster_image_t, scale_px
+    use fortplot_raster_core, only: raster_image_t, scale_px, pt2px
     use fortplot_bitmap, only: rotate_bitmap_90_ccw, &
                                rotate_bitmap_90_cw, composite_bitmap_to_raster, &
                                render_text_to_bitmap_with_size, &
@@ -73,11 +74,15 @@ contains
                                                          label_font_px)
             label_height = calculate_text_height_with_size(label_font_px)
             label_x = plot_area%left + plot_area%width/2 - label_width/2
-            ! Position xlabel below x-tick labels with measured clearance
+            ! Position xlabel below the outer (lower) edge of the x-tick labels by
+            ! an explicit labelpad (matplotlib axes.labelpad). The tick-label
+            ! bottom edge is the tick-label pen top plus its measured height; the
+            ! xlabel pen position is its own top, so adding the pad here makes the
+            ! visible gap equal the pad.
             label_y = plot_area%bottom + plot_area%height + &
                       scale_px(X_TICK_LABEL_PAD, raster%dpi) + &
                       max(raster%last_x_tick_max_height_bottom, FALLBACK_LABEL_HEIGHT_PX) + &
-                      scale_px(XLABEL_VERTICAL_OFFSET, raster%dpi)/3
+                      nint(pt2px(AXIS_LABEL_PAD_PT, raster%dpi))
             label_y = min(label_y, height - label_height - CANVAS_EDGE_PADDING_PX)
             call render_text_with_size(raster%image_data, width, height, &
                                        label_x, label_y, &

--- a/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
@@ -4,8 +4,9 @@ module fortplot_pdf_axes_text
     !! Handles title, axis labels, and mixed-font text rendering with mathtext support.
 
     use iso_fortran_env, only: wp => real64
-    use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE, PDF_TITLE_SIZE
-    use fortplot_constants, only: XLABEL_VERTICAL_OFFSET
+    use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE, PDF_TITLE_SIZE, &
+                                 PDF_TICK_LABEL_SIZE
+    use fortplot_constants, only: AXIS_LABEL_PAD_PT
     use fortplot_pdf_text, only: draw_pdf_text, draw_pdf_text_bold, &
                                  draw_mixed_font_text, draw_rotated_mixed_font_text, &
                                  draw_pdf_mathtext, estimate_pdf_text_width
@@ -47,6 +48,14 @@ contains
         real(wp), parameter :: Y_TICK_GAP_LOCAL = 1.0_wp
         real(wp), parameter :: YLABEL_PAD = 1.0_wp
         real(wp), parameter :: LABEL_THICKNESS = 1.2_wp*PDF_LABEL_SIZE
+        ! X tick-label baseline gap below the axis (matches X_TICK_GAP in
+        ! fortplot_pdf_axes_drawing).
+        real(wp), parameter :: X_TICK_GAP = 15.0_wp
+        ! Helvetica vertical metrics as fractions of the font size: ascent
+        ! reaches roughly the cap line, descent drops below the baseline.
+        real(wp), parameter :: FONT_ASCENT_FRAC = 0.718_wp
+        real(wp), parameter :: FONT_DESCENT_FRAC = 0.207_wp
+        real(wp) :: tick_label_bottom
 
         ! Draw title (centered at top)
         if (present(title)) then
@@ -75,7 +84,15 @@ contains
                 width_pt = estimate_pdf_text_width(processed_xlabel(1:processed_len), &
                                                    PDF_LABEL_SIZE)
                 xlabel_x = plot_area_left + 0.5_wp*plot_area_width - 0.5_wp*width_pt
-                xlabel_y = plot_area_bottom - real(XLABEL_VERTICAL_OFFSET, wp)
+                ! Outer (lower) edge of the x tick labels: baseline sits
+                ! X_TICK_GAP below the axis, descenders reach below that.
+                tick_label_bottom = plot_area_bottom - X_TICK_GAP - &
+                                    FONT_DESCENT_FRAC*PDF_TICK_LABEL_SIZE
+                ! Place the xlabel baseline a labelpad below the tick-label edge,
+                ! leaving room for the xlabel's own ascent so the visible gap
+                ! equals the pad (mirrors the y-label treatment below).
+                xlabel_y = tick_label_bottom - real(AXIS_LABEL_PAD_PT, wp) - &
+                           FONT_ASCENT_FRAC*PDF_LABEL_SIZE
                 call render_mixed_text(ctx, xlabel_x, xlabel_y, trim(xlabel))
             end if
         end if

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -95,6 +95,11 @@ module fortplot_constants
     ! Extra gap between y tick labels and rotated y label (pixels).
     integer, parameter, public :: YLABEL_EXTRA_GAP = 25
 
+    !! Axis-label pad (points): gap between the outer edge of the tick labels
+    !! and the nearest edge of the axis label. Matches matplotlib's default
+    !! axes.labelpad of 4.0 pt. Backends scale this to device units by DPI.
+    real(wp), parameter, public :: AXIS_LABEL_PAD_PT = 4.0_wp
+
     ! ========================================================================
     ! RASTER RENDERING CONSTANTS
     ! ========================================================================


### PR DESCRIPTION
## Summary

Axis labels sat too close to the tick labels. The PDF backend placed the
x-label at a fixed offset from the axis line (`XLABEL_VERTICAL_OFFSET`),
ignoring tick-label height, while the raster backend used an undersized
`XLABEL_VERTICAL_OFFSET/3` residual.

Both backends now offset the axis label from the *outer edge of the tick
labels* by an explicit pad matching matplotlib's `axes.labelpad` default
of 4.0 pt, so the visible gap is `tick-label extent + labelpad`.

- New constant `AXIS_LABEL_PAD_PT = 4.0` in `fortplot_constants` is the
  single source for the pad.
- PDF (`fortplot_pdf_axes_text.f90`): x-label baseline derived from the
  tick-label bottom edge (axis minus tick baseline gap minus descent),
  less the labelpad and the label ascent. Mirrors the existing y-label
  treatment.
- Raster (`fortplot_raster_labels.f90`): replaced the
  `XLABEL_VERTICAL_OFFSET/3` residual with `pt2px(AXIS_LABEL_PAD_PT, dpi)`
  applied after the measured tick-label height. The xlabel pen position
  is the text-box top, the same convention tick labels use, so the
  box-to-box gap equals the pad.
- `XLABEL_VERTICAL_OFFSET` is retained: it is still used for margin
  reservation in `fortplot.f90` and `fortplot_subplot_layout.f90`.

Closes #1963

## Verification

Build:

    make build        # Project compiled successfully.

Label/text/margin tests (no new failures):

    fpm test --target test_axis_label_overlap_1573    # 4/4 PASS
    fpm test --target test_label_bounds_validation     # All PASSED
    fpm test --target test_axis_label_offsets_pdf      # PASS
    fpm test --target test_tick_vs_axis_labels         # All passed
    fpm test --target test_axes_labels_comprehensive   # All PASSED
    fpm test --target test_text_centering              # passed
    make test-ci                                       # completed successfully

`test_matplotlib_margins` reports its pre-existing 1px mismatch
(plot-area top 428 vs expected 427); identical on clean main, unaffected
by this change (plot-area geometry unchanged: left=80 bottom=58 w=496 h=370).

Rendering gate:

    make verify-artifacts        # Artifact verification passed.

Before/after gap (PIL), `output/example/fortran/basic_plots/multi_line.png`,
800x600; vertical white gap between the x tick-label bottom and the x axis
label "x" top, measured at the centre column:

    before: 17 px  ("x" glyph rows 571..578)
    after:  14 px  ("x" glyph rows 568..575)

matplotlib reference (figsize 8x6, dpi 100, same plot, axes.labelpad=4.0):

    tick-label bottom row 554, "x" top row 567  =>  ~12 px gap

The corrected raster gap (14 px) tracks matplotlib's ~12 px; the old
fortplot gap (17 px) was looser. PDF x/y labels confirmed present via
`pdftotext -layout` on the same example ("... y ... x").