### PR TITLE
fix: use linear-interpolation percentiles for boxplot quartiles

### DIFF
--- a/src/figures/plot_types/fortplot_figure_boxplot.f90
+++ b/src/figures/plot_types/fortplot_figure_boxplot.f90
@@ -107,23 +107,20 @@ contains
         !! Compute quartiles, whiskers, and outliers for a box plot in-place
         type(plot_data_t), intent(inout) :: plot
         real(wp), allocatable :: sorted(:)
-        integer :: n, i, q1_idx, q2_idx, q3_idx, n_out
+        integer :: n, i, n_out
         real(wp) :: iqr, lfence, ufence
-        
+
         if (.not. allocated(plot%box_data)) return
         n = size(plot%box_data)
         if (n == 0) return
-        
+
         allocate(sorted(n))
         sorted = plot%box_data
         call sort_array(sorted)
-        
-        q1_idx = max(1, nint(0.25_wp * n))
-        q2_idx = max(1, nint(0.50_wp * n))
-        q3_idx = max(1, nint(0.75_wp * n))
-        plot%q1 = sorted(q1_idx)
-        plot%q2 = sorted(q2_idx)
-        plot%q3 = sorted(q3_idx)
+
+        plot%q1 = linear_percentile(sorted, 25.0_wp)
+        plot%q2 = linear_percentile(sorted, 50.0_wp)
+        plot%q3 = linear_percentile(sorted, 75.0_wp)
         
         iqr = plot%q3 - plot%q1
         lfence = plot%q1 - 1.5_wp * iqr
@@ -176,29 +173,25 @@ contains
         real(wp) :: q1, q2, q3, iqr
         real(wp) :: whisker_low, whisker_high
         real(wp) :: data_min, data_max
-        integer :: n, q1_idx, q2_idx, q3_idx
-        
+        integer :: n
+
         n = size(data)
         if (n == 0) return
-        
+
         ! Position and width
         pos = 1.0_wp
         if (present(position)) pos = position
         box_half_width = 0.3_wp
-        
+
         ! Sort data for quartile calculation
         allocate(sorted_data(n))
         sorted_data = data
         call sort_array(sorted_data)
-        
-        ! Calculate quartiles
-        q1_idx = max(1, int(0.25_wp * n))
-        q2_idx = max(1, int(0.50_wp * n))
-        q3_idx = max(1, int(0.75_wp * n))
-        
-        q1 = sorted_data(q1_idx)
-        q2 = sorted_data(q2_idx)
-        q3 = sorted_data(q3_idx)
+
+        ! Quartiles via matplotlib's linear-interpolation percentile
+        q1 = linear_percentile(sorted_data, 25.0_wp)
+        q2 = linear_percentile(sorted_data, 50.0_wp)
+        q3 = linear_percentile(sorted_data, 75.0_wp)
         
         ! IQR and whiskers
         iqr = q3 - q1
@@ -231,5 +224,32 @@ contains
             y_max = max(y_max, data_max + 0.1_wp * abs(data_max - data_min))
         end if
     end subroutine update_boxplot_ranges
-    
+
+    pure function linear_percentile(sorted_data, percentile) result(value)
+        !! Percentile via linear interpolation between closest ranks.
+        !! Matches numpy's default ('linear', type 7) used by matplotlib boxplots:
+        !! position = (n - 1) * p / 100, interpolating between bracketing samples.
+        real(wp), intent(in) :: sorted_data(:)
+        real(wp), intent(in) :: percentile
+        real(wp) :: value
+
+        integer :: n, lo
+        real(wp) :: rank, frac
+
+        n = size(sorted_data)
+        if (n == 1) then
+            value = sorted_data(1)
+            return
+        end if
+
+        rank = (real(n, wp) - 1.0_wp) * percentile / 100.0_wp
+        lo = int(rank) + 1
+        if (lo >= n) then
+            value = sorted_data(n)
+            return
+        end if
+        frac = rank - real(lo - 1, wp)
+        value = sorted_data(lo) + frac * (sorted_data(lo + 1) - sorted_data(lo))
+    end function linear_percentile
+
 end module fortplot_figure_boxplot

--- a/src/plotting/fortplot_plot_statistics.f90
+++ b/src/plotting/fortplot_plot_statistics.f90
@@ -281,25 +281,20 @@ contains
         logical, intent(in), optional :: show_outliers
         
         real(wp), allocatable :: sorted_data(:)
-        integer :: n, q1_idx, q2_idx, q3_idx, n_outliers, i
+        integer :: n, n_outliers, i
         real(wp) :: iqr, lower_fence, upper_fence
-        
+
         n = size(data)
         allocate(sorted_data(n))
         sorted_data = data
-        
+
         ! Sort data
         call sort_array(sorted_data)
