### PR TITLE
fix: 3D panes/gridlines and depth ordering (mplot3d-style)

### DIFF
--- a/src/core/fortplot_projection.f90
+++ b/src/core/fortplot_projection.f90
@@ -1,113 +1,122 @@
 module fortplot_projection
     !! 3D to 2D projection module for rendering 3D plots in 2D backends
-    !! 
+    !!
     !! Based on matplotlib's implementation with default viewing angles:
     !! - azimuth: -60 degrees
-    !! - elevation: 30 degrees  
+    !! - elevation: 30 degrees
     !! - distance: 10 units
     !! - perspective projection with focal_length = 1
-    
+
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
-    
+
     private
     public :: project_3d_to_2d, get_default_view_angles, create_projection_matrix
-    
+
     real(wp), parameter :: PI = 3.14159265358979323846_wp
-    
+
 contains
 
     subroutine get_default_view_angles(azim, elev, dist)
         !! Get default viewing angles matching matplotlib
         real(wp), intent(out) :: azim, elev, dist
-        
-        azim = -60.0_wp * PI / 180.0_wp  ! -60 degrees
-        elev = 30.0_wp * PI / 180.0_wp   ! 30 degrees  
+
+        azim = -60.0_wp*PI/180.0_wp  ! -60 degrees
+        elev = 30.0_wp*PI/180.0_wp   ! 30 degrees
         dist = 10.0_wp                   ! 10 units from origin
     end subroutine get_default_view_angles
-    
+
     subroutine create_projection_matrix(azim, elev, dist, proj_matrix)
         !! Create 4x4 projection matrix for 3D to 2D transformation
         real(wp), intent(in) :: azim, elev, dist
-        real(wp), intent(out) :: proj_matrix(4,4)
-        
+        real(wp), intent(out) :: proj_matrix(4, 4)
+
         real(wp) :: cos_azim, sin_azim, cos_elev, sin_elev
-        real(wp) :: rotation(3,3)
-        
+        real(wp) :: rotation(3, 3)
+
         ! Initialize matrix
         proj_matrix = 0.0_wp
-        
+
         ! Calculate trig functions
         cos_azim = cos(azim)
         sin_azim = sin(azim)
         cos_elev = cos(elev)
         sin_elev = sin(elev)
-        
+
         ! Create rotation matrix (simplified approach)
         ! First rotate around z-axis (azimuth), then around x-axis (elevation)
-        rotation(1,1) = cos_azim
-        rotation(1,2) = sin_azim * sin_elev
-        rotation(1,3) = sin_azim * cos_elev
-        
-        rotation(2,1) = -sin_azim
-        rotation(2,2) = cos_azim * sin_elev
-        rotation(2,3) = cos_azim * cos_elev
-        
-        rotation(3,1) = 0.0_wp
-        rotation(3,2) = -cos_elev
-        rotation(3,3) = sin_elev
-        
+        rotation(1, 1) = cos_azim
+        rotation(1, 2) = sin_azim*sin_elev
+        rotation(1, 3) = sin_azim*cos_elev
+
+        rotation(2, 1) = -sin_azim
+        rotation(2, 2) = cos_azim*sin_elev
+        rotation(2, 3) = cos_azim*cos_elev
+
+        rotation(3, 1) = 0.0_wp
+        rotation(3, 2) = -cos_elev
+        rotation(3, 3) = sin_elev
+
         ! Build 4x4 projection matrix
-        proj_matrix(1:3,1:3) = rotation
-        proj_matrix(4,4) = 1.0_wp
-        
+        proj_matrix(1:3, 1:3) = rotation
+        proj_matrix(4, 4) = 1.0_wp
+
         ! No perspective for now - orthographic projection
         ! This simplifies the math and avoids the scaling issues
     end subroutine create_projection_matrix
 
-    subroutine project_3d_to_2d(x3d, y3d, z3d, azim, elev, dist, x2d, y2d)
-        !! Project 3D coordinates to 2D using orthographic projection
+    subroutine project_3d_to_2d(x3d, y3d, z3d, azim, elev, dist, x2d, y2d, depth)
+        !! Project 3D coordinates to 2D using orthographic projection.
+        !!
+        !! The optional depth output is the camera-space depth (distance toward
+        !! the viewer) under the same rotation used for the screen coordinates:
+        !! larger values are closer to the front. Callers that omit depth are
+        !! unaffected, so existing behavior is preserved.
         real(wp), contiguous, intent(in) :: x3d(:), y3d(:), z3d(:)
         real(wp), intent(in) :: azim, elev, dist
         real(wp), intent(out) :: x2d(size(x3d)), y2d(size(x3d))
-        
+        real(wp), intent(out), optional :: depth(size(x3d))
+
         real(wp) :: cos_azim, sin_azim, cos_elev, sin_elev
         real(wp) :: x_rot, y_rot, z_rot
         integer :: i, n
-        
+
         n = size(x3d)
-        
+
         ! Calculate trig functions
         cos_azim = cos(azim)
         sin_azim = sin(azim)
         cos_elev = cos(elev)
         sin_elev = sin(elev)
-        
+
         ! Transform each point using simplified rotation
         do i = 1, n
             ! Rotate around z-axis (azimuth)
-            x_rot = x3d(i) * cos_azim - y3d(i) * sin_azim
-            y_rot = x3d(i) * sin_azim + y3d(i) * cos_azim
+            x_rot = x3d(i)*cos_azim - y3d(i)*sin_azim
+            y_rot = x3d(i)*sin_azim + y3d(i)*cos_azim
             z_rot = z3d(i)
-            
+
             ! Rotate around x-axis (elevation)
             ! Project to 2D (drop the rotated z component)
             x2d(i) = x_rot
