### PR TITLE
fix: draw ticks across the margin-expanded view like matplotlib

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -122,7 +122,9 @@ contains
                                            xscale, yscale, symlog_threshold, &
                                            x_min, x_max, y_min, y_max, &
                                            title, xlabel, ylabel, &
-                                           x_date_format, y_date_format)
+                                           x_date_format, y_date_format, &
+                                           view_x_min, view_x_max, &
+                                           view_y_min, view_y_max)
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
@@ -131,6 +133,8 @@ contains
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         character(len=:), allocatable, intent(in), optional :: title, xlabel, ylabel
         character(len=*), intent(in), optional :: x_date_format, y_date_format
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         call draw_raster_axes_lines(raster, width, height, plot_area, x_min, x_max, &
                                     y_min, y_max)
@@ -138,11 +142,13 @@ contains
         call raster_draw_x_axis_ticks_wrapper(raster, width, height, plot_area, &
                                               xscale, symlog_threshold, &
                                               x_min, x_max, y_min, y_max, &
-                                              date_format=x_date_format)
+                                              date_format=x_date_format, &
+                                              view_min=view_x_min, view_max=view_x_max)
         call raster_draw_y_axis_ticks_wrapper(raster, width, height, plot_area, &
                                               yscale, symlog_threshold, &
                                               x_min, x_max, y_min, y_max, &
-                                              date_format=y_date_format)
+                                              date_format=y_date_format, &
+                                              view_min=view_y_min, view_max=view_y_max)
 
         call raster_draw_axis_labels_wrapper(raster, width, height, plot_area, title, &
                                              xlabel, ylabel)
@@ -150,13 +156,17 @@ contains
 
     subroutine raster_draw_axes_lines_and_ticks(raster, width, height, plot_area, &
                                                 xscale, yscale, symlog_threshold, &
-                                                x_min, x_max, y_min, y_max)
+                                                x_min, x_max, y_min, y_max, &
+                                                view_x_min, view_x_max, &
+                                                view_y_min, view_y_max)
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         call draw_raster_axes_lines(raster, width, height, plot_area, x_min, x_max, &
                                     y_min, y_max)
@@ -164,11 +174,15 @@ contains
         call raster_draw_x_axis_tick_marks_only_wrapper(raster, width, height, &
                                                         plot_area, xscale, &
                                                         symlog_threshold, &
-                                                        x_min, x_max, y_min, y_max)
+                                                        x_min, x_max, y_min, y_max, &
+                                                        view_min=view_x_min, &
+                                                        view_max=view_x_max)
         call raster_draw_y_axis_tick_marks_only_wrapper(raster, width, height, &
                                                         plot_area, yscale, &
                                                         symlog_threshold, &
-                                                        x_min, x_max, y_min, y_max)
+                                                        x_min, x_max, y_min, y_max, &
+                                                        view_min=view_y_min, &
+                                                        view_max=view_y_max)
     end subroutine raster_draw_axes_lines_and_ticks
 
     subroutine raster_draw_axis_labels_only(raster, width, height, plot_area, &
@@ -177,7 +191,9 @@ contains
                                             title, xlabel, ylabel, &
                                             custom_xticks, custom_xtick_labels, &
                                             custom_yticks, custom_ytick_labels, &
-                                            x_date_format, y_date_format)
+                                            x_date_format, y_date_format, &
+                                            view_x_min, view_x_max, &
+                                            view_y_min, view_y_max)
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
@@ -189,6 +205,8 @@ contains
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
         character(len=*), intent(in), optional :: x_date_format, y_date_format
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         if (present(custom_xticks) .and. present(custom_xtick_labels)) then
             call raster_draw_x_axis_tick_labels_only_custom(raster, width, height, &
@@ -203,7 +221,9 @@ contains
                                                              symlog_threshold, &
                                                              x_min, x_max, &
                                                              y_min, y_max, &
-                                                             date_format=x_date_format)
+                                                             date_format=x_date_format, &
+                                                             view_min=view_x_min, &
+                                                             view_max=view_x_max)
         end if
 
         if (present(custom_yticks) .and. present(custom_ytick_labels)) then
@@ -219,7 +239,9 @@ contains
                                                              symlog_threshold, &
                                                              x_min, x_max, &
                                                              y_min, y_max, &
