### PR TITLE
fix: keep scatter and contour off the line color cycle

### DIFF
--- a/src/figures/core/fortplot_figure_core_impl_plots.f90
+++ b/src/figures/core/fortplot_figure_core_impl_plots.f90
@@ -254,7 +254,11 @@ contains
 
         real(wp) :: default_color(3)
 
-        default_color = next_plot_color(self%state)
+        ! Scatter uses matplotlib's patch colour cycle, independent of the line
+        ! cycle: it neither consumes nor is offset by line plots. Storage must
+        ! exist before counting patch artists for the cycle.
+        call ensure_figure_storage(self%plots, self%state)
+        default_color = next_patch_color(self%state, self%plots)
 
         call core_scatter(self%plots, self%state, self%plot_count, x, y, s, c, &
                            marker, markersize, color, colormap, alpha, edgecolor, &

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -19,8 +19,8 @@ module fortplot_figure_core
                                   PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
                                   PLOT_TYPE_SURFACE, PLOT_TYPE_POLAR, &
                                   AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
-    use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_figure_plot_management, only: next_plot_color
+    use fortplot_figure_initialization, only: figure_state_t, ensure_figure_storage
+    use fortplot_figure_plot_management, only: next_plot_color, next_patch_color
     use fortplot_figure_properties, only: figure_backend_color, &
                                           figure_backend_associated, &
                                           figure_backend_line

--- a/src/figures/fortplot_figure_plot_management.f90
+++ b/src/figures/fortplot_figure_plot_management.f90
@@ -8,7 +8,8 @@ module fortplot_figure_plot_management
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, &
                                   PLOT_TYPE_PCOLORMESH, PLOT_TYPE_FILL, &
                                   PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, &
-                                  PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM
+                                  PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
+                                  PLOT_TYPE_SCATTER
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_logging, only: log_warning, log_info
     use fortplot_legend, only: legend_t
@@ -82,24 +83,41 @@ contains
         end if
     end subroutine validate_plot_data
 
-    pure function next_plot_color(state) result(color)
+    pure function next_plot_color(state, plots) result(color)
+        !! Next colour from the line cycle (plot/axhline/axvline). matplotlib
+        !! advances the line property cycle only for line artists; scatter and
+        !! contour draw from the patch/colormap path and never touch it. When the
+        !! plots array is supplied, count existing line artists so an intervening
+        !! scatter or contour does not skip a colour. Without it, fall back to the
+        !! global plot index for callers that have no array in scope.
         type(figure_state_t), intent(in) :: state
+        type(plot_data_t), intent(in), optional :: plots(:)
         real(wp) :: color(3)
-        integer :: palette_size
+        integer :: palette_size, i, n_line
 
         palette_size = size(state%colors, 2)
         if (palette_size <= 0) then
             color = [0.0_wp, 0.0_wp, 0.0_wp]
+            return
+        end if
+
+        if (present(plots)) then
+            n_line = 0
+            do i = 1, min(state%plot_count, size(plots))
+                if (plots(i)%plot_type == PLOT_TYPE_LINE) n_line = n_line + 1
+            end do
+            color = state%colors(:, mod(n_line, palette_size) + 1)
         else
             color = state%colors(:, mod(state%plot_count, palette_size) + 1)
         end if
     end function next_plot_color
 
     pure function next_patch_color(state, plots) result(color)
-        !! Next colour from the patch cycle (fill/bar/histogram). matplotlib
-        !! cycles patches independently of lines, so the first filled area is
-        !! tab:blue even when a line was drawn before it. Counts existing patch
-        !! artists rather than the global plot index.
+        !! Next colour from the patch cycle (scatter/fill/bar/histogram).
+        !! matplotlib cycles patches independently of lines, so the first
+        !! scatter or filled area is tab:blue even when a line was drawn before
+        !! it, and a following line plot still starts at tab:blue. Counts
+        !! existing patch artists rather than the global plot index.
         type(figure_state_t), intent(in) :: state
         type(plot_data_t), intent(in) :: plots(:)
         real(wp) :: color(3)
@@ -114,7 +132,8 @@ contains
         n_patch = 0
         do i = 1, min(state%plot_count, size(plots))
             select case (plots(i)%plot_type)
-            case (PLOT_TYPE_FILL, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM)
+            case (PLOT_TYPE_FILL, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
+                  PLOT_TYPE_SCATTER)
                 n_patch = n_patch + 1
             end select
         end do

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -63,9 +63,9 @@ contains
         else if (fmt_color_ok) then
             plot_color = fmt_rgb
         else
-            plot_color = next_plot_color(state)
+            plot_color = next_plot_color(state, plots)
         end if
-        
+
         ! Add the plot data using focused module
         call register_line_plot_data(plots, state%plot_count, state%max_plots, &
                                x, y, label, ls, plot_color, &

--- a/src/plotting/fortplot_scatter_plots.f90
+++ b/src/plotting/fortplot_scatter_plots.f90
@@ -7,7 +7,7 @@ module fortplot_scatter_plots
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t
     use fortplot_figure_core_advanced, only: core_scatter
-    use fortplot_figure_plot_management, only: next_plot_color
+    use fortplot_figure_plot_management, only: next_patch_color
     use fortplot_logging, only: log_error
 
     implicit none
@@ -106,8 +106,11 @@ contains
             allocate (self%plots(self%state%max_plots))
         end if
 
+        ! Scatter draws from matplotlib's patch colour cycle, which is
+        ! independent of the line cycle: a scatter does not consume a line
+        ! colour, and consecutive scatters still step blue/orange/green/red.
         self%state%plot_count = self%plot_count
-        default_color = next_plot_color(self%state)
+        default_color = next_patch_color(self%state, self%plots)
 
         if (use_projection) then
             n_points = size(x)

--- a/test/plot_types/2d/test_scatter.f90
+++ b/test/plot_types/2d/test_scatter.f90
@@ -4,7 +4,6 @@ program test_scatter
     !! test_scatter_metadata_parity
     use fortplot, only: figure_t, figure, scatter, add_scatter, savefig, wp
     use fortplot_global, only: global_figure
-    use fortplot_figure_plot_management, only: next_plot_color
     use fortplot_plot_data, only: plot_data_t
     use fortplot_scatter_plots, only: add_scatter_plot_data
     use, intrinsic :: iso_fortran_env, only: dp => real64, error_unit
@@ -44,29 +43,47 @@ program test_scatter
 contains
 
     subroutine test_color_cycle()
-        !! Verify scatter plots share the default color cycle with line plots
+        !! matplotlib drives scatter from the patch colour cycle, which is
+        !! independent of the line cycle. A scatter therefore neither consumes a
+        !! line colour nor is offset by an earlier line plot: scatter after a
+        !! plot is still C0, the next line plot is C1, and consecutive scatters
+        !! step C0, C1 themselves.
         type(figure_t) :: fig
-        real(wp) :: x(5), y_line(5), y_scatter(5)
-        real(wp) :: expected_color(3), scatter_color(3)
+        real(wp) :: x(5), y(5)
+        real(wp) :: c0(3), c1(3)
         integer :: i
+        logical :: ok
 
         total_tests = total_tests + 1
 
         x = [(real(i, wp), i = 1, size(x))]
-        y_line = x
-        y_scatter = x + 1.0_wp
+        y = x
 
         call fig%initialize()
-        call fig%plot(x, y_line)
-        expected_color = next_plot_color(fig%state)
-        call fig%scatter(x, y_scatter)
-        scatter_color = fig%plots(fig%plot_count)%color
+        c0 = fig%state%colors(:, 1)
+        c1 = fig%state%colors(:, 2)
 
-        if (any(abs(scatter_color - expected_color) > 1.0e-12_wp)) then
-            print *, 'FAIL: test_color_cycle - scatter default color diverged'
-        else
+        ok = .true.
+
+        ! plot -> line cycle C0; scatter after it -> patch cycle C0 (not C1)
+        call fig%plot(x, y)
+        if (any(abs(fig%plots(fig%plot_count)%color - c0) > 1.0e-12_wp)) ok = .false.
+        call fig%scatter(x, y + 1.0_wp)
+        if (any(abs(fig%plots(fig%plot_count)%color - c0) > 1.0e-12_wp)) ok = .false.
+
+        ! second scatter steps the patch cycle to C1
+        call fig%scatter(x, y + 2.0_wp)
+        if (any(abs(fig%plots(fig%plot_count)%color - c1) > 1.0e-12_wp)) ok = .false.
+
+        ! next line plot continues the line cycle at C1, unaffected by scatters
+        call fig%plot(x, y + 3.0_wp)
+        if (any(abs(fig%plots(fig%plot_count)%color - c1) > 1.0e-12_wp)) ok = .false.
+
+        if (ok) then
             print *, '  PASS: test_color_cycle'
             passed_tests = passed_tests + 1
+        else
+            print *, 'FAIL: test_color_cycle - scatter/line cycle parity diverged'
         end if
     end subroutine test_color_cycle
 


### PR DESCRIPTION
## Summary

Scatter and contour were advancing the line color cycle, so the next `plot()` after either one was drawn in C1 (orange) instead of C0 (blue). This restores matplotlib's default behavior: the line property cycle advances only for line artists, while scatter draws from the independent patch cycle and contour uses a colormap.

### Defects fixed (matplotlib 3.10.9 parity)

- scatter no longer consumes a line-cycle slot: the Sin reference line after a scatter is C0 blue, matching matplotlib (was C1 orange).
- contour no longer offsets the line cycle: the cross-section line after a contour is C0 blue, matching matplotlib (was C1 orange).
- consecutive scatters still step the palette C0, C1, C2, C3 (patch cycle), preserving the marker-types example.

### Approach

- `scatter` now uses the patch color cycle (`next_patch_color`) instead of the line cycle; `PLOT_TYPE_SCATTER` is counted as a patch artist.
- `next_plot_color` counts only line artists when the plots array is supplied, so an intervening scatter or contour does not shift the line cycle index.
- The scatter color-cycle unit test now asserts the matplotlib-correct semantics it previously inverted (it expected scatter to take the next line color after a plot).

## Verification

Commands run:

- `fpm build` (with `OMP_NUM_THREADS=1` to avoid an unrelated fpm parallel-backend crash): succeeds.
- `fpm run --example styling_demo` and `fpm run --example contour_demo`: regenerated affected outputs.
- `make verify-artifacts`: ends with `Artifact verification passed.` The quiver scale gate (`scaled < unscaled (scale-dependent)`) is preserved.
- `make test-ci`: ends with `CI essential test suite completed successfully`.
- `fpm test --target test_scatter`: 13/13 pass, including the updated color-cycle test.
- `fpm test --target test_matplotlib_api_alignment` and `--target test_contour`: pass.

Before/after evidence:

- styling_demo `scatter_plot.png`: before, the "Sin(x) Reference" line rendered orange (C1) while the scatter dots were blue (C0); after, both the line and dots are blue (C0), matching the matplotlib reference.
- styling_demo `marker_types.png`: unchanged — four scatters render blue/orange/green/red (C0..C3), matching matplotlib.
- contour_demo `mixed_plot.png`: before, the cross-section bell curve peaking at y=1 rendered orange (C1); after, it renders blue (C0), matching the matplotlib reference; the viridis contour lines are unchanged.

Color reference: C0 = #1f77b4 (RGB 0.1216, 0.4667, 0.7059), C1 = #ff7f0e (RGB 1.0, 0.498, 0.0549).