-            y2d(i) = y_rot * cos_elev - z_rot * sin_elev
+            y2d(i) = y_rot*cos_elev - z_rot*sin_elev
+            ! Camera depth: same convention as the surface renderer's
+            ! mean_view_depth (larger = nearer the viewer).
+            if (present(depth)) depth(i) = y_rot*sin_elev + z_rot*cos_elev
         end do
     end subroutine project_3d_to_2d
 
     subroutine matrix_multiply(A, B, C)
         !! Multiply two 4x4 matrices: C = A * B
-        real(wp), intent(in) :: A(4,4), B(4,4)
-        real(wp), intent(out) :: C(4,4)
+        real(wp), intent(in) :: A(4, 4), B(4, 4)
+        real(wp), intent(out) :: C(4, 4)
         integer :: i, j, k
-        
+
         do i = 1, 4
             do j = 1, 4
-                C(i,j) = 0.0_wp
+                C(i, j) = 0.0_wp
                 do k = 1, 4
-                    C(i,j) = C(i,j) + A(i,k) * B(k,j)
+                    C(i, j) = C(i, j) + A(i, k)*B(k, j)
                 end do
             end do
         end do
@@ -115,14 +124,14 @@ contains
 
     subroutine matrix_vector_multiply(A, v, result)
         !! Multiply 4x4 matrix by 4-element vector: result = A * v
-        real(wp), intent(in) :: A(4,4), v(4)
+        real(wp), intent(in) :: A(4, 4), v(4)
         real(wp), intent(out) :: result(4)
         integer :: i, j
-        
+
         do i = 1, 4
             result(i) = 0.0_wp
             do j = 1, 4
-                result(i) = result(i) + A(i,j) * v(j)
+                result(i) = result(i) + A(i, j)*v(j)
             end do
         end do
     end subroutine matrix_vector_multiply

--- a/src/plotting/fortplot_3d_axes.f90
+++ b/src/plotting/fortplot_3d_axes.f90
@@ -7,14 +7,20 @@ module fortplot_3d_axes
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context, only: plot_context
     use fortplot_tick_calculation, only: find_nice_tick_locations, &
-                                       format_tick_value_consistent, &
-                                       determine_decimal_places_from_step
+                                         format_tick_value_consistent, &
+                                         determine_decimal_places_from_step
     use fortplot_projection, only: project_3d_to_2d
+    use fortplot_3d_box, only: draw_back_panes, draw_pane_gridlines, &
+                               draw_box_spines, &
+                               CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, &
+                               CORNER_MAX_MAX_MIN, CORNER_MIN_MAX_MIN, &
+                               CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
+                               CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX
     implicit none
-    
+
     private
     public :: draw_3d_axes
-    
+
     ! Constants for 3D visualization - percentage of axis length for true consistency
     integer, parameter :: MAX_TICKS_PER_AXIS = 10
     ! Constants for visually consistent tick appearance (percentages of rendered axis length)
@@ -27,138 +33,114 @@ module fortplot_3d_axes
     real(wp), parameter :: VISUAL_PADDING_MIN = 0.03_wp
     real(wp), parameter :: VISUAL_PADDING_MAX = 0.12_wp
     real(wp), parameter :: EPSILON = 1.0e-12_wp            ! Numerical epsilon for divisions
-    
+
     ! Axis identification
     integer, parameter :: X_AXIS = 1, Y_AXIS = 2, Z_AXIS = 3
-    
-    ! Corner indices for readability
-    integer, parameter :: &
-        CORNER_MIN_MIN_MIN = 1, &  ! (x_min, y_min, z_min)
-        CORNER_MAX_MIN_MIN = 2, &  ! (x_max, y_min, z_min) 
-        CORNER_MAX_MAX_MIN = 3, &  ! (x_max, y_max, z_min)
-        CORNER_MIN_MAX_MIN = 4, &  ! (x_min, y_max, z_min)
-        CORNER_MIN_MIN_MAX = 5, &  ! (x_min, y_min, z_max)
-        CORNER_MAX_MIN_MAX = 6, &  ! (x_max, y_min, z_max)
-        CORNER_MAX_MAX_MAX = 7, &  ! (x_max, y_max, z_max)
-        CORNER_MIN_MAX_MAX = 8     ! (x_min, y_max, z_max)
 
 contains
 
     subroutine draw_3d_axes(ctx, x_min, x_max, y_min, y_max, z_min, z_max)
         !! Draw complete 3D axes frame with ticks and labels
-        !! 
+        !!
         !! This is the main entry point that handles all 3D axis rendering:
         !! - Projects 3D bounding box to 2D coordinates
-        !! - Draws visible axis segments 
+        !! - Draws visible axis segments
         !! - Places tick marks and labels at appropriate positions
         class(plot_context), intent(inout) :: ctx
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
-        
-        real(wp) :: corners_3d(3,8), corners_2d(2,8)
+
+        real(wp) :: corners_3d(3, 8), corners_2d(2, 8), corners_depth(8)
         real(wp) :: azim, elev, dist
-        
+
         ! Validate input ranges
         if (x_max <= x_min .or. y_max <= y_min .or. z_max <= z_min) return
-        
+
         ! Set up 3D projection using the backend's stored view angles
         azim = ctx%view_azim
         elev = ctx%view_elev
         dist = ctx%view_dist
         call create_unit_cube(corners_3d)
-        call project_to_2d(corners_3d, azim, elev, dist, corners_2d)
+        call project_to_2d(corners_3d, azim, elev, dist, corners_2d, corners_depth)
         call scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
