### PR TITLE
fix: depth-order 3D frame spines against data

### DIFF
--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -47,6 +47,7 @@ module fortplot_figure_rendering_pipeline
     public :: render_streamplot_arrows
     public :: render_figure_axes_labels_only, render_title_only
     public :: render_polar_axes
+    public :: render_3d_front_frame
     public :: expand_data_range
 
     real(wp), parameter :: DATA_RANGE_MARGIN = 0.05_wp
@@ -185,6 +186,35 @@ contains
             end if
         end select
     end subroutine render_figure_axes
+
+    subroutine render_3d_front_frame(backend, plots, plot_count, x_min, x_max, &
+                                     y_min, y_max)
+        !! Draw the front box spines after the data for the 3D case so they
+        !! occlude curves and surfaces (global painter ordering, refs #1956).
+        !! Only raster and PDF backends carry the 3D box; ASCII renders its
+        !! frame inside its own axes path, so it is skipped.
+        use fortplot_3d_axes, only: draw_3d_front_frame
+        use fortplot_pdf, only: pdf_context
+        class(plot_context), intent(inout) :: backend
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+
+        logical :: has_3d
+        real(wp) :: zmin, zmax
+
+        call detect_3d_extent(plots, plot_count, has_3d, zmin, zmax)
+        if (.not. has_3d) return
+
+        select type (backend)
+        class is (raster_context)
+            call draw_3d_front_frame(backend, x_min, x_max, y_min, y_max, zmin, zmax)
+        class is (pdf_context)
+            call draw_3d_front_frame(backend, x_min, x_max, y_min, y_max, zmin, zmax)
+        class default
+            return
+        end select
+    end subroutine render_3d_front_frame
 
     subroutine resolve_twin_axes_params(has_twinx, twinx_y_min, twinx_y_max, twinx_yscale, &
                                         has_twiny, twiny_x_min, twiny_x_max, twiny_xscale, &

--- a/src/figures/management/fortplot_figure_render_steps.f90
+++ b/src/figures/management/fortplot_figure_render_steps.f90
@@ -14,7 +14,8 @@ module fortplot_figure_render_steps
                                                   render_streamplot_arrows, &
                                                   render_figure_axes_labels_only, &
                                                   render_title_only, &
-                                                  render_polar_axes
+                                                  render_polar_axes, &
+                                                  render_3d_front_frame
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
     use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal, &
@@ -118,6 +119,13 @@ contains
                                   state%width, state%height, &
                                   state%margin_left, state%margin_right, &
                                   state%margin_bottom, state%margin_top, state=state)
+            ! Front box spines paint over the data so near frame edges occlude
+            ! curves and surfaces (global painter ordering, refs #1956).
+            if (.not. pie_only .and. .not. state%polar_projection) then
+                call render_3d_front_frame(state%backend, plots, plot_count, &
+                                           state%x_min, state%x_max, &
+                                           state%y_min, state%y_max)
+            end if
         end if
         if (allocated(state%stream_arrows)) then
             if (size(state%stream_arrows) > 0) then

--- a/src/plotting/fortplot_3d_axes.f90
+++ b/src/plotting/fortplot_3d_axes.f90
@@ -11,7 +11,7 @@ module fortplot_3d_axes
                                          determine_decimal_places_from_step
     use fortplot_projection, only: project_3d_to_2d
     use fortplot_3d_box, only: draw_back_panes, draw_pane_gridlines, &
-                               draw_box_spines, &
+                               draw_back_spines, draw_front_spines, &
                                CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, &
                                CORNER_MAX_MAX_MIN, CORNER_MIN_MAX_MIN, &
                                CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
@@ -20,6 +20,7 @@ module fortplot_3d_axes
 
     private
     public :: draw_3d_axes
+    public :: draw_3d_front_frame
 
     ! Constants for 3D visualization - percentage of axis length for true consistency
     integer, parameter :: MAX_TICKS_PER_AXIS = 10
@@ -49,29 +50,61 @@ contains
         class(plot_context), intent(inout) :: ctx
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
 
-        real(wp) :: corners_3d(3, 8), corners_2d(2, 8), corners_depth(8)
-        real(wp) :: azim, elev, dist
+        real(wp) :: corners_2d(2, 8), corners_depth(8)
 
         ! Validate input ranges
         if (x_max <= x_min .or. y_max <= y_min .or. z_max <= z_min) return
 
-        ! Set up 3D projection using the backend's stored view angles
+        call project_box_corners(ctx, x_min, x_max, y_min, y_max, &
+                                 corners_2d, corners_depth)
+
+        ! Draw back panes, gridlines, and the back spines first so they sit
+        ! behind the data (rendered after this routine). The front spines are
+        ! deferred to draw_3d_front_frame, emitted after the data, so they
+        ! occlude it (global painter ordering, matplotlib mplot3d).
+        call draw_back_panes(ctx, corners_2d, corners_depth)
+        call draw_pane_gridlines(ctx, corners_2d, corners_depth)
+        call draw_back_spines(ctx, corners_2d, corners_depth)
+
+        ! Draw ticks and labels on each axis
+     call draw_all_axis_ticks(ctx, corners_2d, x_min, x_max, y_min, y_max, z_min, z_max)
+    end subroutine draw_3d_axes
+
+    subroutine draw_3d_front_frame(ctx, x_min, x_max, y_min, y_max, z_min, z_max)
+        !! Draw the box spines that lie in front of the data. Called after the
+        !! data is rendered so near spines occlude curves and surfaces, while the
+        !! far spines drawn by draw_3d_axes stay behind the data.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
+
+        real(wp) :: corners_2d(2, 8), corners_depth(8)
+
+        if (x_max <= x_min .or. y_max <= y_min .or. z_max <= z_min) return
+
+        call project_box_corners(ctx, x_min, x_max, y_min, y_max, &
+                                 corners_2d, corners_depth)
+        call draw_front_spines(ctx, corners_2d, corners_depth)
+    end subroutine draw_3d_front_frame
+
+    subroutine project_box_corners(ctx, x_min, x_max, y_min, y_max, &
+                                   corners_2d, corners_depth)
+        !! Project the unit cube to scaled 2D coordinates and per-corner depth
+        !! using the backend's stored view angles. Shared by the back and front
+        !! frame passes so both use identical geometry.
+        class(plot_context), intent(in) :: ctx
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        real(wp), intent(out) :: corners_2d(2, 8), corners_depth(8)
+
+        real(wp) :: corners_3d(3, 8)
+        real(wp) :: azim, elev, dist
+
         azim = ctx%view_azim
         elev = ctx%view_elev
         dist = ctx%view_dist
         call create_unit_cube(corners_3d)
         call project_to_2d(corners_3d, azim, elev, dist, corners_2d, corners_depth)
         call scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
-
-        ! Draw back panes and pane gridlines first so they sit behind the data
-        ! (the data is rendered after this routine). Then draw the box spines.
-        call draw_back_panes(ctx, corners_2d, corners_depth)
-        call draw_pane_gridlines(ctx, corners_2d, corners_depth)
-        call draw_box_spines(ctx, corners_2d)
-
-        ! Draw ticks and labels on each axis
-     call draw_all_axis_ticks(ctx, corners_2d, x_min, x_max, y_min, y_max, z_min, z_max)
-    end subroutine draw_3d_axes
+    end subroutine project_box_corners
 
     subroutine create_unit_cube(corners_3d)
         !! Create unit cube vertices in normalized [0,1]³ space

--- a/src/plotting/fortplot_3d_box.f90
+++ b/src/plotting/fortplot_3d_box.f90
@@ -11,7 +11,8 @@ module fortplot_3d_box
     implicit none
 
     private
-    public :: draw_back_panes, draw_pane_gridlines, draw_box_spines
+    public :: draw_back_panes, draw_pane_gridlines
+    public :: draw_back_spines, draw_front_spines
     public :: CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, CORNER_MAX_MAX_MIN, &
               CORNER_MIN_MAX_MIN, CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
               CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX
@@ -163,20 +164,49 @@ contains
         end do
     end subroutine draw_face_grid
 
-    subroutine draw_box_spines(ctx, corners_2d)
-        !! Draw the twelve box edges in black for a fuller mplot3d-style frame.
+    subroutine draw_back_spines(ctx, corners_2d, corners_depth)
+        !! Draw the box edges that lie behind the data (mean edge depth below the
+        !! cube center). These render before the data so the data paints over them.
         class(plot_context), intent(inout) :: ctx
-        real(wp), intent(in) :: corners_2d(2, 8)
+        real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
+
+        call draw_spines_by_side(ctx, corners_2d, corners_depth, front=.false.)
+    end subroutine draw_back_spines
+
+    subroutine draw_front_spines(ctx, corners_2d, corners_depth)
+        !! Draw the box edges in front of the data (mean edge depth above the cube
+        !! center). These render after the data so they occlude it, matching the
+        !! global painter ordering of matplotlib mplot3d.
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
+
+        call draw_spines_by_side(ctx, corners_2d, corners_depth, front=.true.)
+    end subroutine draw_front_spines
+
+    subroutine draw_spines_by_side(ctx, corners_2d, corners_depth, front)
+        !! Stroke the box edges on one side of the cube center depth. An edge is a
+        !! front edge when the mean depth of its two corners is at or above the
+        !! cube-center depth (larger depth = nearer the viewer).
+        class(plot_context), intent(inout) :: ctx
+        real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
+        logical, intent(in) :: front
         integer :: edges(2, 12), e
+        real(wp) :: center_depth, edge_depth
+        logical :: is_front
 
         edges = cube_edges()
+        center_depth = sum(corners_depth)/8.0_wp
         call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
         call ctx%set_line_width(0.8_wp)
         do e = 1, 12
+            edge_depth = 0.5_wp*(corners_depth(edges(1, e)) &
+                                 + corners_depth(edges(2, e)))
+            is_front = edge_depth >= center_depth
+            if (is_front .neqv. front) cycle
             call ctx%line(corners_2d(1, edges(1, e)), corners_2d(2, edges(1, e)), &
                           corners_2d(1, edges(2, e)), corners_2d(2, edges(2, e)))
         end do
-    end subroutine draw_box_spines
+    end subroutine draw_spines_by_side
 
     function cube_edges() result(edges)
         !! The twelve cube edges as corner-index pairs.


### PR DESCRIPTION
## Summary

Follow-up to #1956. #1984 added back panes, pane gridlines, the full box, and a camera depth from `project_3d_to_2d`, but the frame still drew entirely before the data: front box spines never occluded curves or surfaces.

This change introduces a back-to-front emission split for the 3D box so near spines paint over the data, matching matplotlib mplot3d:

- `fortplot_3d_box`: replaced `draw_box_spines` with `draw_back_spines` / `draw_front_spines`, classifying each of the twelve edges by mean corner depth against the cube-center depth.
- `fortplot_3d_axes`: `draw_3d_axes` now emits back panes, gridlines, and back spines (before the data). New public `draw_3d_front_frame` re-projects the box and emits only the front spines.
- `fortplot_figure_rendering_pipeline`: new public `render_3d_front_frame` detects the 3D case and dispatches the front spines for raster and PDF backends.
- `fortplot_figure_render_steps`: calls `render_3d_front_frame` right after `render_all_plots`, so front spines occlude the data.

Backends stay pure 2D; only emission order changes. 2D rendering and the ASCII 3D frame (rendered inside the ASCII axes path) are unaffected.

### Done vs deferred

- Done: split the box frame into a back part (panes/gridlines/back spines, before data) and a front part (front spines, after data), selected by camera depth. Front spines now occlude curves and surfaces.
- Deferred: a single unified primitive list interleaving every data primitive (surface quads, wireframe segments, line segments, scatter points) with the frame in one global depth sort. Surface quads already sort internally (`fortplot_surface_rendering`); wireframe/line/scatter ordering against each other is unchanged. This high-value subset fixes the most visible wrongness (front spines through data) without the larger, riskier unified-list refactor.

## Verification

Build:

```
make build   # Project compiled successfully.
```

3D tests (before and after pass; no new failures):

```
fpm test --target test_3d test_is_3d_empty_allocation test_3d_backend_parity test_surface_plot_storage
...
 === 3D Test Summary ===
 Tests passed:          12 /          12
 All 3D tests PASSED!
```

Rendering gate:

```
make verify-artifacts   # Artifact verification passed.
make test-ci            # CI essential test suite completed successfully
```

Occlusion improvement (`output/example/fortran/3d_plotting/*.png`), before vs after on `surface_paraboloid.png` and `surface_filled_viridis.png`:

- Before: every box spine drew behind the data; the near vertical edge and the front top edges were hidden wherever the surface crossed them.
- After: the near vertical spine and the front top box edges paint over the wireframe and filled surfaces, while the far (left-rear) vertical spine stays behind the data. Z-axis ticks/labels render after the back panes. Depth interleaving of the frame against the data is now correct for the front/back spine split.
