### PR TITLE
fix: render twin log axes with sub-decade ticks

### DIFF
--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -127,6 +127,17 @@ contains
             end if
         end if
 
+        if (i + 5 <= n) then
+            if (input_text(i + 1:i + 5) == 'times') then
+                ! Emit U+00D7 (multiplication sign) so log mantissa labels like
+                ! 4.2 x 10^1 render with matplotlib's cross glyph.
+                call append_current_text(current_text, current_len, &
+                                         achar(195)//achar(151))
+                i = i + 6
+                return
+            end if
+        end if
+
         if (i + 1 <= n) then
             select case (input_text(i + 1:i + 1))
             case ('_', '^', '$', '\')

--- a/src/ui/fortplot_axes.f90
+++ b/src/ui/fortplot_axes.f90
@@ -8,7 +8,8 @@ module fortplot_axes
     use fortplot_context
     use fortplot_scales
     use fortplot_constants, only: SCIENTIFIC_THRESHOLD_HIGH
-    use fortplot_tick_formatting, only: format_power_of_ten_label
+    use fortplot_tick_formatting, only: format_power_of_ten_label, &
+                                        format_log_mantissa_label
     use fortplot_axes_date, only: is_date_scale, format_date_tick_label, &
                                   default_date_format, date_value_to_unix_seconds, &
                                   compute_date_ticks, pick_fixed_step_seconds
@@ -122,35 +123,116 @@ contains
     end subroutine compute_linear_ticks
 
     subroutine compute_log_ticks(data_min, data_max, tick_positions, num_ticks)
-        !! Compute tick positions for logarithmic scale
+        !! Compute tick positions for logarithmic scale.
+        !!
+        !! Matches matplotlib's LogLocator: when the visible range spans at least
+        !! one full decade, the decade powers (10**p) are the ticks. For a
+        !! sub-decade range like [42, 50] no power of ten lands inside, so
+        !! matplotlib promotes mantissa subdivisions to labeled ticks. We mirror
+        !! that by trying progressively finer mantissa sets {1..9} then 0.1 steps
+        !! and keeping the coarsest set that yields enough ticks.
         real(wp), intent(in) :: data_min, data_max
         real(wp), intent(out) :: tick_positions(MAX_TICKS)
         integer, intent(out) :: num_ticks
 
-        real(wp) :: log_min, log_max, current_power
-        integer :: start_power, end_power, power
+        integer, parameter :: MIN_SUBDECADE_TICKS = 2
+        real(wp) :: trial_positions(MAX_TICKS)
+        real(wp) :: sub_min
+        integer :: num_decade_ticks, trial_count
 
         if (data_min <= 0.0_wp .or. data_max <= 0.0_wp) then
             num_ticks = 0
             return
         end if
 
-        log_min = log10(data_min)
-        log_max = log10(data_max)
+        call collect_log_mantissa_ticks(data_min, data_max, 1.0_wp, &
+                                        tick_positions, num_decade_ticks)
+        num_ticks = num_decade_ticks
+        if (num_decade_ticks >= MIN_SUBDECADE_TICKS) return
 
-        start_power = floor(log_min)
-        end_power = ceiling(log_max)
+        ! Too few decade ticks. Promote mantissa subdivisions to labeled ticks,
+        ! matching matplotlib's sub-decade log labels. When a decade power is in
+        ! range, only subdivide from that power upward (matplotlib does not label
+        ! the partial decade below the lowest visible power); otherwise subdivide
+        ! the data's own decade so a sub-decade range like [42, 50] is covered.
+        if (num_decade_ticks == 1) then
+            sub_min = tick_positions(1)
+        else
+            sub_min = data_min
+        end if
+
+        ! Try integer mantissa subdivisions {1..9} first, then 0.1 steps.
+        call collect_log_mantissa_ticks(sub_min, data_max, 0.0_wp, &
+                                        trial_positions, trial_count)
+        if (trial_count >= MIN_SUBDECADE_TICKS .and. trial_count <= MAX_TICKS) then
+            tick_positions = trial_positions
+            num_ticks = trial_count
+            return
+        end if
+
+        call collect_log_mantissa_ticks(sub_min, data_max, 0.1_wp, &
+                                        trial_positions, trial_count)
+        if (trial_count >= MIN_SUBDECADE_TICKS) then
+            tick_positions = trial_positions
+            num_ticks = trial_count
+        end if
+    end subroutine compute_log_ticks
+
+    subroutine collect_log_mantissa_ticks(data_min, data_max, mantissa_step, &
+                                          tick_positions, num_ticks)
+        !! Collect log-scale tick positions in [data_min, data_max].
+        !! mantissa_step controls the subdivision within each decade:
+        !!   1.0 -> decade powers only (10**p)
+        !!   0.0 -> integer mantissas {1,2,...,9} * 10**p
+        !!   0.1 -> tenth mantissas    {1.0,1.1,...,9.9} * 10**p
+        real(wp), intent(in) :: data_min, data_max, mantissa_step
+        real(wp), intent(out) :: tick_positions(MAX_TICKS)
+        integer, intent(out) :: num_ticks
+
+        real(wp) :: value, mantissa, step
+        integer :: start_power, end_power, power, m, m_max
+        real(wp) :: lo_eps, hi_eps
 
         num_ticks = 0
+        start_power = floor(log10(data_min))
+        end_power = ceiling(log10(data_max))
+        lo_eps = data_min*(1.0_wp - TICK_EPS)
+        hi_eps = data_max*(1.0_wp + TICK_EPS)
+
+        if (mantissa_step >= 1.0_wp) then
+            do power = start_power, end_power
+                if (num_ticks >= MAX_TICKS) exit
+                value = 10.0_wp**power
+                if (value >= lo_eps .and. value <= hi_eps) then
+                    num_ticks = num_ticks + 1
+                    tick_positions(num_ticks) = value
+                end if
+            end do
+            return
+        end if
+
+        if (mantissa_step <= 0.0_wp) then
+            step = 1.0_wp
+            m_max = 9
+        else
+            step = mantissa_step
+            m_max = nint(9.0_wp/mantissa_step) + 9
+        end if
+
         do power = start_power, end_power
+            do m = 1, m_max
+                if (num_ticks >= MAX_TICKS) exit
+                mantissa = 1.0_wp + real(m - 1, wp)*step
+                if (mantissa >= 10.0_wp) exit
+                value = mantissa*10.0_wp**power
+                if (value >= lo_eps .and. value <= hi_eps) then
+                    num_ticks = num_ticks + 1
+                    tick_positions(num_ticks) = value
+                end if
+            end do
             if (num_ticks >= MAX_TICKS) exit
-            current_power = 10.0_wp**power
-            if (current_power >= data_min .and. current_power <= data_max) then
-                num_ticks = num_ticks + 1
-                tick_positions(num_ticks) = current_power
-            end if
         end do
-    end subroutine compute_log_ticks
+    end subroutine collect_log_mantissa_ticks
 
     subroutine compute_symlog_ticks(data_min, data_max, threshold, &
                                     tick_positions, num_ticks)
@@ -215,6 +297,10 @@ contains
         else if (is_log_scale .and. is_power_of_ten(value)) then
             ! Unify log and symlog formatting: show powers of ten with superscript
             label = format_power_of_ten_label(value)
+        else if (trim(scale_type) == 'log') then
+            ! Sub-decade log ticks (e.g. 4.2e1) render as m x 10^p, matching
+            ! matplotlib's minor log labels when no decade tick is in range.
+            label = format_log_mantissa_label(value)
         else if (.not. is_log_scale .and. abs_value < TICK_EPS) then
             label = '0'
         else if (abs_value >= SCIENTIFIC_THRESHOLD_HIGH .or. abs_value < &

--- a/src/utilities/fortplot_scales.f90
+++ b/src/utilities/fortplot_scales.f90
@@ -219,9 +219,16 @@ contains
             return
         end if
         
-        ! Ensure positive values for log transformation
+        ! Ensure positive values for log transformation. Only widen the upper
+        ! edge when the data range is degenerate (max <= min after the floor);
+        ! a real sub-decade range like [42, 50] must be preserved, not inflated
+        ! to a full octave, otherwise the curve collapses toward one edge.
         clamped_min = max(data_min, 10.0_wp**MIN_LOG_VALUE)
-        clamped_max = max(data_max, clamped_min * 2.0_wp)
+        if (data_max > clamped_min) then
+            clamped_max = data_max
+        else
+            clamped_max = clamped_min * 2.0_wp
+        end if
         
         ! Calculate log range
         log_min = log10(clamped_min)

--- a/src/utilities/ticks/fortplot_tick_formatting.f90
+++ b/src/utilities/ticks/fortplot_tick_formatting.f90
@@ -13,7 +13,7 @@ module fortplot_tick_formatting
     
     private
     public :: format_tick_value, format_tick_value_smart, format_log_tick_value
-    public :: format_power_of_ten_label
+    public :: format_power_of_ten_label, format_log_mantissa_label
     public :: remove_trailing_zeros, ensure_leading_zero
 
 contains
@@ -173,6 +173,38 @@ contains
         end if
         formatted = adjustl(formatted)
     end function format_power_of_ten_label
+
+    function format_log_mantissa_label(value) result(formatted)
+        !! Build a mathtext label for a sub-decade log tick: m x 10^{p}.
+        !! Mirrors matplotlib's minor log labels, e.g. 2 x 10^0 or 4.2 x 10^1.
+        !! Exact powers of ten are delegated to format_power_of_ten_label.
+        real(wp), intent(in) :: value
+        character(len=30) :: formatted
+        character(len=16) :: mantissa_str
+        real(wp) :: log_val, mantissa
+        integer :: exponent
+
+        if (abs(value) < 1.0e-10_wp) then
+            formatted = '0'
+            return
+        end if
+
+        log_val = log10(abs(value))
+        exponent = floor(log_val + 1.0e-10_wp)
+        mantissa = value/10.0_wp**exponent
+
+        if (abs(mantissa - nint(mantissa)) < 1.0e-6_wp) then
+            write (mantissa_str, '(I0)') nint(mantissa)
+        else
+            write (mantissa_str, '(F0.1)') mantissa
+            call ensure_leading_zero(mantissa_str)
+            call remove_trailing_zeros(mantissa_str)
+        end if
+
+        write (formatted, '(A, I0, A)') &
+            '$'//trim(adjustl(mantissa_str))//'\times10^{', exponent, '}$'
+        formatted = adjustl(formatted)
+    end function format_log_mantissa_label
 
     subroutine remove_trailing_zeros(str)
         !! Remove trailing zeros from decimal representation

--- a/test/scale/test_log_symlog_ticks.f90
+++ b/test/scale/test_log_symlog_ticks.f90
@@ -11,7 +11,9 @@ program test_log_symlog_ticks
     call test_should_include_symlog_threshold_ticks()
     call test_should_maintain_coordinate_bounds()
     call test_should_handle_scientific_ranges()
-    
+    call test_should_emit_subdecade_log_ticks()
+    call test_should_label_subdecade_mantissa()
+
     print *, "All log/symlog tick tests passed!"
     
 contains
@@ -181,6 +183,56 @@ contains
             stop 1
         end if
     end subroutine test_should_maintain_coordinate_bounds
+
+    subroutine test_should_emit_subdecade_log_ticks()
+        !! A sub-decade log range like [42, 50] contains no power of ten, yet
+        !! matplotlib still labels the mantissa subdivisions. The locator must
+        !! emit several ticks here rather than zero (twin-axis log regression).
+        use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
+        real(wp) :: ticks(MAX_TICKS)
+        integer :: num_ticks, i
+
+        call compute_scale_ticks('log', 42.0_wp, 50.0_wp, 1.0_wp, ticks, num_ticks)
+
+        if (num_ticks < 3) then
+            print *, 'FAIL: sub-decade log range [42,50] should yield ticks, got', &
+                num_ticks
+            stop 1
+        end if
+
+        do i = 1, num_ticks
+            if (ticks(i) < 42.0_wp - 1.0e-6_wp .or. ticks(i) > 50.0_wp + 1.0e-6_wp) then
+                print *, 'FAIL: sub-decade log tick outside range:', ticks(i)
+                stop 1
+            end if
+        end do
+    end subroutine test_should_emit_subdecade_log_ticks
+
+    subroutine test_should_label_subdecade_mantissa()
+        !! Sub-decade log ticks render as mantissa x 10^p, matching matplotlib.
+        use fortplot_axes, only: format_tick_label
+        character(len=50) :: label
+
+        label = format_tick_label(42.0_wp, 'log')
+        if (trim(label) /= '$4.2\times10^{1}$') then
+            print *, 'FAIL: 42 on log scale should be $4.2\times10^{1}$, got ', &
+                trim(label)
+            stop 1
+        end if
+
+        label = format_tick_label(2.0_wp, 'log')
+        if (trim(label) /= '$2\times10^{0}$') then
+            print *, 'FAIL: 2 on log scale should be $2\times10^{0}$, got ', trim(label)
+            stop 1
+        end if
+
+        ! Exact powers of ten keep the bare power-of-ten form.
+        label = format_tick_label(10.0_wp, 'log')
+        if (trim(label) /= '$10^{1}$') then
+            print *, 'FAIL: 10 on log scale should be $10^{1}$, got ', trim(label)
+            stop 1
+        end if
+    end subroutine test_should_label_subdecade_mantissa
 
     subroutine test_should_handle_scientific_ranges()
         !! Very large or small ranges should be handled gracefully


### PR DESCRIPTION
## Summary

Fixes the twin-axis log-scale defect cluster surfaced by `twin_axes_demo`. A secondary (twinx) axis with a sub-decade log range rendered with no tick labels and its curve collapsed against one edge; a twiny log axis showed only a single `10^0` tick.

Root causes and fixes:

- `clamp_extreme_log_range` forced the upper edge of every log range to at least twice the minimum (a full octave). For a real sub-decade range such as `[42, 50]` this inflated the view to roughly `[42, 84]`, so the secondary curve mapped into the bottom fraction of the axis and the right-hand labels fell outside the data. The octave floor is now only applied when the range is degenerate (`max <= min`); genuine sub-decade ranges are preserved.
- `compute_log_ticks` emitted only exact powers of ten, so a range with no power of ten in view produced zero ticks. It now mirrors matplotlib's `LogLocator`: decade powers when at least one is visible, otherwise promoted mantissa subdivisions (integer mantissas `{1..9}`, then tenth-mantissa steps), restricted to the visible decade so the partial decade below the lowest visible power is not over-labeled.
- Sub-decade log ticks are formatted as `m x 10^p` (e.g. `4.2 x 10^1`, `2 x 10^0`) via a new `format_log_mantissa_label`, while exact powers keep the `10^p` form.
- The mathtext parser now understands `\times`, emitting U+00D7 so the multiplication glyph renders in the raster and PDF backends.

## Verification

Commands run (from the package root):

- `fpm build` - succeeds.
- `fpm run --example twin_axes_demo` - regenerates the PNG/PDF/TXT.
- `make verify-artifacts` - ends with `Artifact verification passed.` (quiver scale assertion preserved: `scaled 0.0659 < unscaled 0.1318`).
- `make test-ci` - ends with `CI essential test suite completed successfully` (exit 0).
- `fpm test --target test_log_symlog_ticks` - passes, including the two new sub-decade cases.
- `fpm test --target test_twin_axes_data_ranges` and `--target test_range_clamping` - pass.

Before vs after (`output/example/fortran/twin_axes_demo/`):

- Right y-axis (twinx, log): before, no tick labels at all and the orange secondary curve was pinned to the lower third of the frame. After, the axis is labeled `4.2 x 10^1, 4.3 x 10^1, ... , 5 x 10^1` and the curve spans the full height, matching the reference.
- Top x-axis (twiny, log): before, a single `10^0` label. After, `10^0, 2 x 10^0, 3 x 10^0, 4 x 10^0, 5 x 10^0`, matching the reference label sequence.

`pdftotext -layout twin_axes_demo.pdf` after the fix shows the same labels in both backends:

```
Cumulative index (log scale)
10^0   2x10^0   3x10^0   4x10^0  5x10^0
...
5x10^1
4.8x10^1
4.6x10^1
4.4x10^1
4.2x10^1
```

(Glyphs above transcribed; the artifact carries the U+00D7 multiplication sign and superscript exponents.)