-        
-        ! Draw the three visible axis segments
-        call draw_axis_lines(ctx, corners_2d)
-        
+
+        ! Draw back panes and pane gridlines first so they sit behind the data
+        ! (the data is rendered after this routine). Then draw the box spines.
+        call draw_back_panes(ctx, corners_2d, corners_depth)
+        call draw_pane_gridlines(ctx, corners_2d, corners_depth)
+        call draw_box_spines(ctx, corners_2d)
+
         ! Draw ticks and labels on each axis
-        call draw_all_axis_ticks(ctx, corners_2d, x_min, x_max, y_min, y_max, z_min, z_max)
+     call draw_all_axis_ticks(ctx, corners_2d, x_min, x_max, y_min, y_max, z_min, z_max)
     end subroutine draw_3d_axes
 
     subroutine create_unit_cube(corners_3d)
         !! Create unit cube vertices in normalized [0,1]³ space
-        real(wp), intent(out) :: corners_3d(3,8)
-        
+        real(wp), intent(out) :: corners_3d(3, 8)
+
         ! Define all 8 corners of unit cube systematically
-        corners_3d(:,CORNER_MIN_MIN_MIN) = [0.0_wp, 0.0_wp, 0.0_wp]
-        corners_3d(:,CORNER_MAX_MIN_MIN) = [1.0_wp, 0.0_wp, 0.0_wp]
-        corners_3d(:,CORNER_MAX_MAX_MIN) = [1.0_wp, 1.0_wp, 0.0_wp]
-        corners_3d(:,CORNER_MIN_MAX_MIN) = [0.0_wp, 1.0_wp, 0.0_wp]
-        corners_3d(:,CORNER_MIN_MIN_MAX) = [0.0_wp, 0.0_wp, 1.0_wp]
-        corners_3d(:,CORNER_MAX_MIN_MAX) = [1.0_wp, 0.0_wp, 1.0_wp]
-        corners_3d(:,CORNER_MAX_MAX_MAX) = [1.0_wp, 1.0_wp, 1.0_wp]
-        corners_3d(:,CORNER_MIN_MAX_MAX) = [0.0_wp, 1.0_wp, 1.0_wp]
+        corners_3d(:, CORNER_MIN_MIN_MIN) = [0.0_wp, 0.0_wp, 0.0_wp]
+        corners_3d(:, CORNER_MAX_MIN_MIN) = [1.0_wp, 0.0_wp, 0.0_wp]
+        corners_3d(:, CORNER_MAX_MAX_MIN) = [1.0_wp, 1.0_wp, 0.0_wp]
+        corners_3d(:, CORNER_MIN_MAX_MIN) = [0.0_wp, 1.0_wp, 0.0_wp]
+        corners_3d(:, CORNER_MIN_MIN_MAX) = [0.0_wp, 0.0_wp, 1.0_wp]
+        corners_3d(:, CORNER_MAX_MIN_MAX) = [1.0_wp, 0.0_wp, 1.0_wp]
+        corners_3d(:, CORNER_MAX_MAX_MAX) = [1.0_wp, 1.0_wp, 1.0_wp]
+        corners_3d(:, CORNER_MIN_MAX_MAX) = [0.0_wp, 1.0_wp, 1.0_wp]
     end subroutine create_unit_cube
 
-    subroutine project_to_2d(corners_3d, azim, elev, dist, corners_2d)
-        !! Project 3D corners to 2D using standard viewing transformation
-        real(wp), intent(in) :: corners_3d(3,8), azim, elev, dist
-        real(wp), intent(out) :: corners_2d(2,8)
-        
+    subroutine project_to_2d(corners_3d, azim, elev, dist, corners_2d, corners_depth)
+        !! Project 3D corners to 2D and report camera depth per corner
+        real(wp), intent(in) :: corners_3d(3, 8), azim, elev, dist
+        real(wp), intent(out) :: corners_2d(2, 8)
+        real(wp), intent(out) :: corners_depth(8)
+
         real(wp) :: x3d(8), y3d(8), z3d(8), x2d(8), y2d(8)
-        
+
         ! Extract coordinates for projection
-        x3d = corners_3d(1,:)
-        y3d = corners_3d(2,:)
-        z3d = corners_3d(3,:)
-        
-        call project_3d_to_2d(x3d, y3d, z3d, azim, elev, dist, x2d, y2d)
-        
-        corners_2d(1,:) = x2d
-        corners_2d(2,:) = y2d
+        x3d = corners_3d(1, :)
+        y3d = corners_3d(2, :)
+        z3d = corners_3d(3, :)
+
+        call project_3d_to_2d(x3d, y3d, z3d, azim, elev, dist, x2d, y2d, &
+                              depth=corners_depth)
+
+        corners_2d(1, :) = x2d
+        corners_2d(2, :) = y2d
     end subroutine project_to_2d
 
     subroutine scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
         !! Scale projected coordinates to actual data ranges
-        real(wp), intent(inout) :: corners_2d(2,8)
+        real(wp), intent(inout) :: corners_2d(2, 8)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
-        
+
         real(wp) :: proj_bounds(4), data_ranges(2)
-    integer :: i
-        
+        integer :: i
+
         ! Find projection bounds
-        proj_bounds(1) = minval(corners_2d(1,:))  ! proj_x_min
-        proj_bounds(2) = maxval(corners_2d(1,:))  ! proj_x_max
-        proj_bounds(3) = minval(corners_2d(2,:))  ! proj_y_min
-        proj_bounds(4) = maxval(corners_2d(2,:))  ! proj_y_max
-        
+        proj_bounds(1) = minval(corners_2d(1, :))  ! proj_x_min
+        proj_bounds(2) = maxval(corners_2d(1, :))  ! proj_x_max
+        proj_bounds(3) = minval(corners_2d(2, :))  ! proj_y_min
+        proj_bounds(4) = maxval(corners_2d(2, :))  ! proj_y_max
+
         ! Calculate scaling factors
         data_ranges(1) = max(EPSILON, x_max - x_min)
         data_ranges(2) = max(EPSILON, y_max - y_min)
