### PR TITLE
feat: animate 3D view angle with fixed limits

### DIFF
--- a/example/fortran/3d_animation_demo/3d_animation_demo.f90
+++ b/example/fortran/3d_animation_demo/3d_animation_demo.f90
@@ -1,8 +1,10 @@
 program three_d_animation_demo
-    !! Animate a rotating 3D Lissajous curve and save it to MP4 and ASCII.
+    !! Animate a 3D Lissajous curve by rotating the camera and save it to
+    !! MP4 and ASCII.
     !!
-    !! Demonstrates that animation works the same way for vector/raster
-    !! backends (.mp4) and the ASCII backend (.txt).
+    !! The data and the axis limits stay fixed; only the view azimuth advances
+    !! per frame (matplotlib's ax.view_init(elev, azim) pattern), so the 3D box
+    !! keeps a constant shape instead of rescaling.
     use iso_fortran_env, only: wp => real64
     use fortplot
     use fortplot_animation
@@ -34,8 +36,9 @@ program three_d_animation_demo
     pfig => get_global_figure()
     call add_3d_plot(xs, ys, zs, label="Lissajous 3D", linestyle='-')
     call title("Rotating 3D Lissajous")
+    call set_fixed_limits()
 
-    anim = FuncAnimation(rotate_curve, frames=N_FRAMES, interval=33, fig=pfig)
+    anim = FuncAnimation(rotate_view, frames=N_FRAMES, interval=33, fig=pfig)
 
     print *, "Saving 3D animation as MP4..."
     call save_animation(anim, OUTDIR // "/animation.mp4", fps=30, status=status)
@@ -52,26 +55,25 @@ program three_d_animation_demo
 
 contains
 
-    subroutine rotate_curve(frame)
-        integer, intent(in) :: frame
-        real(wp) :: phase, c, s
-        integer :: k
+    subroutine set_fixed_limits()
+        !! Pin the axis box so autoscale does not refit between frames.
+        call xlim(-1.2_wp, 1.2_wp)
+        call ylim(-1.2_wp, 1.2_wp)
+    end subroutine set_fixed_limits
 
-        phase = real(frame - 1, wp) * 2.0_wp * 3.141592653589793_wp / real(N_FRAMES, wp)
-        c = cos(phase)
-        s = sin(phase)
-        do k = 1, N_POINTS
-            t = real(k - 1, wp) * 2.0_wp * 3.141592653589793_wp / real(N_POINTS - 1, wp)
-            xs(k) =  c * sin(3.0_wp * t) - s * cos(2.0_wp * t)
-            ys(k) =  s * sin(3.0_wp * t) + c * cos(2.0_wp * t)
-            zs(k) =  sin(t) * cos(t)
-        end do
+    subroutine rotate_view(frame)
+        integer, intent(in) :: frame
+        real(wp) :: azim
+
+        azim = -60.0_wp + real(frame - 1, wp) * 360.0_wp / real(N_FRAMES, wp)
 
         call pfig%clear()
+        call view_init(elev=30.0_wp, azim=azim)
         call add_3d_plot(xs, ys, zs, label="Lissajous 3D", linestyle='-')
         call title("Rotating 3D Lissajous")
+        call set_fixed_limits()
         call pfig%set_rendered(.false.)
-    end subroutine rotate_curve
+    end subroutine rotate_view
 
     subroutine report_status(label, st)
         character(len=*), intent(in) :: label

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -127,7 +127,7 @@ module fortplot
                                     add_pcolormesh, add_errorbar, &
                                     add_3d_plot, add_surface, add_scatter, &
                                     set_xscale, set_yscale, xscale, yscale, &
-                                    xlim, ylim, &
+                                    xlim, ylim, view_init, &
                                     set_line_width, set_ydata, use_axis, &
                                     get_active_axis, minorticks_on, &
                                     axhline, axvline, hlines, vlines, &
@@ -169,7 +169,7 @@ module fortplot
     ! Figure management and configuration
     public :: figure, subplot, subplots, subplots_grid
     public :: xlabel, ylabel, title, suptitle, legend, grid
-    public :: xlim, ylim, set_xscale, set_yscale, xscale, yscale
+    public :: xlim, ylim, view_init, set_xscale, set_yscale, xscale, yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on
     public :: set_xticks, set_yticks
     public :: savefig, savefig_with_status

--- a/src/core/fortplot_context.f90
+++ b/src/core/fortplot_context.f90
@@ -16,6 +16,10 @@ module fortplot_context
     type, abstract :: plot_context
         integer :: width, height
         real(wp) :: x_min, x_max, y_min, y_max
+        ! 3D view angles (radians), matplotlib defaults: azim=-60 deg, elev=30 deg
+        real(wp) :: view_azim = -1.0471975511965976_wp
+        real(wp) :: view_elev = 0.5235987755982988_wp
+        real(wp) :: view_dist = 10.0_wp
         ! Arrow rendering properties
         logical :: has_rendered_arrows = .false.
         logical :: uses_vector_arrows = .false.

--- a/src/figures/core/fortplot_figure_core_config.f90
+++ b/src/figures/core/fortplot_figure_core_config.f90
@@ -26,6 +26,7 @@ module fortplot_figure_core_config
     public :: core_set_xscale, core_set_yscale, core_set_xlim, core_set_ylim
     public :: core_set_xaxis_date_format, core_set_yaxis_date_format
     public :: core_set_line_width, core_grid
+    public :: set_view_figure, core_set_view
 
 contains
 
@@ -127,6 +128,19 @@ contains
         call set_figure_limits(state, y_min=y_min, y_max=y_max)
     end subroutine set_ylim_figure
 
+    subroutine set_view_figure(state, elev, azim, dist)
+        !! Set the 3D view angles (degrees) and optional camera distance.
+        !! Mirrors matplotlib's Axes3D.view_init(elev, azim).
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in), optional :: elev, azim, dist
+        real(wp), parameter :: DEG2RAD = 3.14159265358979323846_wp / 180.0_wp
+
+        if (present(elev)) state%view_elev = elev * DEG2RAD
+        if (present(azim)) state%view_azim = azim * DEG2RAD
+        if (present(dist)) state%view_dist = dist
+        state%rendered = .false.
+    end subroutine set_view_figure
+
     subroutine set_line_width_figure(state, width)
         !! Set line width for subsequent plots
         type(figure_state_t), intent(inout) :: state
@@ -202,6 +216,12 @@ contains
         real(wp), intent(in) :: x_min, x_max
         call set_xlim_figure(state, x_min, x_max)
     end subroutine core_set_xlim
+
+    subroutine core_set_view(state, elev, azim, dist)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in), optional :: elev, azim, dist
+        call set_view_figure(state, elev, azim, dist)
+    end subroutine core_set_view
 
     subroutine core_set_ylim(state, y_min, y_max)
         type(figure_state_t), intent(inout) :: state