-                                                             date_format=y_date_format)
+                                                             date_format=y_date_format, &
+                                                             view_min=view_y_min, &
+                                                             view_max=view_y_max)
         end if
 
         call raster_draw_axis_labels_wrapper(raster, width, height, plot_area, title, &

--- a/src/backends/raster/fortplot_raster_axes_custom.f90
+++ b/src/backends/raster/fortplot_raster_axes_custom.f90
@@ -122,7 +122,8 @@ contains
    subroutine raster_draw_x_axis_ticks_wrapper(raster, width, height, plot_area, &
                                                xscale, symlog_threshold, &
                                                x_min, x_max, &
-                                               y_min, y_max, date_format)
+                                               y_min, y_max, date_format, &
+                                               view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
@@ -130,13 +131,17 @@ contains
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
       character(len=*), intent(in), optional :: date_format
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: x_tick_positions(MAX_TICKS)
       character(len=50) :: tick_labels(MAX_TICKS)
       integer :: tick_colors(3, MAX_TICKS)
       integer :: num_x_ticks, i, decimals
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                               x_tick_positions, num_x_ticks)
+      call resolve_tick_view(xscale, x_min, x_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(xscale, lo, hi, symlog_threshold, &
+                               x_tick_positions, num_x_ticks, &
+                               step_min=x_min, step_max=x_max)
 
       if (num_x_ticks > 0) then
          decimals = 0
@@ -160,14 +165,15 @@ contains
                                        symlog_threshold, &
                                        x_tick_positions(1:num_x_ticks), &
                                        tick_labels(1:num_x_ticks), &
-                                       tick_colors(:, 1:num_x_ticks), x_min, x_max)
+                                       tick_colors(:, 1:num_x_ticks), lo, hi)
       end if
    end subroutine raster_draw_x_axis_ticks_wrapper
 
    subroutine raster_draw_y_axis_ticks_wrapper(raster, width, height, plot_area, &
                                                yscale, symlog_threshold, &
                                                x_min, x_max, &
-                                               y_min, y_max, date_format)
+                                               y_min, y_max, date_format, &
+                                               view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
@@ -175,13 +181,17 @@ contains
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
       character(len=*), intent(in), optional :: date_format
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: y_tick_positions(MAX_TICKS)
       character(len=50) :: tick_labels(MAX_TICKS)
       integer :: tick_colors(3, MAX_TICKS)
       integer :: num_y_ticks, i, decimals
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
-                               y_tick_positions, num_y_ticks)
+      call resolve_tick_view(yscale, y_min, y_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(yscale, lo, hi, symlog_threshold, &
+                               y_tick_positions, num_y_ticks, &
+                               step_min=y_min, step_max=y_max)
 
       if (num_y_ticks > 0) then
          decimals = 0
@@ -205,28 +215,51 @@ contains
                                        symlog_threshold, &
                                        y_tick_positions(1:num_y_ticks), &
                                        tick_labels(1:num_y_ticks), &
-                                       tick_colors(:, 1:num_y_ticks), y_min, y_max)
+                                       tick_colors(:, 1:num_y_ticks), lo, hi)
       end if
    end subroutine raster_draw_y_axis_ticks_wrapper
+
+   subroutine resolve_tick_view(scale, data_min, data_max, view_min, view_max, &
+                                lo, hi)
+      !! Pick the interval ticks are generated and positioned over. For linear
+      !! axes this is the margin-expanded view (so edge ticks in the margin show
+      !! and align with the data); other scales keep the data range, whose own
+      !! tick logic is unaffected by the margin.
+      character(len=*), intent(in) :: scale
+      real(wp), intent(in) :: data_min, data_max
+      real(wp), intent(in), optional :: view_min, view_max
+      real(wp), intent(out) :: lo, hi
+
+      lo = data_min
+      hi = data_max
+      if (trim(scale) /= 'linear') return
+      if (present(view_min)) lo = view_min
+      if (present(view_max)) hi = view_max
+   end subroutine resolve_tick_view
 
    subroutine raster_draw_x_axis_tick_marks_only_wrapper(raster, width, height, &
                                                          plot_area, &
                                                          xscale, &
                                                          symlog_threshold, &
                                                          x_min, &
-                                                         x_max, y_min, y_max)
+                                                         x_max, y_min, y_max, &
+                                                         view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
       character(len=*), intent(in) :: xscale
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: x_tick_positions(MAX_TICKS)
       integer :: tick_colors(3, MAX_TICKS)
       integer :: num_x_ticks, i
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                               x_tick_positions, num_x_ticks)
+      call resolve_tick_view(xscale, x_min, x_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(xscale, lo, hi, symlog_threshold, &
+                               x_tick_positions, num_x_ticks, &
+                               step_min=x_min, step_max=x_max)
 
       if (num_x_ticks > 0) then
          do i = 1, num_x_ticks
@@ -237,7 +270,7 @@ contains
                                                  x_tick_positions(1:num_x_ticks), &
                                                  tick_colors(:, &
                                                              1:num_x_ticks), &
-                                                 x_min, x_max)
+                                                 lo, hi)
       end if
    end subroutine raster_draw_x_axis_tick_marks_only_wrapper
 
@@ -246,19 +279,24 @@ contains
                                                          yscale, &
                                                          symlog_threshold, &
                                                          x_min, &
-                                                         x_max, y_min, y_max)
+                                                         x_max, y_min, y_max, &
+                                                         view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
       character(len=*), intent(in) :: yscale
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: y_tick_positions(MAX_TICKS)
       integer :: tick_colors(3, MAX_TICKS)
       integer :: num_y_ticks, i
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
-                               y_tick_positions, num_y_ticks)
+      call resolve_tick_view(yscale, y_min, y_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(yscale, lo, hi, symlog_threshold, &
+                               y_tick_positions, num_y_ticks, &
+                               step_min=y_min, step_max=y_max)
 
       if (num_y_ticks > 0) then
          do i = 1, num_y_ticks
@@ -269,7 +307,7 @@ contains
                                                  y_tick_positions(1:num_y_ticks), &
                                                  tick_colors(:, &
                                                              1:num_y_ticks), &
-                                                 y_min, y_max)
+                                                 lo, hi)
       end if
    end subroutine raster_draw_y_axis_tick_marks_only_wrapper
 
@@ -279,7 +317,8 @@ contains
                                                           symlog_threshold, &
                                                           x_min, &
                                                           x_max, y_min, y_max, &
-                                                          date_format)
+                                                          date_format, &
+                                                          view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
@@ -287,12 +326,16 @@ contains
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
       character(len=*), intent(in), optional :: date_format
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: x_tick_positions(MAX_TICKS)
       character(len=50) :: tick_labels(MAX_TICKS)
       integer :: num_x_ticks, i, decimals
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                               x_tick_positions, num_x_ticks)
+      call resolve_tick_view(xscale, x_min, x_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(xscale, lo, hi, symlog_threshold, &
+                               x_tick_positions, num_x_ticks, &
+                               step_min=x_min, step_max=x_max)
 
       if (num_x_ticks > 0) then
          decimals = 0
@@ -315,7 +358,7 @@ contains
                                                   xscale, symlog_threshold, &
                                                   x_tick_positions(1:num_x_ticks), &
                                                   tick_labels(1:num_x_ticks), &
-                                                  x_min, x_max)
+                                                  lo, hi)
       end if
    end subroutine raster_draw_x_axis_tick_labels_only_wrapper
 