-        
+
         ! Scale all corners
         do i = 1, 8
-            corners_2d(1,i) = x_min + (corners_2d(1,i) - proj_bounds(1)) / &
-                              max(EPSILON, proj_bounds(2) - proj_bounds(1)) * data_ranges(1)
-            corners_2d(2,i) = y_min + (corners_2d(2,i) - proj_bounds(3)) / &
-                              max(EPSILON, proj_bounds(4) - proj_bounds(3)) * data_ranges(2)
+            corners_2d(1, i) = x_min + (corners_2d(1, i) - proj_bounds(1))/ &
+                            max(EPSILON, proj_bounds(2) - proj_bounds(1))*data_ranges(1)
+            corners_2d(2, i) = y_min + (corners_2d(2, i) - proj_bounds(3))/ &
+                            max(EPSILON, proj_bounds(4) - proj_bounds(3))*data_ranges(2)
         end do
     end subroutine scale_to_data_range
-
-    subroutine draw_axis_lines(ctx, corners_2d)
-        !! Draw the three visible axis lines forming the 3D coordinate frame
-        class(plot_context), intent(inout) :: ctx
-        real(wp), intent(in) :: corners_2d(2,8)
-        
-        ! X-axis: front bottom edge
-        call ctx%line(corners_2d(1,CORNER_MIN_MIN_MIN), corners_2d(2,CORNER_MIN_MIN_MIN), &
-                      corners_2d(1,CORNER_MAX_MIN_MIN), corners_2d(2,CORNER_MAX_MIN_MIN))
-        
-        ! Y-axis: front right edge  
-        call ctx%line(corners_2d(1,CORNER_MAX_MIN_MIN), corners_2d(2,CORNER_MAX_MIN_MIN), &
-                      corners_2d(1,CORNER_MAX_MAX_MIN), corners_2d(2,CORNER_MAX_MAX_MIN))
-        
-        ! Z-axis: front left vertical
-        call ctx%line(corners_2d(1,CORNER_MIN_MIN_MIN), corners_2d(2,CORNER_MIN_MIN_MIN), &
-                      corners_2d(1,CORNER_MIN_MIN_MAX), corners_2d(2,CORNER_MIN_MIN_MAX))
-    end subroutine draw_axis_lines
 
     subroutine draw_all_axis_ticks(ctx, corners_2d, x_min, x_max, y_min, y_max, z_min, z_max)
         !! Draw ticks and labels for all three axes
         class(plot_context), intent(inout) :: ctx
-        real(wp), intent(in) :: corners_2d(2,8)
+        real(wp), intent(in) :: corners_2d(2, 8)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
-        
+
         ! Draw each axis independently using the same pattern
         call draw_single_axis_ticks(ctx, corners_2d, X_AXIS, x_min, x_max, x_min, x_max, y_min, y_max, z_min, z_max)
         call draw_single_axis_ticks(ctx, corners_2d, Y_AXIS, y_min, y_max, x_min, x_max, y_min, y_max, z_min, z_max)  
@@ -168,38 +150,38 @@ contains
     subroutine draw_single_axis_ticks(ctx, corners_2d, axis_id, axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max)
         !! Draw ticks and labels for a single axis
         class(plot_context), intent(inout) :: ctx
-        real(wp), intent(in) :: corners_2d(2,8)
+        real(wp), intent(in) :: corners_2d(2, 8)
         integer, intent(in) :: axis_id
-        real(wp), intent(in) :: axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max
-        
+    real(wp), intent(in) :: axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max
+
         real(wp) :: tick_values(MAX_TICKS_PER_AXIS), step_size
         real(wp) :: nice_min, nice_max
         integer :: n_ticks, decimals, corner1, corner2
-        
+
         ! Get nice tick locations
         call find_nice_tick_locations(axis_min, axis_max, 5, nice_min, nice_max, &
-                                     step_size, tick_values, n_ticks)
+                                      step_size, tick_values, n_ticks)
         decimals = determine_decimal_places_from_step(step_size)
-        
+
         ! Determine corner indices for this axis
         select case (axis_id)
         case (X_AXIS)
             corner1 = CORNER_MIN_MIN_MIN; corner2 = CORNER_MAX_MIN_MIN
-        case (Y_AXIS) 
+        case (Y_AXIS)
             corner1 = CORNER_MAX_MIN_MIN; corner2 = CORNER_MAX_MAX_MIN
         case (Z_AXIS)
             corner1 = CORNER_MIN_MIN_MIN; corner2 = CORNER_MIN_MIN_MAX
         end select
-        
-        call draw_ticks_on_edge(ctx, corners_2d, corner1, corner2, tick_values, n_ticks, &
-                               axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max, decimals, axis_id)
+
+      call draw_ticks_on_edge(ctx, corners_2d, corner1, corner2, tick_values, n_ticks, &
+        axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max, decimals, axis_id)
     end subroutine draw_single_axis_ticks
 
-  subroutine draw_ticks_on_edge(ctx, corners_2d, corner1, corner2, tick_values, n_ticks, &
-                                  axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max, decimals, axis_id)
+subroutine draw_ticks_on_edge(ctx, corners_2d, corner1, corner2, tick_values, n_ticks, &
+        axis_min, axis_max, x_min, x_max, y_min, y_max, z_min, z_max, decimals, axis_id)
         !! Draw tick marks and labels along a specific edge with visually consistent lengths
         class(plot_context), intent(inout) :: ctx