--- a/src/figures/core/fortplot_figure_core_impl_state.f90
+++ b/src/figures/core/fortplot_figure_core_impl_state.f90
@@ -66,6 +66,12 @@ contains
         call core_set_ylim(self%state, y_min, y_max)
     end subroutine set_ylim
 
+    module subroutine set_view(self, elev, azim, dist)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in), optional :: elev, azim, dist
+        call core_set_view(self%state, elev, azim, dist)
+    end subroutine set_view
+
     module subroutine set_line_width(self, width)
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: width

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -32,6 +32,7 @@ module fortplot_figure_core
     use fortplot_figure_core_config, only: core_grid, core_set_xlabel, core_set_ylabel, &
                                             core_set_title, core_set_xscale, core_set_yscale, &
                                             core_set_xlim, core_set_ylim, core_set_line_width, &
+                                            core_set_view, &
                                             core_set_xaxis_date_format, core_set_yaxis_date_format
     use fortplot_figure_core_utils, only: core_set_ydata, core_figure_legend
     use fortplot_figure_core_accessors, only: core_get_width, core_get_height, &
@@ -113,6 +114,8 @@ module fortplot_figure_core
         procedure :: set_yaxis_date_format
         procedure :: set_xlim
         procedure :: set_ylim
+        procedure :: set_view
+        procedure :: view_init => set_view
         procedure :: set_line_width
         procedure :: set_ydata
         procedure :: legend => figure_legend
@@ -563,6 +566,11 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             class(figure_t), intent(inout) :: self
             real(wp), intent(in) :: y_min, y_max
         end subroutine set_ylim