@@ -325,7 +368,8 @@ contains
                                                           symlog_threshold, &
                                                           x_min, &
                                                           x_max, y_min, y_max, &
-                                                          date_format)
+                                                          date_format, &
+                                                          view_min, view_max)
       type(raster_image_t), intent(inout) :: raster
       integer, intent(in) :: width, height
       type(plot_area_t), intent(in) :: plot_area
@@ -333,12 +377,16 @@ contains
       real(wp), intent(in) :: symlog_threshold
       real(wp), intent(in) :: x_min, x_max, y_min, y_max
       character(len=*), intent(in), optional :: date_format
+      real(wp), intent(in), optional :: view_min, view_max
       real(wp) :: y_tick_positions(MAX_TICKS)
       character(len=50) :: tick_labels(MAX_TICKS)
       integer :: num_y_ticks, i, decimals
+      real(wp) :: lo, hi
 
-      call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
-                               y_tick_positions, num_y_ticks)
+      call resolve_tick_view(yscale, y_min, y_max, view_min, view_max, lo, hi)
+      call compute_scale_ticks(yscale, lo, hi, symlog_threshold, &
+                               y_tick_positions, num_y_ticks, &
+                               step_min=y_min, step_max=y_max)
 
       if (num_y_ticks > 0) then
          decimals = 0
@@ -361,7 +409,7 @@ contains
                                                   yscale, symlog_threshold, &
                                                   y_tick_positions(1:num_y_ticks), &
                                                   tick_labels(1:num_y_ticks), &
-                                                  y_min, y_max)
+                                                  lo, hi)
       end if
    end subroutine raster_draw_y_axis_tick_labels_only_wrapper
 

--- a/src/backends/raster/fortplot_raster_context_impl.f90
+++ b/src/backends/raster/fortplot_raster_context_impl.f90
@@ -165,14 +165,20 @@ contains
                                              title_str, xlabel_str, ylabel_str)
             end if
         else
-            ! Delegate to standard 2D axes module
+            ! Delegate to standard 2D axes module. this%{x,y}_{min,max} carry the
+            ! margin-expanded view set via set_coordinates; pass them so linear
+            ! ticks cover the rendered view and align with the data.
             call raster_draw_axes_and_labels(this%raster, this%width, this%height, &
                                              this%plot_area, &
                                              xscale, yscale, symlog_threshold, &
                                              x_min, x_max, y_min, y_max, &
                                              title, xlabel, ylabel, &
                                              x_date_format=x_date_format, &
-                                             y_date_format=y_date_format)
+                                             y_date_format=y_date_format, &
+                                             view_x_min=this%x_min, &
+                                             view_x_max=this%x_max, &
+                                             view_y_min=this%y_min, &
+                                             view_y_max=this%y_max)
         end if
     end subroutine raster_draw_axes_and_labels_context
 
@@ -192,11 +198,16 @@ contains
         ! Set color to black for axes and ticks
         call this%color(0.0_wp, 0.0_wp, 0.0_wp)
 
-        ! Delegate to axes module
+        ! Delegate to axes module. this%{x,y}_{min,max} carry the
+        ! margin-expanded view (set via set_coordinates) for tick coverage.
         call raster_draw_axes_lines_and_ticks(this%raster, this%width, this%height, &
                                               this%plot_area, &
                                               xscale, yscale, symlog_threshold, &
-                                              x_min, x_max, y_min, y_max)
+                                              x_min, x_max, y_min, y_max, &
+                                              view_x_min=this%x_min, &
+                                              view_x_max=this%x_max, &
+                                              view_y_min=this%y_min, &
+                                              view_y_max=this%y_max)
     end subroutine raster_draw_axes_lines_and_ticks_context
 
     module subroutine raster_draw_axis_labels_only_context(this, xscale, yscale, &
@@ -226,7 +237,8 @@ contains
         ! Set color to black for text
         call this%color(0.0_wp, 0.0_wp, 0.0_wp)
 
-        ! Delegate to axes module
+        ! Delegate to axes module. this%{x,y}_{min,max} carry the
+        ! margin-expanded view (set via set_coordinates) for tick coverage.
         call raster_draw_axis_labels_only(this%raster, this%width, this%height, &
                                           this%plot_area, &
                                           xscale, yscale, symlog_threshold, &
@@ -235,7 +247,11 @@ contains
                                           custom_xticks, custom_xtick_labels, &
                                           custom_yticks, custom_ytick_labels, &
                                           x_date_format=x_date_format, &
-                                          y_date_format=y_date_format)
+                                          y_date_format=y_date_format, &
+                                          view_x_min=this%x_min, &
+                                          view_x_max=this%x_max, &
+                                          view_y_min=this%y_min, &
+                                          view_y_max=this%y_max)
     end subroutine raster_draw_axis_labels_only_context
 
     !! ── Coordinate management ──────────────────────────────────────────

--- a/src/backends/vector/pdf/fortplot_pdf_axes.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes.f90
@@ -113,7 +113,8 @@ contains
                                    plot_area_height, &
                                    symlog_threshold, &
                                    custom_xticks, custom_xtick_labels, &
-                                   custom_yticks, custom_ytick_labels)
+                                   custom_yticks, custom_ytick_labels, &
+                                   view_x_min, view_x_max, view_y_min, view_y_max)
         !! Generate tick positions and labels for axes
         type(pdf_context_core), intent(in) :: ctx
         real(wp), intent(in) :: data_x_min, data_x_max, data_y_min, data_y_max
