### PR TITLE
fix: restore continuous streamplot trajectory coverage

### DIFF
--- a/src/plotting/fortplot_streamplot_matplotlib.f90
+++ b/src/plotting/fortplot_streamplot_matplotlib.f90
@@ -105,8 +105,9 @@ contains
                                                 trajectory_y, &
                                                 n_points, success)
 
-                ! Add trajectory if successful (matplotlib line 156-157)
-                if (success .and. n_points > 5) then  ! Deviation: require >= 6 points
+                ! Accept on matplotlib's arc-length minlength test (applied in
+                ! the integrator); keep only the >= 2 points a polyline needs.
+                if (success .and. n_points >= 2) then
                     n_trajectories = n_trajectories + 1
 
                     ! Store trajectory

--- a/test/plot_types/vector/test_streamplot.f90
+++ b/test/plot_types/vector/test_streamplot.f90
@@ -179,12 +179,17 @@ contains
     end subroutine test_streamplot_max_time_parameter
 
     subroutine test_streamplot_rtol_parameter()
-        !! When arrowsize=0, rtol controls trajectory point count.
+        !! When arrowsize=0, rtol controls per-trajectory sampling density.
+        !! Trajectory acceptance follows matplotlib's arc-length minlength, so
+        !! the count of accepted trajectories is governed by mask collisions,
+        !! not rtol. The genuine rtol effect is finer per-trajectory sampling:
+        !! a stricter rtol takes smaller steps and yields more points per
+        !! streamline. Assert on points-per-trajectory, not the raw figure
+        !! total (which the number of accepted trajectories confounds).
         type(figure_t) :: fig
         real(dp), dimension(3) :: x, y
         real(dp), dimension(3, 3) :: u, v
-        integer :: plot_idx
-        integer :: total_points_strict, total_points_lenient
+        real(dp) :: density_strict, density_lenient
 
         call setup_test_grid_3x3(x, y, u, v)
 
@@ -195,15 +200,7 @@ contains
             print *, "ERROR: Expected strict rtol streamplot to generate plots"
             stop 1
         end if
-
-        total_points_strict = 0
-        do plot_idx = 1, fig%plot_count
-            if (.not. allocated(fig%plots(plot_idx)%x)) then
-                print *, "ERROR: Expected streamline x data to be allocated"
-                stop 1
-            end if
-            total_points_strict = total_points_strict + size(fig%plots(plot_idx)%x)
-        end do
+        density_strict = mean_points_per_trajectory(fig)
 
         call fig%initialize(800, 600)
         call fig%streamplot(x, y, u, v, rtol=1.0e-3_dp, max_time=0.5_dp, &
@@ -212,21 +209,30 @@ contains
             print *, "ERROR: Expected lenient rtol streamplot to generate plots"
             stop 1
         end if
+        density_lenient = mean_points_per_trajectory(fig)
 
-        total_points_lenient = 0
+        if (density_strict <= density_lenient) then
+            print *, "ERROR: Expected smaller rtol to increase per-streamline points"
+            stop 1
+        end if
+    end subroutine test_streamplot_rtol_parameter
+
+    function mean_points_per_trajectory(fig) result(mean_points)
+        !! Average number of points across accepted streamlines.
+        type(figure_t), intent(in) :: fig
+        real(dp) :: mean_points
+        integer :: plot_idx, total_points
+
+        total_points = 0
         do plot_idx = 1, fig%plot_count
             if (.not. allocated(fig%plots(plot_idx)%x)) then
                 print *, "ERROR: Expected streamline x data to be allocated"
                 stop 1
             end if
-            total_points_lenient = total_points_lenient + size(fig%plots(plot_idx)%x)
+            total_points = total_points + size(fig%plots(plot_idx)%x)
         end do
-
-        if (total_points_strict <= total_points_lenient) then
-            print *, "ERROR: Expected smaller rtol to increase integration points"
-            stop 1
-        end if
-    end subroutine test_streamplot_rtol_parameter
+        mean_points = real(total_points, dp) / real(fig%plot_count, dp)
+    end function mean_points_per_trajectory
 
     subroutine test_streamplot_grid_validation()
         type(figure_t) :: fig


### PR DESCRIPTION
## Summary

Streamplot dropped valid short streamlines near the domain boundary, leaving
the vector field sparsely covered and short of the frame compared to
matplotlib's default. Acceptance used an extra `n_points > 5` point-count
filter layered on top of the arc-length test. matplotlib accepts a trajectory
purely on its arc length exceeding `minlength` (already implemented inside the
integrator). This change removes the redundant point-count filter and keeps
only the structural minimum of 2 points required to form a polyline.

Affected example: `streamplot_demo` (`streamplot_demo.png`, `streamplot_arrows.png`).

## Verification

Commands run:
- `fpm build` — succeeds
- `fpm run --example streamplot_demo` — regenerates both PNGs/PDFs
- `make verify-artifacts` — ends with "Artifact verification passed."
  (quiver geometry gate preserved: scaled shaft 0.0659 < unscaled 0.1318)
- `make test-ci` — completes successfully

Before vs after, 20x20 circular-flow grid (`u=-y, v=x`, density=1.0):
- Accepted trajectories: 50 (before) -> 61 (after). matplotlib default: 62.
- Before: concentric streamlines were sparse, with visible gaps toward the
  top/bottom of the frame and fewer arrows than the reference.
- After: full-frame concentric coverage; one arrow per streamline at the
  midpoint, matching matplotlib's regular spacing and counterclockwise flow
  direction.

Axis ranges match the reference exactly (x and y from -2.0 to 2.0, identical
tick labels), confirmed via `pdftotext -layout` on `streamplot_demo.pdf`.

## Test change

`test_streamplot_rtol_parameter` previously asserted that a stricter rtol
yields a larger raw figure-wide point total. That inequality only held because
the old `n_points > 5` filter dropped more short trajectories on the lenient
side. With acceptance now matching matplotlib, the number of accepted
trajectories is governed by mask collisions, not rtol, so the raw total is
confounded. The test now asserts the genuine rtol effect: a stricter rtol
takes smaller steps and produces more points per streamline (mean
points-per-trajectory: strict 6.78 > lenient 6.67).