### PR TITLE
fix: render bare underscore and caret outside math literally

### DIFF
--- a/src/text/fortplot_text_layout.f90
+++ b/src/text/fortplot_text_layout.f90
@@ -34,54 +34,20 @@ module fortplot_text_layout
 contains
 
     pure function has_mathtext(text) result(is_mathtext)
-        !! Check if text needs math layout: either a '$...$' segment or bare
-        !! superscript/subscript markup ('^'/'_', optionally braced) outside math.
+        !! Check if text needs math layout. Matching matplotlib, script markup
+        !! ('^'/'_', optionally braced) is only honoured inside a '$...$' segment.
+        !! Bare '^'/'_' outside dollars render literally and are not math.
         character(len=*), intent(in) :: text
         logical :: is_mathtext
         integer :: first_dollar, second_dollar
 
+        is_mathtext = .false.
         first_dollar = index(text, '$')
         if (first_dollar > 0) then
             second_dollar = index(text(first_dollar+1:), '$')
-            if (second_dollar > 0) then
-                is_mathtext = .true.
-                return
-            end if
+            if (second_dollar > 0) is_mathtext = .true.
         end if
-
-        is_mathtext = has_bare_script_markup(text)
     end function has_mathtext
-
-    pure function has_bare_script_markup(text) result(has_markup)
-        !! True when text carries unescaped '^'/'_' script markup with content,
-        !! ignoring any '$...$' regions (those go through the delimiter path).
-        character(len=*), intent(in) :: text
-        logical :: has_markup
-        integer :: i, n
-        logical :: in_math
-
-        has_markup = .false.
-        n = len_trim(text)
-        in_math = .false.
-        i = 1
-        do while (i <= n)
-            select case (text(i:i))
-            case ('$')
-                in_math = .not. in_math
-                i = i + 1
-            case ('\')
-                i = i + 2  ! skip escaped character
-            case ('^', '_')
-                if (.not. in_math .and. i < n) then
-                    has_markup = .true.
-                    return
-                end if
-                i = i + 1
-            case default
-                i = i + 1
-            end select
-        end do
-    end function has_bare_script_markup
 
     function calculate_text_width(text) result(width)
         !! Calculate the pixel width of text using STB TrueType with UTF-8 support
@@ -262,23 +228,22 @@ contains
     end function calculate_mathtext_width_internal
 
     subroutine preprocess_math_text(input_text, result_text, result_len)
-        !! Remove '$' delimiters and escape '^'/'_' outside math so they render literally.
-        !! When the string carries no '$' delimiters at all, bare '^'/'_' markup is
-        !! treated as math (laid out as super/subscripts), matching has_mathtext.
+        !! Remove '$' delimiters and escape '^'/'_' outside math so they render
+        !! literally. Only content between '$...$' is treated as math, matching
+        !! matplotlib: bare '^'/'_' outside dollars stay literal characters.
         !! UTF-8 aware: multi-byte characters are copied as intact sequences
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: result_text
         integer, intent(out) :: result_len
         integer :: i, n, pos, char_len
-        logical :: in_math, no_delimiters
+        logical :: in_math
         character(len=1) :: ch
 
         result_text = ''
         result_len = 0
         pos = 1
         n = len_trim(input_text)
-        no_delimiters = (index(input_text, '$') <= 0)
-        in_math = no_delimiters
+        in_math = .false.
 
         i = 1
         do while (i <= n)

--- a/test/text/test_text_layout_split.f90
+++ b/test/text/test_text_layout_split.f90
@@ -52,31 +52,25 @@ program test_text_layout_split
         error stop "non mathtext should not be marked"
     end if
 
-    if (.not. has_mathtext('e^{-x} t')) then
-        error stop "bare superscript markup should be detected"
+    ! Matching matplotlib: script markup is only math inside '$...$'. Bare
+    ! '^'/'_' outside dollars render literally and are not detected as math.
+    if (has_mathtext('e^{-x} t')) then
+        error stop "bare superscript outside dollars is literal, not math"
     end if
 
-    if (.not. has_mathtext('rate_i value')) then
-        error stop "bare subscript markup should be detected"
+    if (has_mathtext('rate_i value')) then
+        error stop "bare subscript outside dollars is literal, not math"
     end if
 
     if (has_mathtext('a trailing caret^')) then
         error stop "trailing caret without content is literal"
     end if
 
-    ! Bare markup (no $ delimiters) is treated as math: '^' stays unescaped
-    ! so parse_mathtext lays it out instead of drawing a literal caret.
+    ! Bare markup (no $ delimiters) renders literally: '^' is escaped so the
+    ! layout draws a caret glyph instead of raising the next character.
     call preprocess_math_text('e^{-x} t', processed_label, processed_len)
-    if (index(processed_label(1:processed_len), '\^') /= 0) then
-        error stop "bare markup must not escape the caret into a literal glyph"
-    end if
-    elements = parse_mathtext(processed_label(1:processed_len))
-    subscripts = 0
-    do i = 1, size(elements)
-        if (elements(i)%vertical_offset > 0.0_wp) subscripts = subscripts + 1
-    end do
-    if (subscripts /= 1) then
-        error stop "bare superscript should produce one raised element"
+    if (index(processed_label(1:processed_len), '\^') == 0) then
+        error stop "bare caret outside dollars must be escaped to a literal glyph"
     end if
 
     mixed_label = 'fill_between data $x_1$'


### PR DESCRIPTION
## Summary

Match matplotlib's default text handling: superscript and subscript markup is honoured only inside `$...$` delimiters. Bare `^`/`_` characters outside dollars now render as literal glyphs instead of being consumed as script markup.

Before this change, a title like `Stateful fill_between with mask` lost the underscore and lowered `between` as a subscript (`fillbetween`), and `polar_demo:` dropped its underscore. matplotlib renders both underscores literally.

Changes:
- `has_mathtext` detects math only when a `$...$` pair is present.
- `preprocess_math_text` escapes bare `^`/`_` outside dollars so they render as literal characters; only content between `$...$` is laid out as math.
- Dollar-delimited math (`x^2`, `x_i`, `e^{-x/3}`) is unaffected.

## Verification

Commands run:
- `fpm build`
- `fpm run --example mathtext_demo`, `fill_between_demo`, `polar_demo`, `annotation_demo`
- `make verify-artifacts` -> ends with `Artifact verification passed.`
- `make test-ci` -> ends with `CI essential test suite completed successfully`

Build, test-ci, and verify-artifacts all pass.

Before/after evidence:

- fill_between_demo `stateful_fill_between.png` title:
  - Before: rendered `fill` followed by a subscripted `between` (the `_` consumed as subscript markup).
  - After: renders `fill_between` with a literal underscore. PDF text (`pdftotext stateful_fill_between.pdf`) shows `Stateful fill_between with mask`.
- polar_demo `polar_demo.png` title:
  - Before: `_` dropped/subscripted.
  - After: `polar_demo: custom colors, markers, and linestyles` with a literal underscore. PDF text shows `polar_demo: custom colors, markers, and linestyles`.
- mathtext_demo `mathtext_demo.png` (regression check): dollar-delimited `$x^2$`, `$x_i$`, `$e^{-x/3}$` still render as proper super/subscripts in title, legend, and axis labels.
- annotation_demo `annotation_demo.png` (regression check): all `$...$` math (`e^{-x/4}`, `(x-3)^2`, `lim_{x->inf}`) still renders correctly.

Test updates:
- `test/text/test_utf8_text_preprocessing.f90` already asserted that a bare `^` in `x^2` (no dollars) should be escaped to a literal; that assertion failed before this change and now passes.
- `test/text/test_text_layout_split.f90` previously asserted bare `^`/`_` outside dollars were detected as math (the buggy behavior). Those assertions are updated to require literal rendering, matching matplotlib. The existing mixed-case assertion (`fill_between data $x_1$` -> literal underscore segment plus one math subscript) is preserved and still passes.

## Known limitation

matplotlib renders math content inside `$...$` in an italic face. fortplot has no italic font face wired through its backends, so dollar-math still renders upright. That requires italic font infrastructure across all backends and is out of scope for this text-layout fix.
