### PR TITLE
fix: reserve top space for twiny axis label and title

### DIFF
--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -435,7 +435,7 @@ contains
         integer, intent(in) :: top_tick_height
         integer :: title_width, title_height
         real(wp) :: dpi_val
-        integer :: top_xlabel_y, title_gap
+        integer :: top_xlabel_top, title_gap, xlabel_height
 
         dpi_val = REFERENCE_DPI
         if (present(dpi)) dpi_val = dpi
@@ -450,13 +450,18 @@ contains
                         - title_width / 2, wp)
 
         if (top_tick_height > 0) then
-            ! twiny active: place title above the top xlabel
-            top_xlabel_y = plot_area%bottom - &
-                           scale_px(X_TICK_LABEL_TOP_PAD, dpi_val) - &
-                           top_tick_height - title_height - &
-                           CANVAS_EDGE_PADDING_PX
+            ! twiny active: stack ticks, then the top xlabel, then the title.
+            ! Mirror raster_draw_top_xlabel's placement so the title clears the
+            ! actual top axis label rather than the tick labels alone.
+            xlabel_height = calculate_text_height_with_size( &
+                axis_label_font_px(dpi_val))
+            if (xlabel_height <= 0) xlabel_height = FALLBACK_LABEL_HEIGHT_PX
+            top_xlabel_top = plot_area%bottom - &
+                             scale_px(X_TICK_LABEL_TOP_PAD, dpi_val) - &
+                             top_tick_height - xlabel_height - &
+                             CANVAS_EDGE_PADDING_PX
             title_gap = TITLE_VERTICAL_OFFSET
-            title_py = real(max(1, top_xlabel_y - title_gap - title_height), wp)
+            title_py = real(max(1, top_xlabel_top - title_gap - title_height), wp)
         else
             title_py = real(plot_area%bottom - TITLE_VERTICAL_OFFSET, wp)
             title_py = max(1.0_wp, title_py)

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -36,6 +36,10 @@ module fortplot_pdf
         type(pdf_context_handle), private :: coord_ctx
         integer :: x_tick_count = 0
         integer :: y_tick_count = 0
+        ! Points reserved above the plot-area top edge for a twiny (top x-axis)
+        ! block (its tick labels and axis label). Lifts the title above that
+        ! block instead of letting it overlap. Zero when no twiny is active.
+        integer :: twiny_top_offset = 0
         logical, private :: axes_rendered = .false.
         ! Custom tick support (set_xticks / set_yticks)
         real(wp), allocatable :: custom_xtick_positions(:)

--- a/src/backends/vector/pdf/fortplot_pdf_axes_io.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_io.f90
@@ -135,6 +135,10 @@ contains
         character(len=256) :: title_str, xlabel_str, ylabel_str
         associate (dzmin => z_min, dzmax => z_max, dh3d => has_3d_plots); end associate
 
+        ! Carry the twiny top reservation into the core context so the title is
+        ! lifted above the top-axis block when a twiny is active.
+        this%core_ctx%twiny_top_offset = this%twiny_top_offset
+
         title_str = ""; xlabel_str = ""; ylabel_str = ""
         if (present(title)) title_str = title
         if (present(xlabel)) xlabel_str = xlabel

--- a/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
@@ -66,7 +66,11 @@ contains
                 width_pt = estimate_pdf_text_width(processed_title(1:processed_len), &
                                                    PDF_TITLE_SIZE)
                 title_x = plot_area_left + 0.5_wp*plot_area_width - 0.5_wp*width_pt
