### PR TITLE
fix: align 3D axes box, grid, ticks, and labels with matplotlib

### DIFF
--- a/src/plotting/fortplot_3d_axes.f90
+++ b/src/plotting/fortplot_3d_axes.f90
@@ -51,6 +51,8 @@ contains
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
 
         real(wp) :: corners_2d(2, 8), corners_depth(8)
+        real(wp) :: frac(MAX_TICKS_PER_AXIS, 3)
+        integer :: n_frac(3)
 
         ! Validate input ranges
         if (x_max <= x_min .or. y_max <= y_min .or. z_max <= z_min) return
@@ -58,12 +60,18 @@ contains
         call project_box_corners(ctx, x_min, x_max, y_min, y_max, &
                                  corners_2d, corners_depth)
 
+        ! Tick fractions per axis drive the per-tick pane gridlines, matching
+        ! matplotlib mplot3d (one gridline at every tick, not a fixed count).
+        call compute_axis_tick_fractions(x_min, x_max, frac(:, X_AXIS), n_frac(X_AXIS))
+        call compute_axis_tick_fractions(y_min, y_max, frac(:, Y_AXIS), n_frac(Y_AXIS))
+        call compute_axis_tick_fractions(z_min, z_max, frac(:, Z_AXIS), n_frac(Z_AXIS))
+
         ! Draw back panes, gridlines, and the back spines first so they sit
         ! behind the data (rendered after this routine). The front spines are
         ! deferred to draw_3d_front_frame, emitted after the data, so they
         ! occlude it (global painter ordering, matplotlib mplot3d).
         call draw_back_panes(ctx, corners_2d, corners_depth)
-        call draw_pane_gridlines(ctx, corners_2d, corners_depth)
+        call draw_pane_gridlines(ctx, corners_2d, corners_depth, frac, n_frac)
         call draw_back_spines(ctx, corners_2d, corners_depth)
 
         ! Draw ticks and labels on each axis
@@ -105,6 +113,32 @@ contains
         call project_to_2d(corners_3d, azim, elev, dist, corners_2d, corners_depth)
         call scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
     end subroutine project_box_corners
+
+    subroutine compute_axis_tick_fractions(axis_min, axis_max, frac, n_frac)
+        !! Nice tick positions for one axis expressed as fractions in [0,1] of the
+        !! axis range. Shared by the pane gridlines so gridlines coincide with the
+        !! drawn ticks, matching matplotlib mplot3d.
+        real(wp), intent(in) :: axis_min, axis_max
+        real(wp), intent(out) :: frac(:)
+        integer, intent(out) :: n_frac
+
+        real(wp) :: tick_values(MAX_TICKS_PER_AXIS), step_size
+        real(wp) :: nice_min, nice_max, span
+        integer :: n_ticks, i
+
+        n_frac = 0
+        frac = 0.0_wp
+        if (axis_max <= axis_min) return
+
+        call find_nice_tick_locations(axis_min, axis_max, 9, nice_min, nice_max, &
+                                      step_size, tick_values, n_ticks)
+        span = max(EPSILON, axis_max - axis_min)
+        do i = 1, n_ticks
+            if (tick_values(i) < axis_min .or. tick_values(i) > axis_max) cycle
+            n_frac = n_frac + 1
+            frac(n_frac) = (tick_values(i) - axis_min)/span
+        end do
+    end subroutine compute_axis_tick_fractions
 
     subroutine create_unit_cube(corners_3d)
         !! Create unit cube vertices in normalized [0,1]³ space
@@ -174,6 +208,9 @@ contains
         real(wp), intent(in) :: corners_2d(2, 8)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
 
+        ! Tick marks and labels are black, regardless of the gray left set by the
+        ! box spines drawn just before this routine.
+        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
         ! Draw each axis independently using the same pattern
         call draw_single_axis_ticks(ctx, corners_2d, X_AXIS, x_min, x_max, x_min, x_max, y_min, y_max, z_min, z_max)
         call draw_single_axis_ticks(ctx, corners_2d, Y_AXIS, y_min, y_max, x_min, x_max, y_min, y_max, z_min, z_max)  
