### PR TITLE
fix: align PDF axis ticks with matplotlib defaults

### DIFF
--- a/src/backends/vector/pdf/fortplot_pdf_axes_tick_data.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_tick_data.f90
@@ -33,11 +33,11 @@ contains
         real(wp), allocatable, intent(out) :: x_positions(:), y_positions(:)
         character(len=50), allocatable, intent(out) :: x_labels(:), y_labels(:)
 
-        integer, parameter :: TARGET_TICKS = 8
-
-        ! Determine number of ticks using plot area dimensions
-        num_x_ticks = min(TARGET_TICKS, max(2, int(plot_width/50.0_wp)))
-        num_y_ticks = min(TARGET_TICKS, max(2, int(plot_height/40.0_wp)))
+        ! Size the tick arrays to the shared MAX_TICKS capacity used by the raster
+        ! backend so the PDF backend renders the same nice-number tick set from
+        ! compute_scale_ticks instead of a smaller, subsampled subset.
+        num_x_ticks = MAX_TICKS
+        num_y_ticks = MAX_TICKS
 
         ! Allocate arrays
         allocate (x_positions(num_x_ticks))
@@ -102,7 +102,7 @@ contains
                                        custom_yticks, custom_ytick_labels, &
                                        data_min, data_max, plot_start, &
                                        plot_size, num_ticks, positions, labels, &
-                                       scale_type, symlog_threshold)
+                                       scale_type, symlog_threshold, applied)
         !! Apply custom tick positions/labels, converting data coords to plot area coords
         character, intent(in) :: axis
         real(wp), intent(in), optional :: custom_xticks(:), custom_yticks(:)
@@ -114,6 +114,7 @@ contains
         character(len=50), intent(out) :: labels(:)
         character(len=*), intent(in), optional :: scale_type
         real(wp), intent(in), optional :: symlog_threshold
+        logical, intent(out) :: applied
         character(len=16) :: scale
         real(wp) :: thr
         integer :: used_ticks
@@ -121,6 +122,7 @@ contains
         logical :: use_custom
         real(wp) :: data_min_t, data_max_t
 
