### PR TITLE
fix: correct dotted and dash-dot spacing in raster backend

### DIFF
--- a/src/backends/raster/fortplot_raster_line_styles.f90
+++ b/src/backends/raster/fortplot_raster_line_styles.f90
@@ -2,7 +2,7 @@ module fortplot_raster_line_styles
     !! Module for handling line styling in raster images
     use iso_c_binding
     use fortplot_raster_drawing, only: draw_line_distance_aa
-    use fortplot_line_styles, only: get_line_pattern, get_pattern_length, should_draw_at_distance
+    use fortplot_line_styles, only: get_line_pattern, get_pattern_length
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
@@ -34,24 +34,25 @@ contains
         real(wp), intent(in) :: pattern_length
         real(wp), intent(inout) :: pattern_distance
         
-        real(wp) :: dx, dy, line_length, segment_length
-        real(wp) :: unit_x, unit_y, current_x, current_y, next_x, next_y
-        real(wp) :: segment_distance, batch_start_x, batch_start_y
-        integer :: num_segments, i
-        logical :: is_drawing, want_draw
-        
+        real(wp) :: dx, dy, line_length
+        real(wp) :: unit_x, unit_y
+        real(wp) :: pos, phase, seg_end, draw_start, draw_end
+        real(wp) :: cap_inset, sx, sy, ex, ey
+        integer :: phase_index
+        logical :: in_draw
+
         ! Calculate line geometry
         dx = px2 - px1
         dy = py2 - py1
         line_length = sqrt(dx * dx + dy * dy)
-        
+
         ! Handle degenerate case
         if (line_length < 1e-6_wp) return
-        
+
         ! Unit direction vector
         unit_x = dx / line_length
         unit_y = dy / line_length
-        
+
         ! For solid lines, draw the whole line at once
         if (trim(line_style) == '-' .or. trim(line_style) == 'solid') then
             call draw_line_distance_aa(image_data, img_w, img_h, &
@@ -59,59 +60,96 @@ contains
                                       r, g, b, line_width)
             return
         end if
-        
-       ! For patterned lines, break into small segments for pattern resolution,
-        ! then batch consecutive draw segments into single line draws to avoid
-        ! per-segment antialiasing artifacts that make dashes look like dots.
-        segment_length = 0.5_wp
-        num_segments = max(1, int(line_length / segment_length))
-        segment_length = line_length / real(num_segments, wp)
-        
-        current_x = px1
-        current_y = py1
-        is_drawing = .false.
-        batch_start_x = px1
-        batch_start_y = py1
-        
-        do i = 1, num_segments
-            if (i == num_segments) then
-                next_x = px2
-                next_y = py2
-            else
-                next_x = current_x + segment_length * unit_x
-                next_y = current_y + unit_y * segment_length
-            end if
-            
-            want_draw = should_draw_at_distance(pattern_distance, line_pattern, &
-                                               pattern_size, pattern_length)
-            
-            if (want_draw .and. .not. is_drawing) then
-                batch_start_x = current_x
-                batch_start_y = current_y
-                is_drawing = .true.
-            else if (.not. want_draw .and. is_drawing) then
-                call draw_line_distance_aa(image_data, img_w, img_h, &
-                                          batch_start_x, batch_start_y, &
-                                          current_x, current_y, &
-                                          r, g, b, line_width)
-                is_drawing = .false.
-            end if
-            
-            segment_distance = sqrt((next_x - current_x)**2 + (next_y - current_y)**2)
-            pattern_distance = pattern_distance + segment_distance * PATTERN_SCALE_FACTOR
-            
-            current_x = next_x
-            current_y = next_y
-        end do
-        
-        if (is_drawing) then
+
+        ! Degenerate pattern -> draw solid to avoid an invisible line.
+        if (pattern_size <= 0 .or. pattern_length <= 0.0_wp) then
             call draw_line_distance_aa(image_data, img_w, img_h, &
-                                      batch_start_x, batch_start_y, &
-                                      px2, py2, &
+                                      px1, py1, px2, py2, &
                                       r, g, b, line_width)
+            pattern_distance = pattern_distance + line_length * PATTERN_SCALE_FACTOR
+            return
         end if