+
+        module subroutine set_view(self, elev, azim, dist)
+            class(figure_t), intent(inout) :: self
+            real(wp), intent(in), optional :: elev, azim, dist
+        end subroutine set_view
 
         module subroutine set_line_width(self, width)
             class(figure_t), intent(inout) :: self

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -22,7 +22,6 @@ module fortplot_figure_rendering_pipeline
     use fortplot_tick_calculation, only: calculate_minor_tick_positions, &
                                          calculate_log_minor_tick_positions
     use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
-    use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
     use fortplot_rendering, only: render_line_plot, render_contour_plot, &
                                   render_pcolormesh_plot, render_fill_between_plot, &
                                   render_markers, render_boxplot_plot, &

--- a/src/figures/fortplot_surface_rendering.f90
+++ b/src/figures/fortplot_surface_rendering.f90
@@ -7,7 +7,7 @@ module fortplot_surface_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_plot_data, only: plot_data_t
-    use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
+    use fortplot_projection, only: project_3d_to_2d
     use fortplot_colormap, only: colormap_value_to_color
     implicit none
 
@@ -69,7 +69,9 @@ contains
         range_y = max(1.0e-9_wp, y_max - y_min)
         range_z = max(1.0e-9_wp, z_max - z_min)
 
-        call get_default_view_angles(azim, elev, dist)
+        azim = backend%view_azim
+        elev = backend%view_elev
+        dist = backend%view_dist
 
         x_corners = [0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, &
                      0.0_wp]

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -150,6 +150,11 @@ module fortplot_figure_initialization
         real(wp) :: tight_w_pad = 0.0_wp
         real(wp) :: tight_h_pad = 0.0_wp
 
+        ! 3D view angles (radians), matplotlib defaults: azim=-60 deg, elev=30 deg
+        real(wp) :: view_azim = -1.0471975511965976_wp  ! -60 deg
+        real(wp) :: view_elev = 0.5235987755982988_wp   ! 30 deg
+        real(wp) :: view_dist = 10.0_wp
+
         ! Polar projection configuration
         logical :: polar_projection = .false.
         real(wp) :: polar_theta_min = 0.0_wp
@@ -353,6 +358,10 @@ contains
         state%tight_pad = 1.08_wp
         state%tight_w_pad = 0.0_wp
         state%tight_h_pad = 0.0_wp
+
+        state%view_azim = -1.0471975511965976_wp
+        state%view_elev = 0.5235987755982988_wp
+        state%view_dist = 10.0_wp
 
         state%polar_projection = .false.
         state%polar_theta_min = 0.0_wp

--- a/src/figures/management/fortplot_figure_render_steps.f90
+++ b/src/figures/management/fortplot_figure_render_steps.f90
@@ -44,6 +44,12 @@ contains
         type(figure_state_t), intent(inout) :: state
         logical, intent(in) :: ascii_bk
 