-        real(wp), intent(in) :: corners_2d(2,8)
+        real(wp), intent(in) :: corners_2d(2, 8)
         integer, intent(in) :: corner1, corner2, n_ticks, decimals, axis_id
         real(wp), contiguous, intent(in) :: tick_values(:)
         real(wp), intent(in) :: axis_min, axis_max
@@ -223,21 +205,21 @@ contains
         ! Phase 1: compute edge geometry
         call compute_edge_geometry(ctx, corners_2d, corner1, corner2, axis_id, &
                                    x_min, x_max, y_min, y_max, &
-                                   edge_vec, edge_len, normal_vec, edge_mid, plot_center, &
-                                   width_scale, height_scale, canvas_w_px, canvas_h_px, &
+                                edge_vec, edge_len, normal_vec, edge_mid, plot_center, &
+                                  width_scale, height_scale, canvas_w_px, canvas_h_px, &
                                    tick_px, pad_px, extra_px)
         if (edge_len <= EPSILON) return
 
         ! Phase 2: collect tick candidates
-        tol = 1.0e-9_wp * max(1.0_wp, abs(axis_max - axis_min))
+        tol = 1.0e-9_wp*max(1.0_wp, abs(axis_max - axis_min))
         do i = 1, n_ticks
             if (tick_values(i) < axis_min .or. tick_values(i) > axis_max) cycle
 
-            range_factor = (tick_values(i) - axis_min) / max(EPSILON, axis_max - axis_min)
+            range_factor = (tick_values(i) - axis_min)/max(EPSILON, axis_max - axis_min)
             tick_pos(1) = corners_2d(1,corner1) + range_factor * (corners_2d(1,corner2) - corners_2d(1,corner1))
             tick_pos(2) = corners_2d(2,corner1) + range_factor * (corners_2d(2,corner2) - corners_2d(2,corner1))
 
-            call compute_tick_positions(axis_id, tick_pos, normal_vec, tick_px, pad_px, extra_px, &
+ call compute_tick_positions(axis_id, tick_pos, normal_vec, tick_px, pad_px, extra_px, &
                                         width_scale, height_scale, tick_end, label_pos)
 
             call ctx%line(tick_pos(1), tick_pos(2), tick_end(1), tick_end(2))
@@ -249,7 +231,7 @@ contains
                                (abs(tick_values(i) - axis_max) <= tol)
 
             if (axis_id == X_AXIS .and. i == n_ticks) cand_valid(i) = .false.
-            if (axis_id == Y_AXIS .and. i == 1)      cand_valid(i) = .false.
+            if (axis_id == Y_AXIS .and. i == 1) cand_valid(i) = .false.
         end do
 
         ! Phase 3: order candidates (endpoints first)
@@ -261,13 +243,13 @@ contains
     end subroutine draw_ticks_on_edge
 
     subroutine compute_edge_geometry(ctx, corners_2d, corner1, corner2, axis_id, &
-                                      x_min, x_max, y_min, y_max, &
-                                      edge_vec, edge_len, normal_vec, edge_mid, plot_center, &
-                                      width_scale, height_scale, canvas_w_px, canvas_h_px, &
-                                      tick_px, pad_px, extra_px)
+                                     x_min, x_max, y_min, y_max, &
+                                edge_vec, edge_len, normal_vec, edge_mid, plot_center, &
+                                  width_scale, height_scale, canvas_w_px, canvas_h_px, &
+                                     tick_px, pad_px, extra_px)
         !! Compute edge direction, normal, and pixel-scale dimensions
         class(plot_context), intent(in) :: ctx
-        real(wp), intent(in) :: corners_2d(2,8)
+        real(wp), intent(in) :: corners_2d(2, 8)
         integer, intent(in) :: corner1, corner2, axis_id
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         real(wp), intent(out) :: edge_vec(2), edge_len
@@ -275,30 +257,30 @@ contains
         real(wp), intent(out) :: width_scale, height_scale, canvas_w_px, canvas_h_px
         real(wp), intent(out) :: tick_px, pad_px, extra_px
 
-        edge_vec(1) = corners_2d(1,corner2) - corners_2d(1,corner1)
-        edge_vec(2) = corners_2d(2,corner2) - corners_2d(2,corner1)
-        edge_len    = sqrt(edge_vec(1)**2 + edge_vec(2)**2)
+        edge_vec(1) = corners_2d(1, corner2) - corners_2d(1, corner1)
+        edge_vec(2) = corners_2d(2, corner2) - corners_2d(2, corner1)
+        edge_len = sqrt(edge_vec(1)**2 + edge_vec(2)**2)
 
-        normal_vec = [ -edge_vec(2)/edge_len, edge_vec(1)/edge_len ]
-        edge_mid   = 0.5_wp * [ corners_2d(1,corner1)+corners_2d(1,corner2), &
-                                 corners_2d(2,corner1)+corners_2d(2,corner2) ]
-        plot_center = [ sum(corners_2d(1,:))/8.0_wp, sum(corners_2d(2,:))/8.0_wp ]
+        normal_vec = [-edge_vec(2)/edge_len, edge_vec(1)/edge_len]
+        edge_mid = 0.5_wp*[corners_2d(1, corner1) + corners_2d(1, corner2), &
+                           corners_2d(2, corner1) + corners_2d(2, corner2)]
+        plot_center = [sum(corners_2d(1, :))/8.0_wp, sum(corners_2d(2, :))/8.0_wp]
         if ( (normal_vec(1)*(edge_mid(1)-plot_center(1)) + normal_vec(2)*(edge_mid(2)-plot_center(2))) < 0.0_wp ) then
             normal_vec = -normal_vec
         end if
 
-        width_scale  = ctx%get_width_scale()
+        width_scale = ctx%get_width_scale()
         height_scale = ctx%get_height_scale()