-                title_y = plot_area_bottom + plot_area_height + TITLE_GAP
+                ! Lift the title above the twiny top-axis block (tick labels and
+                ! top axis label) so it does not overlap them. ctx%twiny_top_offset
+                ! is zero without a twiny, keeping the default position.
+                title_y = plot_area_bottom + plot_area_height + &
+                          real(ctx%twiny_top_offset, wp) + TITLE_GAP
                 ! Process LaTeX commands to Unicode and render with mixed fonts
                 ! Use mathtext rendering for title to handle superscripts properly
                 call draw_pdf_mathtext(ctx, title_x, title_y, trim(title), &

--- a/src/backends/vector/pdf/fortplot_pdf_core.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_core.f90
@@ -45,6 +45,9 @@ module fortplot_pdf_core
         integer :: image_width = 0
         integer :: image_height = 0
         character(len=:), allocatable :: image_data
+        ! Points reserved above the plot-area top edge for a twiny (top x-axis)
+        ! block; lifts the title above that block. Zero when no twiny is active.
+        integer :: twiny_top_offset = 0
     contains
         procedure :: set_color => set_pdf_color
         procedure :: set_line_width => set_pdf_line_width

--- a/src/core/fortplot_layout.f90
+++ b/src/core/fortplot_layout.f90
@@ -12,6 +12,7 @@ module fortplot_layout
     
     private
     public :: plot_margins_t, plot_area_t, calculate_plot_area
+    public :: twiny_top_offset_px
     
     ! Matplotlib default margins (exact values from matplotlibrc)
     type :: plot_margins_t
@@ -28,14 +29,25 @@ module fortplot_layout
     
 contains
 
-    subroutine calculate_plot_area(canvas_width, canvas_height, margins, plot_area)
+    subroutine calculate_plot_area(canvas_width, canvas_height, margins, plot_area, &
+                                   top_offset_px)
         !! Calculate plot area based on canvas size and margins (matplotlib-compatible)
         !! Note: left/bottom are margins, right/top are edge positions
+        !!
+        !! top_offset_px (optional) pushes the plot-area top edge downward by that
+        !! many image pixels. A twiny (top x-axis) needs this so its tick labels,
+        !! axis label, and the figure title fit above the axes without clipping.
+        !! When absent or non-positive the geometry is unchanged, preserving the
+        !! matplotlib-exact default edges.
         integer, intent(in) :: canvas_width, canvas_height
         type(plot_margins_t), intent(in) :: margins
         type(plot_area_t), intent(out) :: plot_area
-        
-        integer :: right_edge, top_edge
+        integer, intent(in), optional :: top_offset_px
+
+        integer :: right_edge, top_edge, offset
+
+        offset = 0
+        if (present(top_offset_px)) offset = max(0, top_offset_px)
 
         ! Round each edge to the nearest pixel, matching matplotlib's axes bbox
         ! rounding. ceiling()/floor() biased the top edge up by one pixel
@@ -45,9 +57,52 @@ contains
         plot_area%width = right_edge - plot_area%left
 
         ! Image coordinates have Y=0 at the top, so the edges are flipped.
-        plot_area%bottom = nint((1.0_wp - margins%top) * real(canvas_height, wp))
+        plot_area%bottom = nint((1.0_wp - margins%top) * real(canvas_height, wp)) &
+                           + offset
         top_edge = nint((1.0_wp - margins%bottom) * real(canvas_height, wp))
         plot_area%height = top_edge - plot_area%bottom
     end subroutine calculate_plot_area
+
+    pure integer function twiny_top_offset_px(dpi, has_top_xlabel) result(offset)
+        !! Extra image pixels to push the plot-area top edge down for a twiny
+        !! (top x-axis), beyond the default top margin.
+        !!
+        !! The raster/PDF backends stack the top band upward from the plot-area
+        !! top edge as: top tick labels, then the top axis label, then the title.
+        !! Without a twiny only the title sits above the axes, and the default
+        !! top margin already holds it inside the canvas. A twiny inserts the
+        !! tick labels and the top axis label below the title, so the stack grows
+        !! and the upper elements clip at y=0. This returns that added height.
+        !!
+        !! Tick and axis label heights match DEFAULT_FONT_SIZE points scaled to
+        !! device pixels by DPI; pads match the constants the label placement
+        !! applies (X_TICK_LABEL_TOP_PAD, CANVAS_EDGE_PADDING_PX). The added
+        !! TITLE_VERTICAL_OFFSET is the gap the title now needs above the
+        !! top-axis block. The title's own height is not added: the default top
+        !! margin already reserves it, and with a twiny the title simply moves
+        !! from just above the axes to the top of this taller stack.
+        use fortplot_constants, only: REFERENCE_DPI, X_TICK_LABEL_TOP_PAD, &
+                                      TITLE_VERTICAL_OFFSET, CANVAS_EDGE_PADDING_PX
+        real(wp), intent(in) :: dpi
+        logical, intent(in) :: has_top_xlabel
+
+        integer, parameter :: LABEL_FONT_PT = 16          ! DEFAULT_FONT_SIZE
+        real(wp) :: dpi_val, scale
+        integer :: label_h
+
+        dpi_val = dpi
+        if (dpi_val <= 0.0_wp) dpi_val = REFERENCE_DPI
+        scale = dpi_val / REFERENCE_DPI
+        label_h = nint(real(LABEL_FONT_PT, wp) * scale)
+
+        ! Top tick labels, the pad above the axis frame, and the title gap that
+        ! now separates the title from the top-axis block are always added.
+        offset = nint(real(CANVAS_EDGE_PADDING_PX, wp) * scale) + &
+                 nint(real(X_TICK_LABEL_TOP_PAD, wp) * scale) + label_h + &
+                 TITLE_VERTICAL_OFFSET
+
+        ! Reserve room for the top axis label only when one is set.
+        if (has_top_xlabel) offset = offset + label_h
+    end function twiny_top_offset_px
 
 end module fortplot_layout

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -372,6 +372,11 @@ contains
 
         select type (backend)
         class is (raster_context)
+            ! The title is drawn here, before the secondary top axis ticks set
+            ! raster%last_x_tick_max_height_top. Seed an estimate so the title's
+            ! twiny branch lifts it above the top-axis block; the exact value is
+            ! filled in later for the top xlabel placement.
+            if (has_twiny_local) call seed_top_tick_height(backend)
             call backend%draw_axis_labels_only(xscale, yscale, symlog_threshold, &
                                                x_min, x_max, y_min, y_max, title, &
                                                xlabel, ylabel, custom_xticks, &
@@ -394,6 +399,19 @@ contains
                                 twinx_y_date_format, twiny_x_date_format, &
                                 twinx_ylabel, twiny_xlabel, draw_primary_labels=.false.)
     end subroutine render_figure_axes_labels_only
+
+    subroutine seed_top_tick_height(backend)
+        !! Pre-seed the top tick-label height used to position the title above a
+        !! twiny block. Matches raster_draw_x_axis_ticks_top, which measures tick
+        !! labels with calculate_text_height; '0' is a representative digit.
+        use fortplot_text, only: calculate_text_height
+        type(raster_context), intent(inout) :: backend
+        integer :: h
+        h = calculate_text_height('0')
+        if (h <= 0) h = 1
+        backend%raster%last_x_tick_max_height_top = &
+            max(backend%raster%last_x_tick_max_height_top, h)
+    end subroutine seed_top_tick_height
 
     subroutine render_title_only(backend, title, x_min, x_max, y_min, y_max, &
                                  custom_title_font_size)

--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -80,6 +80,7 @@ contains
         character(len=64) :: twinx_y_date_format, twiny_x_date_format
 
         call apply_raster_config(state)
+        call reserve_twiny_top_space(state)
         call compute_all_data_ranges(state, plots, plot_count)
         call resolve_date_formats(state, x_date_format, y_date_format, &
                                   twinx_y_date_format, twiny_x_date_format)
@@ -100,6 +101,44 @@ contains
                                 plot_area_supported, annotations, &
                                 annotation_count)
     end subroutine render_single_axis
