### PR TITLE
fix: apply single 5% autoscale margin to boxplot value axis

### DIFF
--- a/src/figures/core/fortplot_figure_data_ranges_specialized.f90
+++ b/src/figures/core/fortplot_figure_data_ranges_specialized.f90
@@ -190,6 +190,7 @@ contains
 
         real(wp) :: data_min, data_max
         real(wp) :: pos, halfw
+        real(wp) :: cat_lo, cat_hi
         logical :: horiz
 
         if (.not. allocated(plot%box_data)) return
@@ -201,31 +202,38 @@ contains
         halfw = 0.5_wp * plot%width
         horiz = plot%horizontal
 
+        ! Return raw extents: the value axis spans the box statistics and the
+        ! category axis spans the box width. The caller applies the single 5%
+        ! autoscale margin, matching matplotlib. Pre-padding here would stack a
+        ! second margin and drag the value axis past zero.
+        cat_lo = pos - halfw
+        cat_hi = pos + halfw
+
         if (.not. horiz) then
             if (first_plot) then
-                x_min_data = pos - halfw - 0.2_wp
-                x_max_data = pos + halfw + 0.2_wp
-                y_min_data = data_min - 0.1_wp * abs(data_max - data_min)
-                y_max_data = data_max + 0.1_wp * abs(data_max - data_min)
+                x_min_data = cat_lo
+                x_max_data = cat_hi
+                y_min_data = data_min
+                y_max_data = data_max
                 first_plot = .false.
             else
-                x_min_data = min(x_min_data, pos - halfw - 0.2_wp)
-                x_max_data = max(x_max_data, pos + halfw + 0.2_wp)
-                y_min_data = min(y_min_data, data_min - 0.1_wp * abs(data_max - data_min))
-                y_max_data = max(y_max_data, data_max + 0.1_wp * abs(data_max - data_min))
+                x_min_data = min(x_min_data, cat_lo)
+                x_max_data = max(x_max_data, cat_hi)
+                y_min_data = min(y_min_data, data_min)
+                y_max_data = max(y_max_data, data_max)
             end if
         else
             if (first_plot) then
-                x_min_data = data_min - 0.1_wp * abs(data_max - data_min)
-                x_max_data = data_max + 0.1_wp * abs(data_max - data_min)
-                y_min_data = pos - halfw - 0.2_wp
-                y_max_data = pos + halfw + 0.2_wp
+                x_min_data = data_min
+                x_max_data = data_max
+                y_min_data = cat_lo
+                y_max_data = cat_hi
                 first_plot = .false.
             else
-                x_min_data = min(x_min_data, data_min - 0.1_wp * abs(data_max - data_min))
-                x_max_data = max(x_max_data, data_max + 0.1_wp * abs(data_max - data_min))
-                y_min_data = min(y_min_data, pos - halfw - 0.2_wp)
-                y_max_data = max(y_max_data, pos + halfw + 0.2_wp)
+                x_min_data = min(x_min_data, data_min)
+                x_max_data = max(x_max_data, data_max)
+                y_min_data = min(y_min_data, cat_lo)
+                y_max_data = max(y_max_data, cat_hi)
             end if
         end if
         has_valid_data = .true.