-        
+
+        ! Walk the dash pattern in exact device units (no per-pixel
+        ! quantization). For each "on" interval, draw the precise sub-segment.
+        ! The distance-AA primitive adds a rounded cap of ~half the line width
+        ! beyond each endpoint; inset every drawn interval by that amount so
+        ! short dots stay round and dashes keep matplotlib-like gaps instead of
+        ! bleeding into the off intervals.
+        cap_inset = line_width * 0.5_wp
+        pos = 0.0_wp
+        do while (pos < line_length - 1e-9_wp)
+            ! Locate the current phase for the global pattern distance at pos.
+            call locate_phase(pattern_distance + pos * PATTERN_SCALE_FACTOR, &
+                              line_pattern, pattern_size, pattern_length, &
+                              phase_index, phase)
+            in_draw = (mod(phase_index, 2) == 1)
+
+            ! Distance (device units) to the end of this phase along the line.
+            seg_end = pos + (line_pattern(phase_index) - phase) / PATTERN_SCALE_FACTOR
+            if (seg_end > line_length) seg_end = line_length
+            if (seg_end <= pos) seg_end = pos + 1e-6_wp
+
+            if (in_draw) then
+                draw_start = pos
+                draw_end = seg_end
+                ! Inset for round-cap compensation, but never invert the
+                ! interval; very short "on" phases collapse to a single dot.
+                if (draw_end - draw_start > 2.0_wp * cap_inset) then
+                    draw_start = draw_start + cap_inset
+                    draw_end = draw_end - cap_inset
+                else
+                    draw_start = 0.5_wp * (pos + seg_end)
+                    draw_end = draw_start
+                end if
+                sx = px1 + draw_start * unit_x
+                sy = py1 + draw_start * unit_y
+                ex = px1 + draw_end * unit_x
+                ey = py1 + draw_end * unit_y
+                call draw_line_distance_aa(image_data, img_w, img_h, &
+                                          sx, sy, ex, ey, &
+                                          r, g, b, line_width)
+            end if
+
+            pos = seg_end
+        end do
+
+        pattern_distance = pattern_distance + line_length * PATTERN_SCALE_FACTOR
+
     end subroutine draw_styled_line
+
+    subroutine locate_phase(distance, pattern, pattern_size, pattern_length, &
+                            phase_index, offset_in_phase)
+        !! Map a cumulative pattern distance to its on/off phase. Returns the
+        !! 1-based phase index (odd = draw, even = gap) and how far into that
+        !! phase the distance falls.
+        real(wp), intent(in) :: distance, pattern_length
+        real(wp), contiguous, intent(in) :: pattern(:)
+        integer, intent(in) :: pattern_size
+        integer, intent(out) :: phase_index
+        real(wp), intent(out) :: offset_in_phase
+
+        real(wp) :: pos_in_cycle, cumulative
+        integer :: i
+
+        pos_in_cycle = mod(distance, pattern_length)
+        if (pos_in_cycle < 0.0_wp) pos_in_cycle = pos_in_cycle + pattern_length
+
+        cumulative = 0.0_wp
+        do i = 1, pattern_size
+            if (pos_in_cycle < cumulative + pattern(i)) then
+                phase_index = i
+                offset_in_phase = pos_in_cycle - cumulative
+                return
+            end if
+            cumulative = cumulative + pattern(i)
+        end do
+
+        ! Numerical edge at the very end of the cycle: report last phase.
+        phase_index = pattern_size
+        offset_in_phase = pattern(pattern_size)
+
+    end subroutine locate_phase
 
     subroutine set_raster_line_style(style, line_style, line_pattern, pattern_size, &
                                     pattern_length, pattern_distance)

--- a/test/line_style/test_dashdot_rendering.f90
+++ b/test/line_style/test_dashdot_rendering.f90
@@ -10,9 +10,67 @@ program test_dashdot_rendering
 
     call test_dashdot_has_gaps()
     call test_dashdot_vs_dotted_different()
+    call test_dotted_has_substantial_gaps()
     print *, "All dash-dot rendering tests passed."
 
 contains