@@ -128,6 +129,8 @@ contains
         real(wp), intent(in), optional :: custom_xticks(:), custom_yticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         ! Calculate number of ticks and allocate arrays
         call initialize_tick_arrays(plot_area_width, plot_area_height, num_x_ticks, &
@@ -141,7 +144,8 @@ contains
                                    date_format=x_date_format, &
                                    symlog_threshold=symlog_threshold, &
                                    custom_xticks=custom_xticks, &
-                                   custom_xtick_labels=custom_xtick_labels)
+                                   custom_xtick_labels=custom_xtick_labels, &
+                                   view_min=view_x_min, view_max=view_x_max)
 
         ! Generate Y axis ticks
         call generate_y_axis_ticks(data_y_min, data_y_max, num_y_ticks, &
@@ -150,7 +154,8 @@ contains
                                    date_format=y_date_format, &
                                    symlog_threshold=symlog_threshold, &
                                    custom_yticks=custom_yticks, &
-                                   custom_ytick_labels=custom_ytick_labels)
+                                   custom_ytick_labels=custom_ytick_labels, &
+                                   view_min=view_y_min, view_max=view_y_max)
 
     end subroutine generate_tick_data
 
@@ -161,7 +166,8 @@ contains
                                         plot_area_left, plot_area_bottom, &
                                         plot_area_width, plot_area_height, &
                                         custom_xticks, custom_xtick_labels, &
-                                        custom_yticks, custom_ytick_labels)
+                                        custom_yticks, custom_ytick_labels, &
+                                        view_x_min, view_x_max, view_y_min, view_y_max)
         !! Draw complete axes system with labels using actual plot area coordinates
         type(pdf_context_core), intent(inout) :: ctx
         character(len=*), intent(in), optional :: xscale, yscale
@@ -174,6 +180,8 @@ contains
         real(wp), intent(in), optional :: custom_xticks(:), custom_yticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         real(wp), allocatable :: x_positions(:), y_positions(:)
         character(len=50), allocatable :: x_labels(:), y_labels(:)
@@ -192,7 +200,9 @@ contains
                                custom_xticks=custom_xticks, &
                                custom_xtick_labels=custom_xtick_labels, &
                                custom_yticks=custom_yticks, &
-                               custom_ytick_labels=custom_ytick_labels)
+                               custom_ytick_labels=custom_ytick_labels, &
+                               view_x_min=view_x_min, view_x_max=view_x_max, &
+                               view_y_min=view_y_min, view_y_max=view_y_max)
 
         ! Draw axes elements
         call draw_axes_elements(ctx, x_positions, y_positions, x_labels, y_labels, &
@@ -210,7 +220,8 @@ contains
                                  plot_area_height, &
                                  symlog_threshold, &
                                  custom_xticks, custom_xtick_labels, &
-                                 custom_yticks, custom_ytick_labels)
+                                 custom_yticks, custom_ytick_labels, &
+                                 view_x_min, view_x_max, view_y_min, view_y_max)
         !! Prepare axes data ranges and generate tick positions
         type(pdf_context_core), intent(inout) :: ctx
         real(wp), intent(in) :: data_x_min, data_x_max, data_y_min, data_y_max
@@ -226,6 +237,8 @@ contains
         real(wp), intent(in), optional :: custom_xticks(:), custom_yticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
+        real(wp), intent(in), optional :: view_x_min, view_x_max
+        real(wp), intent(in), optional :: view_y_min, view_y_max
 
         call setup_axes_data_ranges(ctx, data_x_min, data_x_max, data_y_min, &
                                     data_y_max, &
@@ -242,7 +255,9 @@ contains
                                 custom_xticks=custom_xticks, &
                                 custom_xtick_labels=custom_xtick_labels, &
                                 custom_yticks=custom_yticks, &
-                                custom_ytick_labels=custom_ytick_labels)
+                                custom_ytick_labels=custom_ytick_labels, &
+                                view_x_min=view_x_min, view_x_max=view_x_max, &
+                                view_y_min=view_y_min, view_y_max=view_y_max)
     end subroutine prepare_axes_data
 
     subroutine draw_axes_elements(ctx, x_positions, y_positions, x_labels, y_labels, &

--- a/src/backends/vector/pdf/fortplot_pdf_axes_io.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_io.f90
@@ -157,6 +157,9 @@ contains
                                            real(this%plot_area%width, wp), &
                                            real(this%plot_area%height, wp))
         else
+            ! this%{x,y}_{min,max} hold the margin-expanded view set via
+            ! set_coordinates; pass them so linear ticks cover the rendered view
+            ! and align with the data, like the raster backend and matplotlib.
             call draw_pdf_axes_and_labels(this%core_ctx, xscale, yscale, &
                                           symlog_threshold, x_min, x_max, y_min, &
                                           y_max, title_str, xlabel_str, ylabel_str, &
@@ -173,7 +176,9 @@ contains
                                           custom_xticks=this%custom_xtick_positions, &
                                           custom_xtick_labels=this%custom_xtick_labels, &
                                           custom_yticks=this%custom_ytick_positions, &
-                                          custom_ytick_labels=this%custom_ytick_labels)
+                                          custom_ytick_labels=this%custom_ytick_labels, &
+                                          view_x_min=this%x_min, view_x_max=this%x_max, &
+                                          view_y_min=this%y_min, view_y_max=this%y_max)
         end if
     end subroutine draw_axes_and_labels_backend_wrapper
 

--- a/src/backends/vector/pdf/fortplot_pdf_axes_tick_data.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_tick_data.f90
@@ -49,7 +49,8 @@ contains
     subroutine generate_x_axis_ticks(data_min, data_max, num_ticks, plot_left, &
                                      plot_width, &
                                      positions, labels, scale_type, date_format, &
-                                     symlog_threshold, custom_xticks, custom_xtick_labels)
+                                     symlog_threshold, custom_xticks, &
+                                     custom_xtick_labels, view_min, view_max)
         !! Generate X axis tick positions and labels
         real(wp), intent(in) :: data_min, data_max, plot_left, plot_width
         integer, intent(inout) :: num_ticks