--- a/test/plot_types/test_boxplot_autoscale_margin.f90
+++ b/test/plot_types/test_boxplot_autoscale_margin.f90
@@ -1,0 +1,55 @@
+program test_boxplot_autoscale_margin
+    !! Boxplot value axis must receive a single matplotlib-style 5% autoscale
+    !! margin, not a stacked margin that drags the axis past the data baseline.
+    !! Data spans 1..12, so the value axis must be 0.45..12.55 (5% of the span
+    !! on each side) and must not reach 0.
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_figure, only: figure_t
+    use fortplot_test_helpers, only: test_get_temp_path
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp) :: group_a(10), group_b(10), group_c(10)
+    real(wp) :: y_lo, y_hi, span, expected_lo, expected_hi
+    real(wp), parameter :: tol = 1.0e-6_wp
+    integer :: i
+    logical :: ok
+
+    do i = 1, 10
+        group_a(i) = real(i, wp)
+        group_b(i) = real(i + 1, wp)
+        group_c(i) = real(i + 2, wp)
+    end do
+
+    call fig%initialize()
+    call fig%boxplot(group_a, position=1.0_wp, width=0.6_wp)
+    call fig%boxplot(group_b, position=2.0_wp, width=0.6_wp)
+    call fig%boxplot(group_c, position=3.0_wp, width=0.6_wp)
+    call fig%savefig(test_get_temp_path('boxplot_autoscale_margin.png'))
+
+    y_lo = fig%get_y_min()
+    y_hi = fig%get_y_max()
+
+    span = 12.0_wp - 1.0_wp
+    expected_lo = 1.0_wp - 0.05_wp * span
+    expected_hi = 12.0_wp + 0.05_wp * span
+
+    ok = .true.
+    if (abs(y_lo - expected_lo) > tol) then
+        print *, 'FAIL: y_min', y_lo, 'expected', expected_lo
+        ok = .false.
+    end if
+    if (abs(y_hi - expected_hi) > tol) then
+        print *, 'FAIL: y_max', y_hi, 'expected', expected_hi
+        ok = .false.
+    end if
+    if (y_lo <= 0.0_wp) then
+        print *, 'FAIL: value axis dragged to or past zero', y_lo
+        ok = .false.
+    end if
+
+    if (.not. ok) then
+        error stop 'boxplot autoscale margin regression'
+    end if
+    print *, 'PASS: boxplot value axis has single 5% margin'
+end program test_boxplot_autoscale_margin


### PR DESCRIPTION
## Summary

Fixes a matplotlib-parity defect in the boxplot value axis autoscale margin.

The boxplot range processor pre-padded the value axis by 10% of the data span, then the shared 5% autoscale margin ran on top of it. The two stacked margins dragged the value axis below the data baseline and produced a spurious 0 tick, diverging from matplotlib's default 5%-once behavior.

The processor now returns raw box-statistic extents on the value axis and raw box-width extents on the category axis, so the shared margin applies exactly once.

## Verification

Commands run:
- `fpm build` (succeeds)
- `fpm run --example boxplot_demo` (regenerates boxplot_demo outputs)
- `make verify-artifacts` -> ends with "Artifact verification passed." (quiver scale-dependent shaft assertion preserved: scaled 0.0659 < unscaled 0.1318)
- `make test-ci` -> "CI essential test suite completed successfully"
- `fpm test --target test_boxplot_autoscale_margin` -> PASS
- `fpm test --target test_boxplot_comprehensive` -> all boxplot tests PASS

Added behavioral test `test/plot_types/test_boxplot_autoscale_margin.f90`: data spanning 1..12 must yield value axis 0.45..12.55 (single 5% margin) and must not reach 0. This fails on the old stacked-margin behavior.

Before/after evidence (boxplot_demo, data groups span 1..12):
- Before: value axis ran from below 0 to ~13.5 with a 0 tick present; PDF y tick labels included 0.
- After: value axis runs 0.45..12.55; lowest tick is 2, highest is 12, no 0 tick.

PDF tick labels (`pdftotext ... boxplot_demo.pdf`):
- matplotlib reference y ticks: 2, 4, 6, 8, 10, 12
- fortplot after fix y ticks: 2, 4, 6, 8, 10, 12 (matches; 0 tick removed)

Other examples in this cluster (bar_chart_demo, disconnected_lines, legend_demo, styling_demo) were re-rendered after a clean build and already match matplotlib data ranges and 5% margins (bars: category axis padded both sides, value axis flush at 0 with 5% headroom; line/scatter: 5% margin on both axes; bar sticky baseline at y=0 only). No code change was needed for those.