+        ! Propagate stored 3D view angles so render-time projection (axes,
+        ! surfaces) matches the figure's current view.
+        state%backend%view_azim = state%view_azim
+        state%backend%view_elev = state%view_elev
+        state%backend%view_dist = state%view_dist
+
         call setup_coordinate_system(state%backend, &
                                      state%x_min_transformed, state%x_max_transformed, &
                                      state%y_min_transformed, state%y_max_transformed, &

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -17,7 +17,7 @@ module fortplot_matplotlib
         add_contour, add_contour_filled, add_contourf, add_pcolormesh, &
         add_surface, add_quiver, colorbar, &
         xlabel, ylabel, title, suptitle, legend, grid, &
-        xlim, ylim, set_xscale, set_yscale, xscale, yscale, &
+        xlim, ylim, view_init, set_xscale, set_yscale, xscale, yscale, &
         set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, axis, &
         tight_layout, axhline, axvline, hlines, vlines, set_xticks, set_yticks, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
@@ -46,7 +46,7 @@ module fortplot_matplotlib
 
     ! Axis and annotation functions
     public :: xlabel, ylabel, title, suptitle, legend, grid
-    public :: xlim, ylim, set_xscale, set_yscale, xscale, yscale
+    public :: xlim, ylim, view_init, set_xscale, set_yscale, xscale, yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on, axis
     public :: tight_layout
     public :: axhline, axvline, hlines, vlines

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -13,7 +13,8 @@ module fortplot_matplotlib_advanced
     use fortplot_matplotlib_vector_wrappers, only: &
         streamplot, quiver, add_quiver
     use fortplot_matplotlib_axes, only: &
-        xlabel, ylabel, title, suptitle, legend, grid, xlim, ylim, set_xscale, &
+        xlabel, ylabel, title, suptitle, legend, grid, xlim, ylim, view_init, &
+        set_xscale, &
         set_yscale, xscale, yscale, set_line_width, set_ydata, use_axis, &
         get_active_axis, minorticks_on, axis, tight_layout, &
         axhline, axvline, hlines, vlines, set_xticks, set_yticks
@@ -40,7 +41,7 @@ module fortplot_matplotlib_advanced
     public :: add_quiver
 
     public :: xlabel, ylabel, title, suptitle, legend, grid
-    public :: xlim, ylim, set_xscale, set_yscale, xscale, yscale
+    public :: xlim, ylim, view_init, set_xscale, set_yscale, xscale, yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: minorticks_on, axis, tight_layout
     public :: axhline, axvline, hlines, vlines

--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -17,6 +17,7 @@ module fortplot_matplotlib_axes
     public :: grid
     public :: xlim
     public :: ylim
+    public :: view_init
     public :: set_xscale
     public :: set_yscale
     public :: xscale
@@ -201,6 +202,13 @@ contains
         call ensure_fig_init()
         call fig%set_ylim(ymin, ymax)
     end subroutine ylim
+
+    subroutine view_init(elev, azim, dist)
+        !! Set the 3D view angles (degrees) like matplotlib's view_init.
+        real(wp), intent(in), optional :: elev, azim, dist
+        call ensure_fig_init()
+        call fig%set_view(elev=elev, azim=azim, dist=dist)
+    end subroutine view_init
 
     subroutine set_xscale(scale, linthresh, threshold, base, linscale)
         !! Set x-axis scale (matplotlib-compatible)

--- a/src/plotting/fortplot_3d_axes.f90
+++ b/src/plotting/fortplot_3d_axes.f90
@@ -9,7 +9,7 @@ module fortplot_3d_axes
     use fortplot_tick_calculation, only: find_nice_tick_locations, &
                                        format_tick_value_consistent, &
                                        determine_decimal_places_from_step
-    use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
+    use fortplot_projection, only: project_3d_to_2d
     implicit none
     
     private
@@ -60,8 +60,10 @@ contains
         ! Validate input ranges
         if (x_max <= x_min .or. y_max <= y_min .or. z_max <= z_min) return
         
-        ! Set up 3D projection
-        call get_default_view_angles(azim, elev, dist)
+        ! Set up 3D projection using the backend's stored view angles
+        azim = ctx%view_azim
+        elev = ctx%view_elev
+        dist = ctx%view_dist
         call create_unit_cube(corners_3d)
         call project_to_2d(corners_3d, azim, elev, dist, corners_2d)
         call scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)

--- a/src/plotting/fortplot_3d_plots.f90
+++ b/src/plotting/fortplot_3d_plots.f90
@@ -7,7 +7,7 @@ module fortplot_3d_plots
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t
     use fortplot_2d_plots, only: add_line_plot_data
-    use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
+    use fortplot_projection, only: project_3d_to_2d
     use fortplot_logging, only: log_error
 
     implicit none
@@ -59,7 +59,6 @@ contains
         real(wp), intent(in), optional :: color(3)
         integer :: n_points, plot_idx, previous_count
         real(wp), allocatable :: x_proj(:), y_proj(:)
-        real(wp) :: azim, elev, dist
 
         n_points = size(x)
         if (size(y) /= n_points .or. size(z) /= n_points) then
@@ -74,8 +73,8 @@ contains
 
         allocate(x_proj(n_points))
         allocate(y_proj(n_points))
-        call get_default_view_angles(azim, elev, dist)
-        call project_3d_to_2d(x, y, z, azim, elev, dist, x_proj, y_proj)
+        call project_3d_to_2d(x, y, z, self%state%view_azim, self%state%view_elev, &
+                              self%state%view_dist, x_proj, y_proj)
 
         previous_count = self%plot_count
         call add_line_plot_data(self, x_proj, y_proj, label, linestyle, color_rgb=color, marker=marker)