@@ -60,19 +61,22 @@ contains
         real(wp), intent(in), optional :: symlog_threshold
         real(wp), intent(in), optional :: custom_xticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
+        real(wp), intent(in), optional :: view_min, view_max
 
         call generate_axis_ticks_internal(data_min, data_max, num_ticks, plot_left, &
                                           plot_width, &
                                           positions, labels, scale_type, date_format, &
                                           symlog_threshold, 'x', &
                                           custom_xticks=custom_xticks, &
-                                          custom_xtick_labels=custom_xtick_labels)
+                                          custom_xtick_labels=custom_xtick_labels, &
+                                          view_min=view_min, view_max=view_max)
     end subroutine generate_x_axis_ticks
 
     subroutine generate_y_axis_ticks(data_min, data_max, num_ticks, plot_bottom, &
                                      plot_height, &
                                      positions, labels, scale_type, date_format, &
-                                     symlog_threshold, custom_yticks, custom_ytick_labels)
+                                     symlog_threshold, custom_yticks, &
+                                     custom_ytick_labels, view_min, view_max)
         !! Generate Y axis tick positions and labels
         real(wp), intent(in) :: data_min, data_max, plot_bottom, plot_height
         integer, intent(inout) :: num_ticks
@@ -83,13 +87,15 @@ contains
         real(wp), intent(in), optional :: symlog_threshold
         real(wp), intent(in), optional :: custom_yticks(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
+        real(wp), intent(in), optional :: view_min, view_max
 
         call generate_axis_ticks_internal(data_min, data_max, num_ticks, plot_bottom, &
                                           plot_height, &
                                           positions, labels, scale_type, date_format, &
                                           symlog_threshold, 'y', &
                                           custom_yticks=custom_yticks, &
-                                          custom_ytick_labels=custom_ytick_labels)
+                                          custom_ytick_labels=custom_ytick_labels, &
+                                          view_min=view_min, view_max=view_max)
     end subroutine generate_y_axis_ticks
 
     subroutine apply_custom_axis_ticks(axis, custom_xticks, custom_xtick_labels, &
@@ -164,13 +170,31 @@ contains
         num_ticks = used_ticks
     end subroutine apply_custom_axis_ticks
 
+    subroutine resolve_pdf_tick_view(scale, data_min, data_max, view_min, view_max, &
+                                     lo, hi)
+        !! Pick the interval over which PDF ticks are generated and positioned.
+        !! Linear axes use the margin-expanded view (so edge ticks in the margin
+        !! show and align with the data); other scales keep the data range.
+        character(len=*), intent(in) :: scale
+        real(wp), intent(in) :: data_min, data_max
+        real(wp), intent(in), optional :: view_min, view_max
+        real(wp), intent(out) :: lo, hi
+
+        lo = data_min
+        hi = data_max
+        if (trim(scale) /= 'linear') return
+        if (present(view_min)) lo = view_min
+        if (present(view_max)) hi = view_max
+    end subroutine resolve_pdf_tick_view
+
     subroutine generate_axis_ticks_internal(data_min, data_max, num_ticks, plot_start, &
                                             plot_size, &
                                             positions, labels, scale_type, &
                                             date_format, &
                                             symlog_threshold, axis, &
                                             custom_xticks, custom_xtick_labels, &
-                                            custom_yticks, custom_ytick_labels)
+                                            custom_yticks, custom_ytick_labels, &
+                                            view_min, view_max)
         !! Internal helper to generate axis tick positions and labels
         real(wp), intent(in) :: data_min, data_max, plot_start, plot_size
         integer, intent(inout) :: num_ticks
@@ -183,11 +207,12 @@ contains
         real(wp), intent(in), optional :: custom_xticks(:), custom_yticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: custom_ytick_labels(:)
+        real(wp), intent(in), optional :: view_min, view_max
 
         real(wp) :: tvals(MAX_TICKS)
         integer :: nt
         character(len=16) :: scale
-        real(wp) :: thr
+        real(wp) :: thr, lo, hi
         integer :: used_ticks
 
         call apply_custom_axis_ticks(axis, custom_xticks, custom_xtick_labels, &
@@ -202,7 +227,12 @@ contains
         thr = 1.0_wp
         if (present(symlog_threshold)) thr = symlog_threshold
 
-        call compute_scale_ticks(scale, data_min, data_max, thr, tvals, nt)
+        ! Generate and position ticks over the rendered view (linear axes);
+        ! the nice step still comes from the raw data range.
+        call resolve_pdf_tick_view(scale, data_min, data_max, view_min, view_max, &
+                                   lo, hi)
+        call compute_scale_ticks(scale, lo, hi, thr, tvals, nt, &
+                                 step_min=data_min, step_max=data_max)
         if (nt <= 0) then
             num_ticks = min(num_ticks, size(positions))
             if (num_ticks <= 0) then
@@ -228,7 +258,7 @@ contains
             nt = used_ticks
         end if
 
-        call fill_tick_positions_and_labels(tvals, nt, data_min, data_max, plot_start, &
+        call fill_tick_positions_and_labels(tvals, nt, lo, hi, plot_start, &
                                             plot_size, &
                                             used_ticks, positions, labels, scale, thr, &
                                             date_format)

--- a/src/figures/fortplot_figure_grid.f90
+++ b/src/figures/fortplot_figure_grid.f90
@@ -75,8 +75,10 @@ contains
                                 symlog_threshold, x_min, x_max, y_min, y_max, &
                                 x_min_transformed, x_max_transformed, &
                                 y_min_transformed, y_max_transformed, grid_linestyle, &
-                                grid_color_hex)
+                                grid_color_hex, &
+                                sticky_x_min, sticky_x_max, sticky_y_min, sticky_y_max)
         !! Render grid lines on the figure
