### PR TITLE
fix: align legend best placement and render errorbar legends

### DIFF
--- a/src/plotting/fortplot_errorbar_plots.f90
+++ b/src/plotting/fortplot_errorbar_plots.f90
@@ -39,7 +39,10 @@ contains
         integer :: plot_idx, color_idx
         self%plot_count = self%plot_count + 1
         plot_idx = self%plot_count
-        
+        ! Keep the figure-state plot count in sync so legend setup (which reads
+        ! state%plot_count) sees this errorbar entry. Mirrors plot()/scatter().
+        self%state%plot_count = self%plot_count
+
         ! Ensure plots array is allocated
         if (.not. allocated(self%plots)) then
             allocate(self%plots(self%state%max_plots))

--- a/src/ui/fortplot_legend_layout.f90
+++ b/src/ui/fortplot_legend_layout.f90
@@ -72,11 +72,11 @@ contains
                                                 max_text_width, total_text_width, box, px_w, px_h)
         
         ! Get appropriate margins for this backend
-        margins = get_legend_margins(data_width, data_height)
-        
+        margins = get_legend_margins(data_width, data_height, px_w, px_h)
+
         ! Calculate position based on legend location
         call calculate_legend_position(box, data_width, data_height, position, margins)
-        
+
     end function calculate_legend_box
 
     function choose_best_legend_position(labels, data_width, data_height, &
@@ -274,16 +274,29 @@ contains
         
     end function get_actual_text_dimensions
     
-    function get_legend_margins(data_width, data_height) result(margins)
-        !! Get appropriate margins for legend placement
-        !! DRY: Centralized margin calculation
+    function get_legend_margins(data_width, data_height, &
+                                pixel_plot_width, pixel_plot_height) result(margins)
+        !! Inset between the legend box and the axes frame.
+        !! Matches matplotlib's borderaxespad default (0.5 * 10pt font = 5pt),
+        !! which at the standard ~100 dpi is ~7 px, independent of the data
+        !! range. A fixed pixel inset keeps the legend flush in the corner the
+        !! way matplotlib draws it, instead of a large data-proportional gap.
         real(wp), intent(in) :: data_width, data_height
+        integer, intent(in), optional :: pixel_plot_width, pixel_plot_height
         real(wp) :: margins(2)  ! [x_margin, y_margin]
-        
-        ! Professional margins similar to matplotlib
-        margins(1) = data_width * 0.08_wp    ! 8% horizontal margin  
-        margins(2) = data_height * 0.08_wp   ! 8% vertical margin
-        
+        real(wp), parameter :: BORDER_AXES_PAD_PX = 7.0_wp
+        integer :: px_w, px_h
+
+        if (present(pixel_plot_width) .and. present(pixel_plot_height)) then
+            px_w = max(1, pixel_plot_width)
+            px_h = max(1, pixel_plot_height)
+            margins(1) = BORDER_AXES_PAD_PX * data_width / real(px_w, wp)
+            margins(2) = BORDER_AXES_PAD_PX * data_height / real(px_h, wp)
+        else
+            margins(1) = data_width * 0.02_wp
+            margins(2) = data_height * 0.02_wp
+        end if
+
     end function get_legend_margins
     
     subroutine calculate_legend_position(box, data_width, data_height, position, margins)

--- a/test/legend/test_errorbar_legend_entry.f90
+++ b/test/legend/test_errorbar_legend_entry.f90
@@ -1,0 +1,40 @@
+program test_errorbar_legend_entry
+    !! Regression: errorbar() + legend() must register a legend entry.
+    !! errorbar_impl increments the figure plot count but historically did not
+    !! mirror it into the figure state, so legend setup (which reads the state
+    !! plot count) saw zero plots and drew no legend box for errorbar figures.
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_figure_core, only: figure_t
+    use fortplot_errorbar_plots, only: errorbar
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp) :: x(5), y(5), yerr(5)
+    integer :: i, failures
+
+    failures = 0
+    do i = 1, 5
+        x(i) = real(i, wp)
+        y(i) = sin(real(i, wp) * 0.5_wp)
+        yerr(i) = 0.2_wp
+    end do
+
+    call fig%initialize(640, 480)
+    call errorbar(fig, x, y, yerr=yerr, label='measured')
+    call fig%legend()
+
+    if (fig%state%legend_data%num_entries == 1) then
+        print *, "PASS: errorbar legend entry registered"
+    else
+        print *, "FAIL: expected 1 legend entry, got", &
+            fig%state%legend_data%num_entries
+        failures = failures + 1
+    end if
+
+    if (failures == 0) then
+        print *, "ALL ERRORBAR LEGEND TESTS PASSED"
+    else
+        stop 1
+    end if
+
+end program test_errorbar_legend_entry


### PR DESCRIPTION
## Summary

Aligns the default legend with matplotlib's behaviour for the affected
examples (basic_plots, scatter_demo, legend_demo, errorbar_demo, grid_demo).

- Render a legend box for errorbar figures. errorbar plotting incremented the
  figure plot count but never mirrored it into the figure state, so legend
  setup read zero plots and skipped the box entirely. The state plot count is
  now synced the same way plot()/scatter() do.
- Tighten the legend inset to a fixed pixel border matching matplotlib's
  borderaxespad default (~7 px), replacing the previous 8% data-proportional
  gap. The box now sits flush in its corner instead of floating with a large
  top inset, and the smaller inset makes the best-corner overlap scoring agree
  with matplotlib.

A regression test asserts that errorbar() + legend() registers one legend
entry.

## Verification

Commands:

- `fpm build`
- `fpm run --example errorbar_demo` / `legend_demo` / `scatter_demo` / `grid_demo` / `basic_plots`
- `make verify-artifacts` -> ends with "Artifact verification passed."
- `make test-ci` -> "CI essential test suite completed successfully"
- `fpm test --target test_errorbar_legend_entry` -> "ALL ERRORBAR LEGEND TESTS PASSED"
- `fpm test --target test_legend_best_placement` -> "ALL BEST-PLACEMENT TESTS PASSED"
- legend/errorbar suites: test_legend_comprehensive, test_legend_line_styles, test_pie_legend_inside, test_errorbar_pdf_rendering, test_errorbar_ascii_rendering all pass.

Before/after evidence (PNG comparison against matplotlib reference renders):

- errorbar_demo/errorbar_basic_y.png: before, no legend box despite legend()
  being called; after, the "Data with Y errors" box renders in the upper-right
  corner, matching matplotlib.
- legend_demo/basic_legend.png (sin/cos, loc=best): before, fortplot resolved
  to lower-left while matplotlib uses upper-right; after, fortplot resolves to
  upper-right, matching matplotlib.
- scatter_demo/scatter_multi.png (3 dense scatter series, loc=best): before,
  fortplot resolved to upper-right while matplotlib uses lower-left; after,
  fortplot resolves to lower-left, matching matplotlib.
- basic_plots/multi_line.png (sin/cos, loc=best): after, fortplot resolves to
  lower-left, matching matplotlib; box flush in the corner.
- grid_demo/grid_demo.png and legend_demo/multi_function_legend.png: remain
  upper-right (matching matplotlib), now with the tighter matplotlib-style
  inset instead of the previous large gap.

The quiver scale gate is unaffected: verify-artifacts reports
"quiver shaft geometry: scaled < unscaled (scale-dependent)" with
unscaled=0.1318 scaled=0.0659.