-        
-        ! Calculate quartile indices
-        q1_idx = max(1, nint(0.25_wp * n))
-        q2_idx = max(1, nint(0.50_wp * n))
-        q3_idx = max(1, nint(0.75_wp * n))
-        
-        ! Store quartiles
-        plots(plot_idx)%q1 = sorted_data(q1_idx)
-        plots(plot_idx)%q2 = sorted_data(q2_idx)
-        plots(plot_idx)%q3 = sorted_data(q3_idx)
+
+        ! Quartiles via matplotlib's default linear-interpolation percentile
+        plots(plot_idx)%q1 = linear_percentile(sorted_data, 25.0_wp)
+        plots(plot_idx)%q2 = linear_percentile(sorted_data, 50.0_wp)
+        plots(plot_idx)%q3 = linear_percentile(sorted_data, 75.0_wp)
         
         ! Calculate IQR and fences
         iqr = plots(plot_idx)%q3 - plots(plot_idx)%q1
@@ -366,5 +361,32 @@ contains
             plots(plot_idx)%width = 0.6_wp
         end if
     end subroutine compute_boxplot_statistics
+
+    pure function linear_percentile(sorted_data, percentile) result(value)
+        !! Percentile via linear interpolation between closest ranks.
+        !! Matches numpy's default ('linear', type 7) used by matplotlib boxplots:
+        !! position = (n - 1) * p / 100, interpolating between bracketing samples.
+        real(wp), intent(in) :: sorted_data(:)
+        real(wp), intent(in) :: percentile
+        real(wp) :: value
+
+        integer :: n, lo
+        real(wp) :: rank, frac
+
+        n = size(sorted_data)
+        if (n == 1) then
+            value = sorted_data(1)
+            return
+        end if
+
+        rank = (real(n, wp) - 1.0_wp) * percentile / 100.0_wp
+        lo = int(rank) + 1
+        if (lo >= n) then
+            value = sorted_data(n)
+            return
+        end if
+        frac = rank - real(lo - 1, wp)
+        value = sorted_data(lo) + frac * (sorted_data(lo + 1) - sorted_data(lo))
+    end function linear_percentile
 
 end module fortplot_plot_statistics

--- a/test/plot_types/test_boxplot_comprehensive.f90
+++ b/test/plot_types/test_boxplot_comprehensive.f90
@@ -122,9 +122,20 @@ contains
             error stop 1
         end if
 
-        if (abs(fig%plots(1)%q2 - 5.0_wp) > 1.0e-6_wp .and. &
-            abs(fig%plots(1)%q2 - 6.0_wp) > 1.0e-6_wp) then
+        ! matplotlib/numpy linear-interpolation percentiles for 1..10:
+        ! q1=3.25, median=5.5, q3=7.75
+        if (abs(fig%plots(1)%q1 - 3.25_wp) > 1.0e-6_wp) then
+            print *, 'FAIL: q1 not set as expected: ', fig%plots(1)%q1
+            error stop 1
+        end if
+
+        if (abs(fig%plots(1)%q2 - 5.5_wp) > 1.0e-6_wp) then
             print *, 'FAIL: median (q2) not set as expected: ', fig%plots(1)%q2
+            error stop 1
+        end if
+
+        if (abs(fig%plots(1)%q3 - 7.75_wp) > 1.0e-6_wp) then
+            print *, 'FAIL: q3 not set as expected: ', fig%plots(1)%q3
             error stop 1
         end if
 


### PR DESCRIPTION
## Summary

fortplot boxplots computed quartiles by nearest-rank indexing into the sorted
array (`nint`/`int` of `0.25*n` etc.). matplotlib (via numpy's default `linear`
percentile, type 7) interpolates between bracketing samples. This produced
boxes and medians that did not match matplotlib's default rendering.

This change introduces a `linear_percentile` helper and uses it for Q1, the
median (Q2), and Q3 in both the in-place render statistics and the data-range
computation, so the drawn box matches the computed quartiles.

## Verification

Commands run:
- `fpm build` - succeeds
- `fpm run --example boxplot_demo` - regenerates the affected example
- `fpm test --target test_boxplot_comprehensive` - all boxplot tests pass
- `make verify-artifacts` - ends with "Artifact verification passed."
- `make test-ci` - completes successfully

Before vs after (data `group_a = 1..10`, n=10):
- Before: Q1=3, median=5, Q3=8 (nearest-rank). Box drawn 3..8, median line at 5.
- After: Q1=3.25, median=5.5, Q3=7.75 (linear interpolation). Box drawn
  3.25..7.75, median line at 5.5, matching the matplotlib reference render.
- Group B (2..11): box 4.25..8.75, median 6.5. Group C (3..12): box 5.25..9.75,
  median 7.5. All match matplotlib defaults.

The boxplot comprehensive test previously accepted either the old buggy median
(5.0 or 6.0); it now asserts the matplotlib-correct Q1=3.25, median=5.5,
Q3=7.75 for the 1..10 dataset.