+        use fortplot_figure_rendering_pipeline, only: expand_data_range
         class(plot_context), intent(inout) :: backend
         logical, intent(in) :: grid_enabled
         character(len=10), intent(in) :: grid_which
@@ -91,13 +93,16 @@ contains
         real(wp), intent(in) :: y_min_transformed, y_max_transformed
         character(len=*), intent(in) :: grid_linestyle
         character(len=*), intent(in), optional :: grid_color_hex
-        
+        logical, intent(in), optional :: sticky_x_min, sticky_x_max
+        logical, intent(in), optional :: sticky_y_min, sticky_y_max
+
         real(wp) :: major_ticks(50)
         real(wp) :: tick_val, x1, y1, x2, y2, alpha_val
         integer :: i, num_ticks
         real(wp) :: grid_color(3)
         character(len=:), allocatable :: style
         real(wp) :: xmin_t, xmax_t, ymin_t, ymax_t
+        real(wp) :: vx_min, vx_max, vy_min, vy_max
         
         if (.not. grid_enabled) return
 
@@ -134,17 +139,35 @@ contains
         call backend%color(grid_color(1), grid_color(2), grid_color(3))
         call backend%set_line_style(style)
 
+        ! Margin-expanded view (sticky-aware) so gridlines reach the edge ticks
+        ! that now fall in the margin, staying aligned with the major ticks.
+        ! Only linear axes expand; log/symlog keep the data range.
+        vx_min = x_min; vx_max = x_max
+        vy_min = y_min; vy_max = y_max
+        if (trim(xscale) == 'linear') &
+            call expand_data_range(x_min, x_max, vx_min, vx_max, &
+                                   sticky_x_min, sticky_x_max)
+        if (trim(yscale) == 'linear') &
+            call expand_data_range(y_min, y_max, vy_min, vy_max, &
+                                   sticky_y_min, sticky_y_max)
+
         ! Draw X-axis grid lines (vertical lines)
         if (grid_axis == 'x' .or. grid_axis == 'b') then
-            ! Get major ticks for x-axis
-            call compute_scale_ticks(xscale, x_min, x_max, &
-                                   symlog_threshold, major_ticks, num_ticks)
-            
+            ! Get major ticks for x-axis over the rendered view
+            if (trim(xscale) == 'linear') then
+                call compute_scale_ticks(xscale, vx_min, vx_max, &
+                                       symlog_threshold, major_ticks, num_ticks, &
+                                       step_min=x_min, step_max=x_max)
+            else
+                call compute_scale_ticks(xscale, x_min, x_max, &
+                                       symlog_threshold, major_ticks, num_ticks)
+            end if
+
             ! Draw major tick grid lines
             if (grid_which == 'major' .or. grid_which == 'both') then
                 do i = 1, num_ticks
                     tick_val = major_ticks(i)
-                    if (tick_val >= x_min .and. tick_val <= x_max) then
+                    if (tick_val >= vx_min .and. tick_val <= vx_max) then
                         ! Transform tick value to backend data coordinates
                         tick_val = apply_scale_transform(tick_val, xscale, symlog_threshold)
                         
@@ -163,15 +186,21 @@ contains
         
         ! Draw Y-axis grid lines (horizontal lines)
         if (grid_axis == 'y' .or. grid_axis == 'b') then
-            ! Get major ticks for y-axis
-            call compute_scale_ticks(yscale, y_min, y_max, &
-                                   symlog_threshold, major_ticks, num_ticks)
-            
+            ! Get major ticks for y-axis over the rendered view
+            if (trim(yscale) == 'linear') then
+                call compute_scale_ticks(yscale, vy_min, vy_max, &
+                                       symlog_threshold, major_ticks, num_ticks, &
+                                       step_min=y_min, step_max=y_max)
+            else
+                call compute_scale_ticks(yscale, y_min, y_max, &
+                                       symlog_threshold, major_ticks, num_ticks)
+            end if
+
             ! Draw major tick grid lines
             if (grid_which == 'major' .or. grid_which == 'both') then
                 do i = 1, num_ticks
                     tick_val = major_ticks(i)
-                    if (tick_val >= y_min .and. tick_val <= y_max) then
+                    if (tick_val >= vy_min .and. tick_val <= vy_max) then
                         ! Transform tick value to backend data coordinates
                         tick_val = apply_scale_transform(tick_val, yscale, symlog_threshold)
 

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -48,6 +48,7 @@ module fortplot_figure_rendering_pipeline
     public :: render_streamplot_arrows
     public :: render_figure_axes_labels_only, render_title_only
     public :: render_polar_axes
+    public :: expand_data_range
 
     real(wp), parameter :: DATA_RANGE_MARGIN = 0.05_wp
 
@@ -266,13 +267,34 @@ contains
         real(wp) :: major_x(MAX_TICKS), major_y(MAX_TICKS)
         real(wp) :: minor_x(MAX_TICKS*10), minor_y(MAX_TICKS*10)
         integer :: num_major_x, num_major_y, num_minor_x, num_minor_y
+        real(wp) :: vx_min, vx_max, vy_min, vy_max
 
         if (.not. state%minor_ticks_x .and. .not. state%minor_ticks_y) return
 
+        ! Margin-expanded view (sticky-aware) so major ticks—and the minor
+        ! ticks derived from them—cover the rendered interval like matplotlib.
+        ! Only linear axes use the expanded view; log/symlog keep the data range
+        ! (their tick logic works in transformed space, where this linear-space
+        ! expansion would be wrong).
+        vx_min = x_min; vx_max = x_max
+        vy_min = y_min; vy_max = y_max
+        if (trim(xscale) == 'linear') &
+            call expand_data_range(x_min, x_max, vx_min, vx_max, &
+                                   state%sticky_x_min, state%sticky_x_max)
+        if (trim(yscale) == 'linear') &
+            call expand_data_range(y_min, y_max, vy_min, vy_max, &
+                                   state%sticky_y_min, state%sticky_y_max)
+
         ! Get major tick positions
         if (state%minor_ticks_x) then