+
+    subroutine test_dotted_has_substantial_gaps()
+        !! Regression for the raster dotted/dash-dot density defect: the pattern
+        !! walker used to merge dots into a near-solid stipple. With matplotlib
+        !! spacing (on 1.0pt, off 1.65pt) a horizontal dotted line must leave a
+        !! substantial fraction of fully undrawn (near-white) pixels between the
+        !! dots. The pre-fix renderer left almost none.
+        type(raster_image_t) :: img
+        integer :: i, idx, dark_pixels, light_pixels
+        integer :: px_val
+        real(wp) :: pat(20), plen, pdist
+
+        img = create_raster_image(400, 50, 100.0_wp)
+        call img%set_line_style(':')
+        img%current_r = 0.0_wp
+        img%current_g = 0.0_wp
+        img%current_b = 0.0_wp
+        img%current_line_width = 1.5_wp
+        pat = img%line_pattern
+        call scale_pattern_to_pixels(pat, img%pattern_size, img%dpi, 1.5_wp)
+        plen = get_pattern_length(pat, img%pattern_size)
+        pdist = 0.0_wp
+        call draw_styled_line(img%image_data, img%width, img%height, &
+                              10.0_wp, 25.0_wp, 390.0_wp, 25.0_wp, &
+                              0.0_wp, 0.0_wp, 0.0_wp, 1.5_wp, &
+                              img%line_style, pat, &
+                              img%pattern_size, plen, pdist)
+
+        dark_pixels = 0
+        light_pixels = 0
+        do i = 10, 390
+            idx = 1 + 24*img%width*3 + (i-1)*3
+            px_val = iand(int(img%image_data(idx), int32), 255_int32)
+            if (px_val < 128_int32) then
+                dark_pixels = dark_pixels + 1
+            else if (px_val > 200_int32) then
+                light_pixels = light_pixels + 1
+            end if
+        end do
+
+        write(*,'(A,I0,A,I0)') 'DEBUG: dotted dark=', dark_pixels, &
+            ' light=', light_pixels
+
+        ! At least a quarter of the line span must be near-white gap. The
+        ! near-solid bug left essentially no light pixels.
+        if (light_pixels < 80) then
+            write(*,'(A,I0)') &
+                'FAIL: dotted line is too dense (gaps not visible); light=', &
+                light_pixels
+            call destroy_raster_image(img)
+            error stop 1
+        end if
+
+        write(*,'(A,I0,A,I0)') 'PASS: dotted has clear gaps; light=', &
+            light_pixels, ' dark=', dark_pixels
+        call destroy_raster_image(img)
+    end subroutine test_dotted_has_substantial_gaps
 
     subroutine test_dashdot_has_gaps()
         !! A horizontal dash-dot line must have white (undrawn) pixels


### PR DESCRIPTION
## Summary

The raster pattern walker rendered dotted and dash-dot lines as a near-solid
stipple. It sampled the dash pattern in fixed 0.5px steps and batched
consecutive on-steps into one antialiased draw. The distance-based AA primitive
adds a rounded cap of about half the line width beyond each endpoint, so the
quantized dashes bled across the gaps and merged.

This walks the pattern in exact device units and draws each on interval as its
precise sub-segment, then insets every interval by half the line width so the
round caps land where butt caps would. Dotted lines now render as separated
round dots and dash-dot shows the matplotlib on/off/dot/off alternation with
visible gaps.

Affected: `styling_demo` (line_styles), `annotation_demo`.

## Verification

Commands:

- `fpm build`
- `fpm run --example styling_demo`
- `fpm run --example annotation_demo`
- `make verify-artifacts` -> `Artifact verification passed.`
- `make test-ci` -> `CI essential test suite completed successfully`
- `fpm test --target test_dashdot_rendering`

Build, test-ci, and verify-artifacts all pass.

Before/after (raster PNG, default 100 dpi, line width 1.5pt):

- `output/example/fortran/styling_demo/line_styles.png`
  - Before: dotted (green) was a thick near-continuous bead, dash-dot (red) was
    nearly solid with no resolvable gaps.
  - After: dotted is a row of separated round dots with clear white gaps;
    dash-dot alternates a long dash, gap, dot, gap, matching the matplotlib
    reference.
- `output/example/fortran/annotation_demo/annotation_demo.png`
  - Before: the dashed (red) and dotted (green) curves read as solid.
  - After: red shows dashes with gaps, green shows separated dots.

Regression test `test_dashdot_rendering` now also asserts that a horizontal
dotted line keeps a substantial fraction of near-white gap pixels along its
span (observed light=108 of 381 sampled pixels; the pre-fix renderer left
essentially none). Existing assertions (dash-dot has gaps; dash-dot differs
from dotted) still pass.