### PR TITLE
fix: break vector paths at NaN separators

### DIFF
--- a/src/backends/memory/fortplot_line_rendering.f90
+++ b/src/backends/memory/fortplot_line_rendering.f90
@@ -5,6 +5,7 @@ module fortplot_line_rendering
     !! solid lines, patterned lines, and line segments.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use fortplot_context
     use fortplot_scales, only: apply_scale_transform
     use fortplot_utils
@@ -70,8 +71,13 @@ contains
         integer :: i
         
         if (size(x) < 2) return
-        
+
+        ! Break the polyline at NaN/Inf separators (matplotlib semantics).
+        ! Segments with a non-finite endpoint are not drawn, leaving a gap
+        ! and preventing non-finite operands from reaching backend streams.
         do i = 1, size(x) - 1
+            if (.not. (ieee_is_finite(x(i)) .and. ieee_is_finite(y(i)) .and. &
+                       ieee_is_finite(x(i+1)) .and. ieee_is_finite(y(i+1)))) cycle
             call backend%line(x(i), y(i), x(i+1), y(i+1))
         end do
     end subroutine render_solid_line

--- a/src/backends/vector/pdf/fortplot_pdf_markers.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_markers.f90
@@ -30,6 +30,11 @@ contains
         real(wp) :: pdf_x, pdf_y
         real(wp) :: size
 
+        ! Skip markers at non-finite data points (NaN/Inf separators).
+        ! Otherwise normalize_to_pdf_coords yields NaN operands that serialize
+        ! into the content stream and corrupt the PDF (e.g. "NaN ... c").
+        if (.not. (ieee_is_finite(x) .and. ieee_is_finite(y))) return
+
         size = 5.0_wp
         if (present(area)) size = size*marker_size_scale(area)
         call normalize_to_pdf_coords(ctx_handle, x, y, pdf_x, pdf_y)

--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -1,5 +1,6 @@
 module fortplot_spy_backend
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use fortplot_context, only: plot_context
     use fortplot_plot_data, only: plot_data_t
     implicit none
@@ -16,6 +17,7 @@ module fortplot_spy_backend
         integer :: unexpected_calls = 0
         logical :: fill_color_ok = .true.
         logical :: line_color_ok = .true.
+        logical :: saw_nonfinite_line = .false.
     contains
         procedure :: reset => spy_reset
         procedure :: line => spy_line
@@ -64,6 +66,7 @@ contains
         this%unexpected_calls = 0
         this%fill_color_ok = .true.
         this%line_color_ok = .true.
+        this%saw_nonfinite_line = .false.
 
         this%width = 0
         this%height = 0
@@ -83,6 +86,10 @@ contains
         this%line_calls = this%line_calls + 1
         this%line_color_ok = this%line_color_ok .and. &
                              colors_close(this%current_color, this%expected_edge)
+        if (.not. (ieee_is_finite(x1) .and. ieee_is_finite(y1) .and. &
+                   ieee_is_finite(x2) .and. ieee_is_finite(y2))) then
+            this%saw_nonfinite_line = .true.
+        end if
     end subroutine spy_line
 
     subroutine spy_color(this, r, g, b)

--- a/test/regression/test_nan_line_break.f90
+++ b/test/regression/test_nan_line_break.f90
@@ -1,0 +1,42 @@
+program test_nan_line_break
+    !! Regression: polylines must break at NaN/Inf separators instead of
+    !! drawing through them, and no non-finite endpoint may reach a backend.
+    !! Matplotlib treats NaN as a path break. Drawing a segment that touches
+    !! a NaN point corrupts vector backends (e.g. "NaN ... c" in PDF streams).
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+    use fortplot_spy_backend, only: spy_context_t
+    use fortplot_line_rendering, only: render_solid_line
+    implicit none
+
+    type(spy_context_t) :: spy
+    real(wp) :: x(7), y(7), nan
+    logical :: all_passed
+
+    all_passed = .true.
+    nan = ieee_value(nan, ieee_quiet_nan)
+
+    ! Two segments of three points each, separated by one NaN point.
+    ! Finite-finite adjacent pairs: (1,2),(2,3) and (5,6),(6,7) => 4 segments.
+    x = [0.0_wp, 1.0_wp, 2.0_wp, nan, 4.0_wp, 5.0_wp, 6.0_wp]
+    y = [0.0_wp, 1.0_wp, 0.0_wp, nan, 0.0_wp, 1.0_wp, 0.0_wp]
+
+    call spy%reset()
+    call render_solid_line(spy, x, y)
+
+    if (spy%line_calls /= 4) then
+        print *, "FAIL: expected 4 finite segments, got", spy%line_calls
+        all_passed = .false.
+    end if
+
+    if (spy%saw_nonfinite_line) then
+        print *, "FAIL: a non-finite endpoint was forwarded to the backend"
+        all_passed = .false.
+    end if
+
+    if (all_passed) then
+        print *, "PASS: NaN-bounded segments are skipped and never forwarded"
+    else
+        error stop 1
+    end if
+end program test_nan_line_break


### PR DESCRIPTION
## Summary

NaN separators in plot data (used to draw disconnected line segments) leaked into the PDF content stream and corrupted it. The line path guarded NaN per segment, but the marker draw path normalized NaN data coordinates into NaN device coordinates and serialized them as PDF operands.

Matplotlib treats NaN as a path break: segments touching a NaN point are not drawn, and no marker is placed at a NaN point. This change brings fortplot to that default behavior.

### Changes
- `render_solid_line` skips any polyline segment with a non-finite endpoint, breaking the path at NaN/Inf instead of drawing through it. This keeps non-finite operands out of every backend stream.
- The PDF marker path skips markers at non-finite data points, so NaN coordinates no longer reach the Bezier/line operand formatting.
- Added a regression test (`test/regression/test_nan_line_break.f90`) that drives `render_solid_line` through a spy backend and asserts NaN-bounded segments are dropped and no non-finite endpoint is forwarded.

## Verification

Commands run:
- `fpm build` (succeeds)
- `fpm run --example disconnected_lines`
- `make verify-artifacts` -> ends with `Artifact verification passed.`
- `make test-ci` -> `CI essential test suite completed successfully`
- `fpm test --target test_nan_line_break` -> `PASS`

### Before
`pdftotext` on the generated `disconnected_lines.pdf` reported:
```
Syntax Error (1115): Unknown operator 'NaN'
Syntax Error (1118): Too few (0) args to 'c' operator
```
The decompressed content stream contained a marker drawn at the NaN separator point:
```
.000 .000 m
NaN NaN NaN NaN NaN NaN c
NaN NaN NaN NaN NaN NaN c
NaN NaN NaN NaN NaN NaN c
NaN NaN NaN NaN NaN NaN c
h
B
```
NaN operand tokens in the content streams: many.

### After
`pdftotext` runs with no syntax errors. NaN operand tokens in the decompressed content streams: 0. All text labels extract cleanly (`Disconnected Line Segments Example`, `Disconnected segments`, `Single point`, `x`, `y`).

Rendering the fixed PDF shows the expected matplotlib-parity layout: two disconnected line segments (the line breaks at each NaN separator rather than crossing through the origin), circle markers on every real data point, the isolated circle marker at x=7, and the red square at x=8. No spurious marker at the origin. The PNG backend was already correct and is unchanged visually.