-            call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
-                                     major_x, num_major_x)
+            if (trim(xscale) == 'linear') then
+                call compute_scale_ticks(xscale, vx_min, vx_max, symlog_threshold, &
+                                         major_x, num_major_x, &
+                                         step_min=x_min, step_max=x_max)
+            else
+                call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, &
+                                         major_x, num_major_x)
+            end if
             if (num_major_x >= 2) then
                 if (trim(xscale) == 'log') then
                     call calculate_log_minor_tick_positions(major_x, num_major_x, &
@@ -281,7 +303,7 @@ contains
                 else
                     call calculate_minor_tick_positions(major_x, num_major_x, &
                                                         state%minor_tick_count, &
-                                                        x_min, x_max, &
+                                                        vx_min, vx_max, &
                                                         minor_x, num_minor_x)
                 end if
                 if (num_minor_x > 0) then
@@ -289,14 +311,20 @@ contains
                                                    backend%height, backend%plot_area, &
                                                    xscale, symlog_threshold, &
                                                    minor_x(1:num_minor_x), &
-                                                   x_min, x_max)
+                                                   vx_min, vx_max)
                 end if
             end if
         end if
 
         if (state%minor_ticks_y) then
-            call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
-                                     major_y, num_major_y)
+            if (trim(yscale) == 'linear') then
+                call compute_scale_ticks(yscale, vy_min, vy_max, symlog_threshold, &
+                                         major_y, num_major_y, &
+                                         step_min=y_min, step_max=y_max)
+            else
+                call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
+                                         major_y, num_major_y)
+            end if
             if (num_major_y >= 2) then
                 if (trim(yscale) == 'log') then
                     call calculate_log_minor_tick_positions(major_y, num_major_y, &
@@ -305,7 +333,7 @@ contains
                 else
                     call calculate_minor_tick_positions(major_y, num_major_y, &
                                                         state%minor_tick_count, &
-                                                        y_min, y_max, &
+                                                        vy_min, vy_max, &
                                                         minor_y, num_minor_y)
                 end if
                 if (num_minor_y > 0) then
@@ -313,7 +341,7 @@ contains
                                                    backend%height, backend%plot_area, &
                                                    yscale, symlog_threshold, &
                                                    minor_y(1:num_minor_y), &
-                                                   y_min, y_max)
+                                                   vy_min, vy_max)
                 end if
             end if
         end if

--- a/src/figures/management/fortplot_figure_render_steps.f90
+++ b/src/figures/management/fortplot_figure_render_steps.f90
@@ -63,7 +63,11 @@ contains
                                    state%y_min, state%y_max, &
                                    state%x_min_transformed, state%x_max_transformed, &
                                    state%y_min_transformed, state%y_max_transformed, &
-                                   state%grid_linestyle, state%grid_color)
+                                   state%grid_linestyle, state%grid_color, &
+                                   sticky_x_min=state%sticky_x_min, &
+                                   sticky_x_max=state%sticky_x_max, &
+                                   sticky_y_min=state%sticky_y_min, &
+                                   sticky_y_max=state%sticky_y_max)
         end if
         if (state%polar_projection) then
             call render_polar_axes(state%backend, state%x_min_transformed, &

--- a/src/ui/fortplot_axes.f90
+++ b/src/ui/fortplot_axes.f90
@@ -35,24 +35,34 @@ module fortplot_axes
 contains
 
     subroutine compute_scale_ticks(scale_type, data_min, data_max, threshold, &
-                                   tick_positions, num_ticks)
+                                   tick_positions, num_ticks, &
+                                   step_min, step_max)
         !! Compute tick positions for different scale types
         !!
         !! @param scale_type: Type of scale ('linear', 'log', 'symlog')
-        !! @param data_min: Minimum data value
-        !! @param data_max: Maximum data value
+        !! @param data_min: Lower edge of the interval ticks span (for the
+        !!                  rendered axis this is the margin-expanded view edge).
+        !! @param data_max: Upper edge of the interval ticks span.
         !! @param threshold: Threshold for symlog (ignored for others)
         !! @param tick_positions: Output array of tick positions
         !! @param num_ticks: Number of ticks generated
+        !! @param step_min: Lower edge of the raw data range used to pick the
+        !!                  linear nice step. When absent, [data_min, data_max]
+        !!                  is used (the historical behaviour). Passing the raw
+        !!                  data range here keeps the step matplotlib-correct
+        !!                  while ticks still cover the expanded view.
+        !! @param step_max: Upper edge of the raw data range (see step_min).
 
         character(len=*), intent(in) :: scale_type
         real(wp), intent(in) :: data_min, data_max, threshold
         real(wp), intent(out) :: tick_positions(MAX_TICKS)
         integer, intent(out) :: num_ticks
+        real(wp), intent(in), optional :: step_min, step_max
 
         select case (trim(scale_type))
         case ('linear')
-            call compute_linear_ticks(data_min, data_max, tick_positions, num_ticks)
+            call compute_linear_ticks(data_min, data_max, tick_positions, num_ticks, &
+                                      step_min, step_max)
         case ('log')
             call compute_log_ticks(data_min, data_max, tick_positions, num_ticks)
         case ('symlog')
@@ -66,31 +76,45 @@ contains
         end select
     end subroutine compute_scale_ticks
 