-        canvas_w_px  = width_scale  * (x_max - x_min)
-        canvas_h_px  = height_scale * (y_max - y_min)
+        canvas_w_px = width_scale*(x_max - x_min)
+        canvas_h_px = height_scale*(y_max - y_min)
 
-        tick_px = max(4.0_wp, min(12.0_wp, VISUAL_TICK_PERCENT * min(canvas_w_px, canvas_h_px)))
-        pad_px  = max(6.0_wp, min(24.0_wp, VISUAL_PADDING_PERCENT * min(canvas_w_px, canvas_h_px)))
+  tick_px = max(4.0_wp, min(12.0_wp, VISUAL_TICK_PERCENT*min(canvas_w_px, canvas_h_px)))
+pad_px = max(6.0_wp, min(24.0_wp, VISUAL_PADDING_PERCENT*min(canvas_w_px, canvas_h_px)))
         extra_px = merge(max(0.0_wp, VISUAL_Z_EXTRA_PERCENT) * min(canvas_w_px, canvas_h_px), 0.0_wp, axis_id == Z_AXIS)
     end subroutine compute_edge_geometry
 
     subroutine compute_tick_positions(axis_id, tick_pos, normal_vec, tick_px, pad_px, extra_px, &
-                                       width_scale, height_scale, tick_end, label_pos)
+                                      width_scale, height_scale, tick_end, label_pos)
         !! Compute tick end point and label position for a single tick
         integer, intent(in) :: axis_id
         real(wp), intent(in) :: tick_pos(2), normal_vec(2)
@@ -319,7 +301,7 @@ contains
         end if
     end subroutine compute_tick_positions
 
-    subroutine order_tick_candidates(n_ticks, cand_valid, cand_endpoint, order, n_ordered)
+  subroutine order_tick_candidates(n_ticks, cand_valid, cand_endpoint, order, n_ordered)
         !! Order tick candidates: endpoints first, then others
         integer, intent(in) :: n_ticks
         logical, intent(in) :: cand_valid(:), cand_endpoint(:)
@@ -345,7 +327,7 @@ contains
     end subroutine order_tick_candidates
 
     subroutine select_and_draw_labels(n_ordered, order, cand_valid, cand_label_pos, cand_text, &
-                                       width_scale, height_scale, ctx)
+                                      width_scale, height_scale, ctx)
         !! Greedy label selection with pixel-spacing constraint
         integer, intent(in) :: n_ordered
         integer, intent(in) :: order(MAX_TICKS_PER_AXIS)
@@ -364,20 +346,20 @@ contains
         do i = 1, n_ordered
             if (.not. cand_valid(order(i))) cycle
             if (.not. have_last) then