--- a/src/plotting/fortplot_scatter_plots.f90
+++ b/src/plotting/fortplot_scatter_plots.f90
@@ -8,7 +8,7 @@ module fortplot_scatter_plots
     use fortplot_figure_core, only: figure_t
     use fortplot_figure_core_advanced, only: core_scatter
     use fortplot_figure_plot_management, only: next_plot_color
-    use fortplot_projection, only: project_3d_to_2d, get_default_view_angles
+    use fortplot_projection, only: project_3d_to_2d
     use fortplot_logging, only: log_error
 
     implicit none
@@ -100,7 +100,6 @@ contains
 
         real(wp) :: default_color(3)
         real(wp), allocatable :: x_proj(:), y_proj(:)
-        real(wp) :: azim, elev, dist
         logical :: use_projection
         integer :: plot_idx, n_points, previous_count
 
@@ -125,8 +124,9 @@ contains
 
             allocate (x_proj(n_points))
             allocate (y_proj(n_points))
-            call get_default_view_angles(azim, elev, dist)
-            call project_3d_to_2d(x, y, z, azim, elev, dist, x_proj, y_proj)
+            call project_3d_to_2d(x, y, z, self%state%view_azim, &
+                                  self%state%view_elev, self%state%view_dist, &
+                                  x_proj, y_proj)
         end if
 
         previous_count = self%plot_count


### PR DESCRIPTION
## Summary

The 3D animation example rescaled its axis box every frame because it rotated the data, cleared the figure, re-added the rotated data, and let autoscale refit the projection. matplotlib instead keeps the data and limits fixed and rotates the camera via `ax.view_init(elev, azim)`.

This adds a per-figure 3D view-angle setter and animates that instead of the data.

## Changes

- Store `view_azim`/`view_elev`/`view_dist` on the figure state and on the base `plot_context`, defaulting to the matplotlib values (azim = -60 deg, elev = 30 deg, dist = 10). These are the exact values previously returned by `get_default_view_angles`, so 3D plots render identically when no view is set.
- Expose `set_view(elev, azim, dist)` / `view_init` on the figure facade and a global `view_init` through the matplotlib/pyplot interface and the top-level `fortplot` module.
- Read the stored angles at every 3D projection call site instead of the hardcoded default:
  - `src/plotting/fortplot_3d_plots.f90` and `src/plotting/fortplot_scatter_plots.f90` read `self%state%view_*` (data projected at add time).
  - `src/plotting/fortplot_3d_axes.f90` and `src/figures/fortplot_surface_rendering.f90` read `ctx%/backend%view_*` (projected at render time).
  - The render pipeline copies the figure's view angles onto the backend before drawing (`fortplot_figure_render_steps.f90`).
  - Removed the now-unused `get_default_view_angles` import from `fortplot_figure_rendering_pipeline.f90`.
- Rewrote `example/fortran/3d_animation_demo/3d_animation_demo.f90` to pin `xlim`/`ylim` and step the azimuth per frame via `view_init`, keeping the data and box fixed.

## Verification

Commands run:

- `make build` — succeeds.
- `fpm test --target test_3d` — 12/12 pass, including `test_line_projection`, `test_scatter_projection`, `test_projection_elevation_rotation`.
- `test_3d_backend_parity`, `test_surface_plot_storage`, `test_is_3d_empty_allocation`, `test_animation_clear_regression`, `test_animation_txt_save` — all pass (exit 0).
- `make test-ci` — `CI essential test suite completed successfully`.
- `make verify-artifacts` — `Artifact verification passed.` (static 3D plotting output unchanged).

Box stability (regenerated `output/example/fortran/3d_animation_demo/animation.txt`, 60 frames). Axis tick labels are byte-identical across frames, proving the box no longer rescales while the azimuth advances:

```
frame1  axis numbers: ['-0.5', '-1.0', '-1.01', '0.0', '0.5', '1.0']
frame30 axis numbers: ['-0.5', '-1.0', '-1.01', '0.0', '0.5', '1.0']
frame60 axis numbers: ['-0.5', '-1.0', '-1.01', '0.0', '0.5', '1.0']
identical(1==30==60): True
```

Canvas dimensions are constant across frames (38 lines x 82 columns; the final frame differs only in stripped trailing blank lines).

Before this change the example mutated the data and never pinned limits, so autoscale refit each cleared frame and the box grew and shrank during playback.

Closes #1950