-    subroutine compute_linear_ticks(data_min, data_max, tick_positions, num_ticks)
-        !! Compute tick positions for linear scale
-        real(wp), intent(in) :: data_min, data_max
+    subroutine compute_linear_ticks(view_min, view_max, tick_positions, num_ticks, &
+                                    step_min, step_max)
+        !! Compute tick positions for linear scale.
+        !!
+        !! Ticks are emitted across [view_min, view_max], the interval the axis
+        !! actually renders (data range plus the 5% per-side margin, sticky
+        !! edges already folded in by the caller), so nice-step multiples that
+        !! land in the margin appear, matching matplotlib. The nice step is
+        !! selected from [step_min, step_max] (the raw data range) when given,
+        !! otherwise from the view interval. Deriving the step from the data
+        !! range keeps it matplotlib-correct even though coverage is wider.
+        real(wp), intent(in) :: view_min, view_max
         real(wp), intent(out) :: tick_positions(MAX_TICKS)
         integer, intent(out) :: num_ticks
+        real(wp), intent(in), optional :: step_min, step_max
 
-        real(wp) :: range, step, nice_step, tick_value
+        real(wp) :: step_range, view_range, step, nice_step, tick_value, hi_eps
         integer :: max_ticks_desired
 
         max_ticks_desired = 8
-        range = data_max - data_min
+        view_range = view_max - view_min
+        step_range = view_range
+        if (present(step_min) .and. present(step_max)) step_range = step_max - step_min
 
-        if (range <= 0.0_wp) then
+        if (view_range <= 0.0_wp .or. step_range <= 0.0_wp) then
             num_ticks = 0
             return
         end if
 
-        step = range/real(max_ticks_desired, wp)
+        step = step_range/real(max_ticks_desired, wp)
         nice_step = calculate_nice_step(step)
 
-        ! Find first tick >= data_min
-        tick_value = ceiling(data_min/nice_step)*nice_step
+        ! Walk nice-step multiples across the view interval, not just the data
+        ! range, so edge ticks inside the margin appear (matplotlib behaviour).
+        hi_eps = TICK_EPS*max(1.0_wp, abs(view_max))
+        tick_value = ceiling(view_min/nice_step - TICK_EPS)*nice_step
         num_ticks = 0
 
-        do while (tick_value <= data_max .and. num_ticks < MAX_TICKS)
+        do while (tick_value <= view_max + hi_eps .and. num_ticks < MAX_TICKS)
             num_ticks = num_ticks + 1
             tick_positions(num_ticks) = tick_value
             tick_value = tick_value + nice_step


### PR DESCRIPTION
## Summary

matplotlib draws axis ticks across the full view interval (data range plus the default 5% axes margin), so nice-step multiples that land in the margin appear as edge ticks. fortplot computed ticks only over the raw data range, so those edge ticks were missing even though the view extends into the margin.

`compute_linear_ticks`/`compute_scale_ticks` now take the rendered view interval plus a separate step basis:

- The nice step is still derived from the raw data range, so the `{1, 2, 2.5, 5, 10}` AutoLocator step set is unchanged.
- Linear ticks are generated and positioned across the view interval (data range plus the 5% margin the backends actually display), so margin-region edge ticks are drawn and stay aligned with the data.
- The view bounds come from each backend's coordinate system (set via `set_coordinates`, which already folds in sticky edges), threaded through the raster, PDF, grid, and minor-tick paths.
- Sticky sides (bar baselines pinned to 0; pcolormesh/contour extents flagged by `determine_sticky_edges`) pin to the data value, so they gain no out-of-range margin ticks.
- Log, symlog, date, and ASCII (no margin applied to its coordinate system) keep the data range — behaviour unchanged.

Closes #1955.

## Verification

Ground truth from matplotlib for `multi_line` (x = `arange(0,100)/5` → data `[0, 19.8]`, sin/cos):

- `xlim = [-0.99, 20.79]`, visible x ticks `0.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0` (step 2.5)
- visible y ticks `-1.0, -0.75, …, 1.0` (step 0.25)

fortplot after the change (verified via a direct `compute_scale_ticks` call and `pdftotext`):

```
X view -0.99 .. 20.79  n=9:  0.00 2.50 5.00 7.50 10.00 12.50 15.00 17.50 20.00
Y view -1.10 .. 1.10   n=9: -1.00 -0.75 -0.50 -0.25 0.00 0.25 0.50 0.75 1.00
pdftotext multi_line.pdf: ... 0.0 2.5 5.0 7.5 ... 15.0 17.5 20.0 ; y 1.00 .. -1.00
```

Before the fix the x axis stopped at 17.5 (no 0.0 / 20.0) and the y axis topped at 0.9; `scatter_basic` now shows the x=0 and y=-1.0/1.0 edge ticks. PNG renders for `multi_line` and `scatter_basic` match matplotlib's edge ticks.

Commands run:

- `make build` — passes.
- `fpm test` (full suite) — exit 0, zero failures. No test expectations needed changing: the step-selection test (`test_maxnlocator_steps`) exercises `find_nice_tick_locations` (unchanged), and direct `compute_scale_ticks` callers in tests pass no view bounds, so they keep the data-range behaviour. Targeted suites re-run green: `test_maxnlocator_steps`, `test_minor_ticks`, `test_tick_formatting_digits`, `test_log_scale_ticks`, `test_log_symlog_ticks`, `test_scale_implementation`, `test_scaling`, `test_symlog_axes_implementation`, `test_axes_labels_comprehensive`, `test_axis_label_offsets_pdf`, `test_axis_label_overlap_1573`, `test_ylabel`.
- `make verify-artifacts` — passes.

Sticky check: `bar_chart_demo` keeps baselines pinned (e.g. horizontal bars show x ticks `0, 20, 40, 60, 80` with no negative or beyond-max tick; categorical chart tops at `60` only because data max is `61`). `pcolormesh_negative` and `contour_demo` show no spurious out-of-range ticks.