-                call ctx%text(cand_label_pos(1,order(i)), cand_label_pos(2,order(i)), &
+               call ctx%text(cand_label_pos(1, order(i)), cand_label_pos(2, order(i)), &
                               trim(adjustl(cand_text(order(i)))))
-                last_drawn_px = [ cand_label_pos(1,order(i))*width_scale, &
-                                  cand_label_pos(2,order(i))*height_scale ]
+                last_drawn_px = [cand_label_pos(1, order(i))*width_scale, &
+                                 cand_label_pos(2, order(i))*height_scale]
                 have_last = .true.
             else
-                dxp = cand_label_pos(1,order(i))*width_scale - last_drawn_px(1)
-                dyp = cand_label_pos(2,order(i))*height_scale - last_drawn_px(2)
+                dxp = cand_label_pos(1, order(i))*width_scale - last_drawn_px(1)
+                dyp = cand_label_pos(2, order(i))*height_scale - last_drawn_px(2)
                 dist_px = sqrt(dxp*dxp + dyp*dyp)
                 if (dist_px >= 22.0_wp) then
-                    call ctx%text(cand_label_pos(1,order(i)), cand_label_pos(2,order(i)), &
+               call ctx%text(cand_label_pos(1, order(i)), cand_label_pos(2, order(i)), &
                                   trim(adjustl(cand_text(order(i)))))
-                    last_drawn_px = [ cand_label_pos(1,order(i))*width_scale, &
-                                      cand_label_pos(2,order(i))*height_scale ]
+                    last_drawn_px = [cand_label_pos(1, order(i))*width_scale, &
+                                     cand_label_pos(2, order(i))*height_scale]
                 end if
             end if
         end do

--- a/src/plotting/fortplot_3d_box.f90
+++ b/src/plotting/fortplot_3d_box.f90
@@ -1,0 +1,198 @@
+module fortplot_3d_box
+    !! 3D box frame rendering: back panes, pane gridlines, and box spines.
+    !!
+    !! Selects which of the cube's six panes face away from the viewer using the
+    !! per-corner camera depth, fills those back panes light gray, draws their
+    !! gridlines, and strokes the full twelve-edge box. Drawn before the data so
+    !! panes and gridlines sit behind it, matching matplotlib mplot3d.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
+    implicit none
+
+    private
+    public :: draw_back_panes, draw_pane_gridlines, draw_box_spines
+    public :: CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, CORNER_MAX_MAX_MIN, &
+              CORNER_MIN_MAX_MIN, CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
+              CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX
+
+    ! matplotlib mplot3d pane fill (light gray) and pane gridline color.
+    real(wp), parameter :: PANE_RGB(3) = [0.95_wp, 0.95_wp, 0.95_wp]
+    real(wp), parameter :: GRID_RGB(3) = [0.7_wp, 0.7_wp, 0.7_wp]
+    integer, parameter :: N_GRIDLINES = 4   ! interior gridlines per pane direction
+
+    ! Corner indices for readability
+    integer, parameter :: &
+        CORNER_MIN_MIN_MIN = 1, &  ! (x_min, y_min, z_min)
+        CORNER_MAX_MIN_MIN = 2, &  ! (x_max, y_min, z_min)
+        CORNER_MAX_MAX_MIN = 3, &  ! (x_max, y_max, z_min)
+        CORNER_MIN_MAX_MIN = 4, &  ! (x_min, y_max, z_min)
+        CORNER_MIN_MIN_MAX = 5, &  ! (x_min, y_min, z_max)
+        CORNER_MAX_MIN_MAX = 6, &  ! (x_max, y_min, z_max)
+        CORNER_MAX_MAX_MAX = 7, &  ! (x_max, y_max, z_max)
+        CORNER_MIN_MAX_MAX = 8     ! (x_min, y_max, z_max)
+
+contains
+
+    function cube_faces() result(faces)
+        !! The six cube faces as corner-index quads (counter-clockwise).
+        integer :: faces(4, 6)
+        faces(:, 1) = [CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, &
+                       CORNER_MAX_MAX_MIN, CORNER_MIN_MAX_MIN]  ! z = 0 (bottom)
+        faces(:, 2) = [CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
+                       CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX]  ! z = 1 (top)
+        faces(:, 3) = [CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, &
+                       CORNER_MAX_MIN_MAX, CORNER_MIN_MIN_MAX]  ! y = 0
+        faces(:, 4) = [CORNER_MIN_MAX_MIN, CORNER_MAX_MAX_MIN, &
+                       CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX]  ! y = 1
+        faces(:, 5) = [CORNER_MIN_MIN_MIN, CORNER_MIN_MAX_MIN, &
+                       CORNER_MIN_MAX_MAX, CORNER_MIN_MIN_MAX]  ! x = 0
+        faces(:, 6) = [CORNER_MAX_MIN_MIN, CORNER_MAX_MAX_MIN, &
+                       CORNER_MAX_MAX_MAX, CORNER_MAX_MIN_MAX]  ! x = 1
+    end function cube_faces
+
+    function back_face_flags(corners_depth) result(is_back)
+        !! Select the three back-facing panes: those whose mean camera depth is
+        !! below the cube center (smaller depth = farther from the viewer). The
+        !! three smallest-depth faces are the back panes, matching mplot3d.
+        real(wp), intent(in) :: corners_depth(8)
+        logical :: is_back(6)
+        integer :: faces(4, 6), f, k, order(6)
+        real(wp) :: face_depth(6)
+
+        faces = cube_faces()
+        do f = 1, 6
+            face_depth(f) = 0.0_wp
+            do k = 1, 4
+                face_depth(f) = face_depth(f) + corners_depth(faces(k, f))
+            end do
+            face_depth(f) = face_depth(f)/4.0_wp
+        end do
+
+        do f = 1, 6
+            order(f) = f
+        end do
+        call sort_faces_by_depth(face_depth, order)
+
+        is_back = .false.
+        is_back(order(1)) = .true.
+        is_back(order(2)) = .true.
+        is_back(order(3)) = .true.
+    end function back_face_flags
+
+    subroutine sort_faces_by_depth(face_depth, order)
+        !! Ascending selection sort of face indices by depth.
+        real(wp), intent(in) :: face_depth(6)
+        integer, intent(inout) :: order(6)
+        integer :: i, j, min_idx, tmp
+
+        do i = 1, 5
+            min_idx = i
+            do j = i + 1, 6
+                if (face_depth(order(j)) < face_depth(order(min_idx))) min_idx = j
+            end do
+            if (min_idx /= i) then
+                tmp = order(i); order(i) = order(min_idx); order(min_idx) = tmp
+            end if
+        end do
+    end subroutine sort_faces_by_depth
+
+    subroutine draw_back_panes(ctx, corners_2d, corners_depth)
+        !! Fill the three back-facing panes with light gray, behind the data.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
+        integer :: faces(4, 6), f, k
+        logical :: is_back(6)
+        real(wp) :: xq(4), yq(4)
+
+        faces = cube_faces()
+        is_back = back_face_flags(corners_depth)
+        call ctx%color(PANE_RGB(1), PANE_RGB(2), PANE_RGB(3))
+        do f = 1, 6
+            if (.not. is_back(f)) cycle
+            do k = 1, 4
+                xq(k) = corners_2d(1, faces(k, f))
+                yq(k) = corners_2d(2, faces(k, f))
+            end do
+            call ctx%fill_quad(xq, yq)
+        end do
+        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+    end subroutine draw_back_panes
+
+    subroutine draw_pane_gridlines(ctx, corners_2d, corners_depth)
+        !! Draw interior gridlines across each back pane in light gray.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
+        integer :: faces(4, 6), f
+        logical :: is_back(6)
+
+        faces = cube_faces()
+        is_back = back_face_flags(corners_depth)
+        call ctx%color(GRID_RGB(1), GRID_RGB(2), GRID_RGB(3))
+        call ctx%set_line_width(0.5_wp)
+        do f = 1, 6
+            if (is_back(f)) call draw_face_grid(ctx, corners_2d, faces(:, f))
+        end do
+        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+    end subroutine draw_pane_gridlines
+
+    subroutine draw_face_grid(ctx, corners_2d, face)
+        !! Draw a regular grid on one quad face by interpolating its edges.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8)
+        integer, intent(in) :: face(4)
+        real(wp) :: p1(2), p2(2), p3(2), p4(2), a1(2), a2(2)
+        real(wp) :: t
+        integer :: g
+
+        p1 = corners_2d(:, face(1))
+        p2 = corners_2d(:, face(2))
+        p3 = corners_2d(:, face(3))
+        p4 = corners_2d(:, face(4))
+
+        do g = 1, N_GRIDLINES
+            t = real(g, wp)/real(N_GRIDLINES + 1, wp)
+            ! Lines parallel to edge p1->p4 (interpolate along p1->p2 and p4->p3)
+            a1 = p1 + t*(p2 - p1)
+            a2 = p4 + t*(p3 - p4)
+            call ctx%line(a1(1), a1(2), a2(1), a2(2))
+            ! Lines parallel to edge p1->p2 (interpolate along p1->p4 and p2->p3)
+            a1 = p1 + t*(p4 - p1)
+            a2 = p2 + t*(p3 - p2)
+            call ctx%line(a1(1), a1(2), a2(1), a2(2))
+        end do
+    end subroutine draw_face_grid
+
+    subroutine draw_box_spines(ctx, corners_2d)
+        !! Draw the twelve box edges in black for a fuller mplot3d-style frame.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8)
+        integer :: edges(2, 12), e
+
+        edges = cube_edges()
+        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+        call ctx%set_line_width(0.8_wp)
+        do e = 1, 12
+            call ctx%line(corners_2d(1, edges(1, e)), corners_2d(2, edges(1, e)), &
+                          corners_2d(1, edges(2, e)), corners_2d(2, edges(2, e)))
+        end do
+    end subroutine draw_box_spines
+
+    function cube_edges() result(edges)
+        !! The twelve cube edges as corner-index pairs.
+        integer :: edges(2, 12)
+        edges(:, 1) = [CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN]
+        edges(:, 2) = [CORNER_MAX_MIN_MIN, CORNER_MAX_MAX_MIN]
+        edges(:, 3) = [CORNER_MAX_MAX_MIN, CORNER_MIN_MAX_MIN]
+        edges(:, 4) = [CORNER_MIN_MAX_MIN, CORNER_MIN_MIN_MIN]
+        edges(:, 5) = [CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX]
+        edges(:, 6) = [CORNER_MAX_MIN_MAX, CORNER_MAX_MAX_MAX]
+        edges(:, 7) = [CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX]
+        edges(:, 8) = [CORNER_MIN_MAX_MAX, CORNER_MIN_MIN_MAX]
+        edges(:, 9) = [CORNER_MIN_MIN_MIN, CORNER_MIN_MIN_MAX]
+        edges(:, 10) = [CORNER_MAX_MIN_MIN, CORNER_MAX_MIN_MAX]
+        edges(:, 11) = [CORNER_MAX_MAX_MIN, CORNER_MAX_MAX_MAX]
+        edges(:, 12) = [CORNER_MIN_MAX_MIN, CORNER_MIN_MAX_MAX]
+    end function cube_edges
+
+end module fortplot_3d_box