+
+    subroutine reserve_twiny_top_space(state)
+        !! When a top x-axis (twiny) is active, push the plot-area top edge down
+        !! so its tick labels, axis label, and the title fit above the axes
+        !! without clipping at the canvas top. No-op otherwise, so single-axis
+        !! geometry keeps matplotlib-exact edges.
+        use fortplot_layout, only: twiny_top_offset_px
+        use fortplot_pdf_coordinate, only: calculate_pdf_plot_area
+        use fortplot_constants, only: REFERENCE_DPI
+        type(figure_state_t), intent(inout) :: state
+        integer :: offset, offset_pts
+        logical :: has_top_xlabel
+
+        if (.not. state%has_twiny) return
+
+        has_top_xlabel = .false.
+        if (allocated(state%twiny_xlabel)) has_top_xlabel = &
+            len_trim(state%twiny_xlabel) > 0
+
+        offset = twiny_top_offset_px(state%dpi, has_top_xlabel)
+        if (offset <= 0) return
+
+        select type (bk => state%backend)
+        class is (raster_context)
+            call calculate_plot_area(bk%width, bk%height, bk%margins, &
+                                     bk%plot_area, top_offset_px=offset)
+        class is (pdf_context)
+            ! PDF math coords (Y=0 at bottom), canvas in points. Convert the
+            ! pixel offset to points (PDF uses 72/REFERENCE_DPI), lower the top
+            ! edge, and record it so the title is lifted above the top-axis block.
+            offset_pts = nint(real(offset, wp) * 72.0_wp / REFERENCE_DPI)
+            call calculate_pdf_plot_area(bk%width, bk%height, bk%margins, &
+                                         bk%plot_area)
+            bk%plot_area%height = max(1, bk%plot_area%height - offset_pts)
+            bk%twiny_top_offset = offset_pts
+        class default
+        end select
+    end subroutine reserve_twiny_top_space
 
     subroutine apply_raster_config(state)
         type(figure_state_t), intent(inout) :: state


