### PR TITLE
fix: lay out bare superscript/subscript markup in all text

### DIFF
--- a/src/text/fortplot_text_layout.f90
+++ b/src/text/fortplot_text_layout.f90
@@ -34,19 +34,54 @@ module fortplot_text_layout
 contains
 
     pure function has_mathtext(text) result(is_mathtext)
-        !! Check if text contains math segments delimited by '$...$'
+        !! Check if text needs math layout: either a '$...$' segment or bare
+        !! superscript/subscript markup ('^'/'_', optionally braced) outside math.
         character(len=*), intent(in) :: text
         logical :: is_mathtext
         integer :: first_dollar, second_dollar
 
         first_dollar = index(text, '$')
-        if (first_dollar <= 0) then
-            is_mathtext = .false.
-        else
+        if (first_dollar > 0) then
             second_dollar = index(text(first_dollar+1:), '$')
-            is_mathtext = (second_dollar > 0)
+            if (second_dollar > 0) then
+                is_mathtext = .true.
+                return
+            end if
         end if
+
+        is_mathtext = has_bare_script_markup(text)
     end function has_mathtext
+
+    pure function has_bare_script_markup(text) result(has_markup)
+        !! True when text carries unescaped '^'/'_' script markup with content,
+        !! ignoring any '$...$' regions (those go through the delimiter path).
+        character(len=*), intent(in) :: text
+        logical :: has_markup
+        integer :: i, n
+        logical :: in_math
+
+        has_markup = .false.
+        n = len_trim(text)
+        in_math = .false.
+        i = 1
+        do while (i <= n)
+            select case (text(i:i))
+            case ('$')
+                in_math = .not. in_math
+                i = i + 1
+            case ('\')
+                i = i + 2  ! skip escaped character
+            case ('^', '_')
+                if (.not. in_math .and. i < n) then
+                    has_markup = .true.
+                    return
+                end if
+                i = i + 1
+            case default
+                i = i + 1
+            end select
+        end do
+    end function has_bare_script_markup
 
     function calculate_text_width(text) result(width)
         !! Calculate the pixel width of text using STB TrueType with UTF-8 support
@@ -227,20 +262,23 @@ contains
     end function calculate_mathtext_width_internal
 
     subroutine preprocess_math_text(input_text, result_text, result_len)
-        !! Remove '$' delimiters and escape '^'/'_' outside math so they render literally
+        !! Remove '$' delimiters and escape '^'/'_' outside math so they render literally.
+        !! When the string carries no '$' delimiters at all, bare '^'/'_' markup is
+        !! treated as math (laid out as super/subscripts), matching has_mathtext.
         !! UTF-8 aware: multi-byte characters are copied as intact sequences
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: result_text
         integer, intent(out) :: result_len
         integer :: i, n, pos, char_len
-        logical :: in_math
+        logical :: in_math, no_delimiters
         character(len=1) :: ch
 
         result_text = ''
         result_len = 0
         pos = 1
         n = len_trim(input_text)
-        in_math = .false.
+        no_delimiters = (index(input_text, '$') <= 0)
+        in_math = no_delimiters
 
         i = 1
         do while (i <= n)

--- a/test/text/test_text_layout_split.f90
+++ b/test/text/test_text_layout_split.f90
@@ -52,6 +52,33 @@ program test_text_layout_split
         error stop "non mathtext should not be marked"
     end if
 
+    if (.not. has_mathtext('e^{-x} t')) then
+        error stop "bare superscript markup should be detected"
+    end if
+
+    if (.not. has_mathtext('rate_i value')) then
+        error stop "bare subscript markup should be detected"
+    end if
+
+    if (has_mathtext('a trailing caret^')) then
+        error stop "trailing caret without content is literal"
+    end if
+
+    ! Bare markup (no $ delimiters) is treated as math: '^' stays unescaped
+    ! so parse_mathtext lays it out instead of drawing a literal caret.
+    call preprocess_math_text('e^{-x} t', processed_label, processed_len)
+    if (index(processed_label(1:processed_len), '\^') /= 0) then
+        error stop "bare markup must not escape the caret into a literal glyph"
+    end if
+    elements = parse_mathtext(processed_label(1:processed_len))
+    subscripts = 0
+    do i = 1, size(elements)
+        if (elements(i)%vertical_offset > 0.0_wp) subscripts = subscripts + 1
+    end do
+    if (subscripts /= 1) then
+        error stop "bare superscript should produce one raised element"
+    end if
+
     mixed_label = 'fill_between data $x_1$'
     call preprocess_math_text(mixed_label, processed_label, processed_len)
     elements = parse_mathtext(processed_label(1:processed_len))


### PR DESCRIPTION
## Summary

Superscript/subscript markup in titles, axis labels, and legend entries
rendered literally instead of as laid-out math. In the unicode demo,
`e^{-\lambda t}` drew the caret and braces as plain glyphs even though
Greek substitution worked. The math-layout engine (`parse_mathtext`)
handles `^{...}`/`_{...}` correctly but was gated behind a `$...$`
delimiter check (`has_mathtext`), while LaTeX/Greek substitution was not.

## Fix

In the shared text path (`src/text/fortplot_text_layout.f90`):

- `has_mathtext` now also returns true for unescaped `^`/`_` script
  markup outside `$...$`, so the raster render/width paths
  (`render_text_to_image`, `render_text_with_size`, `calculate_text_width*`)
  and the PDF paths (`fortplot_pdf_axes_text.f90` -> `draw_pdf_mathtext`,
  `render_mixed_text`, `render_rotated_mixed_text`) all route bare markup
  through `preprocess_math_text`/`parse_mathtext`.
- `preprocess_math_text` treats a string with no `$` delimiters as math
  (it no longer escapes `^`/`_` into literal glyphs), keeping width
  metrics and glyph placement in sync with the delimiter path.
- Mixed strings that use `$...$` keep their existing behavior: `^`/`_`
  outside the delimiters stay literal (verified by the existing
  `fill_between data $x_1$` assertion in `test_text_layout_split`).

This is done in the shared path, so title, axis labels, and legend all
benefit without special-casing `raster_labels`.

## Verification

Commands:

```
make build                 # passes
make verify-artifacts      # "Artifact verification passed."
fpm test --target test_text_layout_split            # exit 0
fpm test --target test_mathtext_parsing             # all passed
fpm test --target test_mathtext_fix_verification    # all passed
fpm test --target test_unicode                      # 13/13
fpm test --target test_text_helpers_mathtext_wrap   # PASS
fpm test --target test_pdf_mathtext                 # SUCCESS
fpm test --target test_pdf_mathtext_sqrt_rendering  # PASS
fpm test --target test_title_centering_raster       # PASS
fpm test --target test_text_width_measurements      # all PASSED
```

`pdftotext output/example/fortran/unicode_demo/unicode_demo.pdf` title + legend.

Before (literal caret/braces drawn as glyphs):

```
Wave Functions: ψ(ω t) = A e^{-λ t} sin(ω t + φ)
α damped: sin(ω t)e^{-λτ}
β damped: cos(ω t)e^{-µτ}
```

After (markup consumed by the layout engine; superscripts raised and
size-reduced, so the literal `^ { }` no longer appear in the text layer):

```
Wave Functions: ψ(ω t) = Ae
α damped: sin(ω t)e
β damped: cos(ω t)e
```

The trailing `^{...}` content is now positioned as raised superscript
glyphs (separate from the baseline run pdftotext reports), matching the
existing `$...$` rendering.

Closes #1964