+        applied = .false.
         use_custom = .false.
         if (axis == 'x') then
             if (present(custom_xticks) .and. present(custom_xtick_labels) .and. &
@@ -168,6 +170,7 @@ contains
             labels(i) = ''
         end do
         num_ticks = used_ticks
+        applied = .true.
     end subroutine apply_custom_axis_ticks
 
     subroutine resolve_pdf_tick_view(scale, data_min, data_max, view_min, view_max, &
@@ -214,23 +217,28 @@ contains
         character(len=16) :: scale
         real(wp) :: thr, lo, hi
         integer :: used_ticks
-
-        call apply_custom_axis_ticks(axis, custom_xticks, custom_xtick_labels, &
-                                     custom_yticks, custom_ytick_labels, &
-                                     data_min, data_max, plot_start, plot_size, &
-                                     num_ticks, positions, labels, scale_type, &
-                                     symlog_threshold)
-        if (num_ticks == 0) return
+        logical :: custom_applied
 
         scale = 'linear'
         if (present(scale_type)) scale = scale_type
         thr = 1.0_wp
         if (present(symlog_threshold)) thr = symlog_threshold
 
-        ! Generate and position ticks over the rendered view (linear axes);
-        ! the nice step still comes from the raw data range.
+        ! Position ticks over the rendered view (linear axes) so custom and
+        ! computed ticks align with the plotted data inside the autoscale margin.
         call resolve_pdf_tick_view(scale, data_min, data_max, view_min, view_max, &
                                    lo, hi)
+
+        ! Custom ticks/labels take precedence over computed ticks. When present,
+        ! render them as-is (matching the raster backend) and stop.
+        call apply_custom_axis_ticks(axis, custom_xticks, custom_xtick_labels, &
+                                     custom_yticks, custom_ytick_labels, &
+                                     lo, hi, plot_start, plot_size, &
+                                     num_ticks, positions, labels, scale_type, &
+                                     symlog_threshold, custom_applied)
+        if (custom_applied) return
+        if (num_ticks == 0) return
+
         call compute_scale_ticks(scale, lo, hi, thr, tvals, nt, &
                                  step_min=data_min, step_max=data_max)
         if (nt <= 0) then
@@ -251,8 +259,9 @@ contains
             return
         end if
 
-        ! Subsample ticks when more are generated than can be drawn,
-        ! ensuring the first and last ticks always span the full data range.
+        ! Subsample only if the nice-number tick set exceeds the array capacity,
+        ! keeping the first and last ticks spanning the full range. Normally the
+        ! full set fits (matching the raster backend), so no subsampling occurs.
         if (nt > used_ticks) then
             call subsample_ticks(tvals, nt, used_ticks, scale, thr)
             nt = used_ticks
@@ -260,9 +269,9 @@ contains
 
         call fill_tick_positions_and_labels(tvals, nt, lo, hi, plot_start, &
                                             plot_size, &
-                                            used_ticks, positions, labels, scale, thr, &
+                                            nt, positions, labels, scale, thr, &
                                             date_format)
-        num_ticks = used_ticks
+        num_ticks = nt
     end subroutine generate_axis_ticks_internal
 
     subroutine subsample_ticks(tvals, nt, max_ticks, scale, threshold)

--- a/test/backends/vector/pdf_graphics/test_pdf_contour_axis_range.f90
+++ b/test/backends/vector/pdf_graphics/test_pdf_contour_axis_range.f90
@@ -10,6 +10,8 @@ program test_pdf_contour_axis_range
 
     call test_contour_axis_spans_full_range()
     call test_tick_data_spans_range()
+    call test_tick_data_includes_zero_and_intermediate()
+    call test_tick_data_uses_custom_labels()
 
     print *, 'All PDF contour axis range tests PASSED!'
 
@@ -115,5 +117,100 @@ contains
 
         print *, '  PASS: test_tick_data_spans_range'
     end subroutine test_tick_data_spans_range
+
+    subroutine test_tick_data_includes_zero_and_intermediate()
+        !! PDF ticks must match the nice-number set used by the raster backend:
+        !! the central 0.0 label and every intermediate label are present, not a
+        !! subsampled subset. Regression for the dropped-0.0 cluster.
+        use fortplot_pdf_core, only: pdf_context_core, create_pdf_canvas_core
+        use fortplot_pdf_axes, only: generate_tick_data
+        implicit none
+
+        type(pdf_context_core) :: ctx
+        real(wp), allocatable :: x_pos(:), y_pos(:)
+        character(len=50), allocatable :: xl(:), yl(:)
+        integer :: nx, ny, i
+        logical :: has_zero, has_two
+
+        ctx = create_pdf_canvas_core(640.0_wp, 480.0_wp)
+        call generate_tick_data( &
+            ctx, -2.0_wp, 2.0_wp, -2.0_wp, 2.0_wp, x_pos, y_pos, xl, yl, nx, ny, &
+            xscale='linear', yscale='linear', plot_area_left=100.0_wp, &
+            plot_area_bottom=80.0_wp, plot_area_width=357.0_wp, &
+            plot_area_height=260.0_wp)
+
+        has_zero = .false.
+        has_two = .false.
+        do i = 1, nx
+            if (trim(adjustl(xl(i))) == '0' .or. trim(adjustl(xl(i))) == '0.0') &
+                has_zero = .true.
+            if (trim(adjustl(xl(i))) == '2' .or. trim(adjustl(xl(i))) == '2.0') &
+                has_two = .true.
+        end do
+
+        if (.not. has_zero) then
+            print *, 'FAIL: PDF x ticks drop the central 0 label; nx=', nx
+            do i = 1, nx
+                print *, '    label: ', trim(xl(i))
+            end do
+            error stop 1
+        end if
+        if (.not. has_two) then
+            print *, 'FAIL: PDF x ticks drop the 2 label'
+            error stop 1
+        end if
+        if (nx < 5) then
+            print *, 'FAIL: PDF x ticks subsampled to fewer than the nice set; nx=', nx
+            error stop 1
+        end if
+        print *, '  PASS: test_tick_data_includes_zero_and_intermediate'
+    end subroutine test_tick_data_includes_zero_and_intermediate
+
+    subroutine test_tick_data_uses_custom_labels()
+        !! Custom categorical tick labels must be rendered verbatim by the PDF
+        !! backend instead of computed numeric labels. Regression for the
+        !! ignored-custom-labels cluster.
+        use fortplot_pdf_core, only: pdf_context_core, create_pdf_canvas_core
+        use fortplot_pdf_axes, only: generate_tick_data
+        implicit none
+
+        type(pdf_context_core) :: ctx
+        real(wp), allocatable :: x_pos(:), y_pos(:)
+        character(len=50), allocatable :: xl(:), yl(:)
+        integer :: nx, ny, i
+        real(wp) :: cx(4)
+        character(len=2) :: clabels(4)
+        logical :: found_q1, found_q4
+
+        cx = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        clabels = ['Q1', 'Q2', 'Q3', 'Q4']
+
+        ctx = create_pdf_canvas_core(640.0_wp, 480.0_wp)
+        call generate_tick_data( &
+            ctx, 0.8_wp, 4.2_wp, 0.0_wp, 7.0_wp, x_pos, y_pos, xl, yl, nx, ny, &
+            xscale='linear', yscale='linear', plot_area_left=100.0_wp, &
+            plot_area_bottom=80.0_wp, plot_area_width=357.0_wp, &
+            plot_area_height=260.0_wp, &
+            custom_xticks=cx, custom_xtick_labels=clabels)
+
+        if (nx /= 4) then
+            print *, 'FAIL: PDF custom x tick count wrong; nx=', nx
+            error stop 1
+        end if
+        found_q1 = .false.
+        found_q4 = .false.
+        do i = 1, nx
+            if (trim(adjustl(xl(i))) == 'Q1') found_q1 = .true.
+            if (trim(adjustl(xl(i))) == 'Q4') found_q4 = .true.
+        end do
+        if (.not. found_q1 .or. .not. found_q4) then
+            print *, 'FAIL: PDF ignores custom categorical tick labels'
+            do i = 1, nx
+                print *, '    label: ', trim(xl(i))
+            end do
+            error stop 1
+        end if
+        print *, '  PASS: test_tick_data_uses_custom_labels'
+    end subroutine test_tick_data_uses_custom_labels
 
 end program test_pdf_contour_axis_range


### PR DESCRIPTION
## Summary

The PDF backend computed its own irregular tick set: it capped tick count by plot width and subsampled, ignored custom categorical labels, and dropped the central 0.0 plus intermediate labels. This diverged from both matplotlib's default style and the raster (PNG) backend, which renders the full nice-number set from the shared tick computation.

This change makes the PDF backend size its tick arrays to the shared MAX_TICKS capacity (matching the raster backend), so it renders the same `compute_scale_ticks` nice-number set without subsampling. Custom tick labels (set_xticks) are now honored verbatim and positioned over the rendered view range so they align with the plotted data.

Affected examples: bar_chart_demo, quiver_demo, subplot_demo.

## Parity defects fixed

- PDF dropped the central 0.0 on both axes.
- PDF dropped intermediate tick labels.
- PDF produced irregular tick positions/counts vs the raster backend.
- PDF showed numeric ticks instead of custom categorical labels.

## Verification

Commands:
- `fpm build`
- `fpm run --example bar_chart_demo` / `quiver_demo` / `subplot_demo`
- `make verify-artifacts` -> ends with "Artifact verification passed."
- `make test-ci` -> "CI essential test suite completed successfully" (build + tests + artifact gate all pass)
- `fpm test --target test_pdf_contour_axis_range` -> all PASS

Before/after evidence (pdftotext of the regenerated PDFs vs matplotlib reference):

bar_chart_demo/stateful_grouped.pdf
- before x axis: `1   2   3   5` (numeric, irregular, missing 4, no custom labels); y axis missing 2 and 5
- after  x axis: `Q1  Q2  Q3  Q4` (custom labels aligned under bar groups); y axis `0 1 2 3 4 5 6 7`
- matches matplotlib reference (Q1..Q4, y 0..7)

bar_chart_demo/categorical_labels.pdf
- before x axis: `1  2  3  4  5`; y axis missing 0 and 30
- after  x axis: `Apples Oranges Bananas Grapes Mangoes`; y axis `0 10 20 30 40 50 60`

quiver_demo/quiver_demo.pdf
- before x axis missing `0.0`; y axis missing `0.0`
- after  x axis `-2.0 -1.5 -1.0 -0.5 0.0 0.5 1.0 1.5 2.0`; y axis full set including `0.0`
- matches the raster output and the matplotlib reference

subplot_demo/subplot_2x2_demo.pdf
- before x axis: `0 4 6 10` (missing 2 and 8); y axis `1 -1` (missing 0.0 and intermediates)
- after  x axis `0 2 4 6 8 10`; y axis full set including `0.00`

The quiver rendering gate (scale=0.5 produces ~half-length shafts, shaft length varies with magnitude) still passes: `mean shaft length unscaled=0.1318 scaled=0.0659`.

## New tests

`test/backends/vector/pdf_graphics/test_pdf_contour_axis_range.f90`:
- `test_tick_data_includes_zero_and_intermediate` asserts the PDF x ticks include the central 0 and the 2 label and are not subsampled below the nice set.
- `test_tick_data_uses_custom_labels` asserts custom categorical labels (Q1..Q4) are rendered verbatim with the correct count.