### PR DESCRIPTION
## Summary

When a twiny (top x-axis) is active, the top-axis tick labels, the top-axis label, and the figure title were stacked upward from a fixed plot-area top edge that did not account for the extra content. The upper elements ran past `y = 0` and clipped, and the title overlapped the top-axis label.

This pushes the plot-area top edge down by a twiny-dependent offset so the whole stack fits inside the canvas, and orders the band as matplotlib does: top-axis ticks, then the top-axis label, then the title above. The offset is zero without a twiny, so single-axis geometry keeps the matplotlib-exact edges.

- `src/core/fortplot_layout.f90`: optional `top_offset_px` on `calculate_plot_area` (absent/non-positive leaves geometry unchanged) and a `twiny_top_offset_px` helper.
- `src/figures/management/fortplot_figure_render_engine.f90`: `reserve_twiny_top_space` recomputes the backend plot area only when `has_twiny`.
- `src/figures/fortplot_figure_rendering_pipeline.f90`: seed the top tick-label height so the title's twiny branch fires (the title is drawn before the secondary ticks set the exact value).
- `src/backends/raster/fortplot_raster_labels.f90`: stack the title above the actual top axis label, not just the tick labels.
- PDF (`fortplot_pdf*.f90`): mirror the reservation in points and lift the title above the top-axis block.

Closes #1962

## Verification

Build:
```
make build   # Project compiled successfully.
```

Default (non-twiny) geometry unchanged — `test_matplotlib_margins` still passes (top edge 427 for 640x480):
```
fpm test --target test_matplotlib_margins
 Plot area bottom:          58
 Plot area top:         427
 PASS: MARGINS MATCH MATPLOTLIB
```

Twin/label/title tests pass:
```
fpm test --target test_title_position_twiny      # PASS
fpm test --target test_title_centering_raster    # PASS
fpm test --target test_twin_axes_data_ranges     # PASS
fpm test --target test_tick_vs_axis_labels       # PASS
fpm test --target test_label_bounds_validation   # All label positioning tests PASSED
fpm test --target test_ylabel                    # PASS
fpm test --target test_axis_label_overlap_1573   # PASS
```

Rendering gate and full suite:
```
make verify-artifacts   # Artifact verification passed.
fpm test                # [PASS] ALL FAST TESTS PASSED  (exit 0)
```

Before/after measurement of the top text rows in `output/example/fortran/twin_axes_demo/twin_axes_demo.png` (640x480, via PIL):

Before this change the title and top-axis label clipped at the top edge (dark pixels at rows 0-8). After:
```
PNG dark rows: title 25-38, top xlabel 71-85, top tick (10^0) 92-108, axis frame ~139
PNG topmost dark row: 25   (no pixels in rows 0-24)
```

PDF (`pdftotext -layout` of `twin_axes_demo.pdf`) shows the title on its own line above the top-axis label, no overlap:
```
                                            Twin axis demo
                                     Cumulative index (log scale)
                                 0
                             10
```
PDF render check: topmost dark row 36, nothing in rows 0-3.