@@ -191,8 +228,10 @@ contains
         real(wp) :: nice_min, nice_max
         integer :: n_ticks, decimals, corner1, corner2
 
-        ! Get nice tick locations
-        call find_nice_tick_locations(axis_min, axis_max, 5, nice_min, nice_max, &
+        ! Get nice tick locations. mplot3d places markedly more ticks than the
+        ! 2D default; a target of nine reproduces matplotlib's 0.25 spacing on a
+        ! unit range and unit spacing on a 0..5 range.
+        call find_nice_tick_locations(axis_min, axis_max, 9, nice_min, nice_max, &
                                       step_size, tick_values, n_ticks)
         decimals = determine_decimal_places_from_step(step_size)
 
@@ -243,7 +282,13 @@ subroutine draw_ticks_on_edge(ctx, corners_2d, corner1, corner2, tick_values, n_
                                    tick_px, pad_px, extra_px)
         if (edge_len <= EPSILON) return
 
-        ! Phase 2: collect tick candidates
+        ! Phase 2: collect tick candidates. Initialise the candidate buffers so
+        ! ticks skipped by the range filter below leave no stale stack memory
+        ! that could later be drawn as a tofu label at a garbage position.
+        cand_valid = .false.
+        cand_endpoint = .false.
+        cand_label_pos = 0.0_wp
+        cand_text = ''
         tol = 1.0e-9_wp*max(1.0_wp, abs(axis_max - axis_min))
         do i = 1, n_ticks
             if (tick_values(i) < axis_min .or. tick_values(i) > axis_max) cycle

--- a/src/plotting/fortplot_3d_box.f90
+++ b/src/plotting/fortplot_3d_box.f90
@@ -17,10 +17,16 @@ module fortplot_3d_box
               CORNER_MIN_MAX_MIN, CORNER_MIN_MIN_MAX, CORNER_MAX_MIN_MAX, &
               CORNER_MAX_MAX_MAX, CORNER_MIN_MAX_MAX
 
-    ! matplotlib mplot3d pane fill (light gray) and pane gridline color.
+    ! matplotlib mplot3d pane fill (light gray), pane gridline color, and box
+    ! spine color. mplot3d strokes the spines in a light gray, not pure black,
+    ! and the gridlines a touch lighter still.
     real(wp), parameter :: PANE_RGB(3) = [0.95_wp, 0.95_wp, 0.95_wp]
-    real(wp), parameter :: GRID_RGB(3) = [0.7_wp, 0.7_wp, 0.7_wp]
-    integer, parameter :: N_GRIDLINES = 4   ! interior gridlines per pane direction
+    real(wp), parameter :: GRID_RGB(3) = [0.9_wp, 0.9_wp, 0.9_wp]
+    real(wp), parameter :: SPINE_RGB(3) = [0.6_wp, 0.6_wp, 0.6_wp]
+    integer, parameter :: MAX_TICKS_PER_AXIS = 10
+
+    ! Axis identification (matches fortplot_3d_axes)
+    integer, parameter :: X_AXIS = 1, Y_AXIS = 2, Z_AXIS = 3
 
     ! Corner indices for readability
     integer, parameter :: &
@@ -117,31 +123,53 @@ contains
             end do
             call ctx%fill_quad(xq, yq)
         end do
-        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+        call ctx%color(SPINE_RGB(1), SPINE_RGB(2), SPINE_RGB(3))
     end subroutine draw_back_panes
 
-    subroutine draw_pane_gridlines(ctx, corners_2d, corners_depth)
-        !! Draw interior gridlines across each back pane in light gray.
+    function face_edge_axes() result(ax)
+        !! For each cube face, the data axis that varies along the p1->p2 edge
+        !! (column 1) and along the p1->p4 edge (column 2). Mirrors the corner
+        !! ordering in cube_faces().
+        integer :: ax(2, 6)
+        ax(:, 1) = [X_AXIS, Y_AXIS]   ! z = 0 (bottom)
+        ax(:, 2) = [X_AXIS, Y_AXIS]   ! z = 1 (top)
+        ax(:, 3) = [X_AXIS, Z_AXIS]   ! y = 0
+        ax(:, 4) = [X_AXIS, Z_AXIS]   ! y = 1
+        ax(:, 5) = [Y_AXIS, Z_AXIS]   ! x = 0
+        ax(:, 6) = [Y_AXIS, Z_AXIS]   ! x = 1
+    end function face_edge_axes
+
+    subroutine draw_pane_gridlines(ctx, corners_2d, corners_depth, frac, n_frac)
+        !! Draw gridlines across each back pane at the per-axis tick fractions,
+        !! one line per tick, in light gray (matplotlib mplot3d).
         class(plot_context), intent(inout) :: ctx
         real(wp), intent(in) :: corners_2d(2, 8), corners_depth(8)
-        integer :: faces(4, 6), f
+        real(wp), intent(in) :: frac(MAX_TICKS_PER_AXIS, 3)
+        integer, intent(in) :: n_frac(3)
+        integer :: faces(4, 6), edge_ax(2, 6), f
         logical :: is_back(6)
 
         faces = cube_faces()
+        edge_ax = face_edge_axes()
         is_back = back_face_flags(corners_depth)
         call ctx%color(GRID_RGB(1), GRID_RGB(2), GRID_RGB(3))
         call ctx%set_line_width(0.5_wp)
         do f = 1, 6
-            if (is_back(f)) call draw_face_grid(ctx, corners_2d, faces(:, f))
+            if (is_back(f)) call draw_face_grid(ctx, corners_2d, faces(:, f), &
+                                                edge_ax(:, f), frac, n_frac)
         end do
-        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+        call ctx%color(SPINE_RGB(1), SPINE_RGB(2), SPINE_RGB(3))
     end subroutine draw_pane_gridlines
 
-    subroutine draw_face_grid(ctx, corners_2d, face)
-        !! Draw a regular grid on one quad face by interpolating its edges.
+    subroutine draw_face_grid(ctx, corners_2d, face, edge_ax, frac, n_frac)
+        !! Draw gridlines on one quad face at the tick fractions of each spanning
+        !! axis. Lines parallel to p1->p4 are placed at the p1->p2 axis ticks and
+        !! vice versa, so every gridline meets a tick on the box edge.
         class(plot_context), intent(inout) :: ctx
         real(wp), intent(in) :: corners_2d(2, 8)
-        integer, intent(in) :: face(4)
+        integer, intent(in) :: face(4), edge_ax(2)
+        real(wp), intent(in) :: frac(MAX_TICKS_PER_AXIS, 3)
+        integer, intent(in) :: n_frac(3)
         real(wp) :: p1(2), p2(2), p3(2), p4(2), a1(2), a2(2)
         real(wp) :: t
         integer :: g
@@ -151,13 +179,18 @@ contains
         p3 = corners_2d(:, face(3))
         p4 = corners_2d(:, face(4))
 
-        do g = 1, N_GRIDLINES
-            t = real(g, wp)/real(N_GRIDLINES + 1, wp)
-            ! Lines parallel to edge p1->p4 (interpolate along p1->p2 and p4->p3)
+        ! Lines parallel to edge p1->p4, stepped along the p1->p2 axis ticks.
+        do g = 1, n_frac(edge_ax(1))
+            t = frac(g, edge_ax(1))
+            if (t <= 0.0_wp .or. t >= 1.0_wp) cycle
             a1 = p1 + t*(p2 - p1)
             a2 = p4 + t*(p3 - p4)
             call ctx%line(a1(1), a1(2), a2(1), a2(2))
-            ! Lines parallel to edge p1->p2 (interpolate along p1->p4 and p2->p3)
+        end do
+        ! Lines parallel to edge p1->p2, stepped along the p1->p4 axis ticks.
+        do g = 1, n_frac(edge_ax(2))
+            t = frac(g, edge_ax(2))
+            if (t <= 0.0_wp .or. t >= 1.0_wp) cycle
             a1 = p1 + t*(p4 - p1)
             a2 = p2 + t*(p3 - p2)
             call ctx%line(a1(1), a1(2), a2(1), a2(2))
@@ -196,7 +229,7 @@ contains
 
         edges = cube_edges()
         center_depth = sum(corners_depth)/8.0_wp
-        call ctx%color(0.0_wp, 0.0_wp, 0.0_wp)
+        call ctx%color(SPINE_RGB(1), SPINE_RGB(2), SPINE_RGB(3))
         call ctx%set_line_width(0.8_wp)
         do e = 1, 12
             edge_depth = 0.5_wp*(corners_depth(edges(1, e)) &


### PR DESCRIPTION
## Summary

Fixes the matplotlib-parity defect cluster in the 3D axes box for the `3d_plotting` example.

Defects addressed:
- Projected z tick labels collapsed into a row of tofu boxes across the plot interior.
- Box spines drawn pure black instead of light gray.
- Only ~3 coarse ticks per axis.
- Fixed count of 4 pane gridlines, drawn in a too-dark mid-gray.

Changes:
- Initialise the per-tick candidate buffers in `draw_ticks_on_edge` before
  collecting ticks. Ticks dropped by the in-range filter previously left
  uninitialised stack entries whose `valid` flag could read true, drawing a
  garbage-positioned label as a tofu glyph in the plot interior.
- Stroke box spines and pane gridlines in light gray instead of pure black and
  mid-gray, matching mplot3d defaults.
- Raise the 3D tick target so axes show the denser matplotlib spacing
  (0.25 on a unit range, 1.0 on a 0..5 range).
- Place one pane gridline at every tick on each spanning axis, so gridlines
  coincide with the drawn ticks instead of a fixed count.
- Draw tick marks and labels in black regardless of the spine color.

## Verification

Commands run:
- `fpm build` — succeeds.
- `fpm run --example 3d_plotting` — regenerates the 3D PNGs.
- `make verify-artifacts` — ends with `Artifact verification passed.` The quiver
  geometry assertion (scaled shaft length < unscaled, scale-dependent) still holds.
- `make test-ci` — `CI essential test suite completed successfully`.
- `fpm test --target test_3d` — 13/13 pass, including `test_axes_pdf_ticks`,
  `test_tick_orientation`, `test_pdf_3d_plot_rendering`.
- `fpm test --target test_3d_backend_parity` — PASS.

Before/after evidence (`output/example/fortran/3d_plotting/parametric_curve.png`):
- Before: a horizontal row of tofu boxes sat at roughly z=1.0 across the plot
  interior (uninitialised z label drawn at a garbage position near the cube
  origin). Box spines were pure black. Each pane had 4 evenly spaced gridlines
  in mid-gray. Z axis showed only 0.0/0.5/1.0/1.5 with coarse x/y ticks.
- After: no interior tofu. Box spines are light gray (RGB 0.6). Each back pane
  carries one light-gray gridline (RGB 0.9) per tick. Z axis shows
  0.00..1.75 at 0.25 spacing; x and y show 0.25 spacing, matching the
  matplotlib reference render.

Same improvement is visible in `3d_helix.png` (z ticks 0..4 step 1, light-gray
box and per-tick gridlines) and the surface/scatter renders show no regression.
The fix lives in the backend-agnostic 3D axes path, so it applies equally to the
PDF backend.