### PR DESCRIPTION
## Summary

3D plots drew the axis frame as three bare lines and then painted the data over
them, with no shared depth. `project_3d_to_2d` discarded the camera-space depth,
so nothing downstream could order the frame against the data. There were no back
panes and no pane gridlines.

This change gives the 3D frame the matplotlib mplot3d look: light-gray back panes
with gridlines behind the data, and a full twelve-edge box.

## Changes

- `src/core/fortplot_projection.f90`: `project_3d_to_2d` gains an optional `depth`
  output. It reuses the rotation already computed and returns
  `y_rot*sin_elev + z*cos_elev` (larger = nearer the viewer), the same convention
  as the surface renderer's `mean_view_depth`. `x2d`/`y2d` are unchanged and
  callers that omit `depth` are unaffected.
- `src/plotting/fortplot_3d_box.f90` (new): selects the three back-facing panes
  from per-corner camera depth, fills them light gray, draws pane gridlines, and
  strokes all twelve box edges. Drawn before the data, so panes and gridlines sit
  behind it.
- `src/plotting/fortplot_3d_axes.f90`: `draw_3d_axes` now computes corner depth and
  calls the box renderer (panes, gridlines, spines) before ticks and labels.
  Box-geometry code moved into the new module to keep both files under the size
  limit (axes 369 lines, box 198 lines).

## What remains for follow-up

Full global painter ordering of frame against data is not implemented. The frame
panes/gridlines render behind the data (correct, the big visual win), but front
box spines are not yet drawn over the data, and the surface/wireframe/line/scatter
primitives are not interleaved with the frame by a single depth sort. Back-spine
vs front-spine occlusion against the data is the remaining step (issue #1956 step 3).

## Verification

Build and 3D tests:

```
$ make build
[100%] Project compiled successfully.

$ fpm test --target test_3d
   PASS: test_data_storage
   PASS: test_2d_no_z_allocation
   PASS: test_type_detection
   PASS: test_line_projection
   PASS: test_scatter_projection
   PASS: test_tick_orientation
   PASS: test_axes_pdf_ticks
   PASS: test_pdf_3d_plot_rendering
   PASS: test_filled_surface_depth_ordered_wireframe
   PASS: test_projection_elevation_rotation
   PASS: test_3d_plot_rgb_color
   PASS: test_3d_plot_string_color
 Tests passed:          12 /          12
 All 3D tests PASSED!
```

Rendering gate and CI subset:

```
$ make verify-artifacts
Artifact verification passed.

$ make test-ci
CI essential test suite completed successfully
```

Before/after on `output/example/fortran/3d_plotting/` (regenerated with
`fpm run --example 3d_plotting`):

- Before: three bare axis lines (front X, front Y, front Z); data painted on top;
  no box, no panes, no gridlines.
- After: full box with the three back panes filled light gray and pane gridlines
  behind the curve/surface; data renders in front of the panes. Confirmed on
  `surface_paraboloid.png` (wireframe inside a paned box) and `3d_helix.png`
  (helix inside a paned box).

PDF backend stays valid: `test_axes_pdf_ticks` and `test_pdf_3d_plot_rendering`
pass, so tick labels and filled-quad operators are still emitted.
