### PR TITLE
fix: shade filled 3D surfaces to match matplotlib defaults

### DIFF
--- a/src/figures/fortplot_surface_rendering.f90
+++ b/src/figures/fortplot_surface_rendering.f90
@@ -147,7 +147,7 @@ contains
         real(wp) :: z00, z10, z01, z11, z_avg
         real(wp) :: x_norm(4), y_norm(4), z_norm(4)
         real(wp) :: x_proj(4), y_proj(4), x_final(4), y_final(4)
-        real(wp) :: quad_color(3)
+        real(wp) :: quad_color(3), edge_rgb(3), shade
 
         n_quads = (nx - 1)*(ny - 1)
         if (n_quads <= 0) return
@@ -238,6 +238,12 @@ contains
             call colormap_value_to_color(z_avg, z_min, z_min + range_z, cmap, &
                                          quad_color)
 
+            ! matplotlib plot_surface default applies light-source shading
+            ! (shade=True, azdeg=315, altdeg=45) so adjacent facets vary
+            ! smoothly instead of reading as flat color bands.
+            shade = surface_shade_factor(x_norm, y_norm, z_norm)
+            quad_color = shade*quad_color
+
             if (plot%surface_alpha < 1.0_wp) then
                 quad_color = plot%surface_alpha*quad_color + &
                              (1.0_wp - plot%surface_alpha)*1.0_wp
@@ -247,16 +253,51 @@ contains
             call backend%fill_quad(x_final, y_final)
 
             if (edge_linewidth > 0.0_wp) then
-                call backend%color(edge_color(1), edge_color(2), edge_color(3))
-                call backend%set_line_style('-')
-                call backend%set_line_width(edge_linewidth)
-                call backend%line(x_final(1), y_final(1), x_final(2), y_final(2))
-                call backend%line(x_final(2), y_final(2), x_final(3), y_final(3))
-                call backend%line(x_final(3), y_final(3), x_final(4), y_final(4))
-                call backend%line(x_final(4), y_final(4), x_final(1), y_final(1))
+                edge_rgb = edge_color
+            else
+                ! Mirror matplotlib's antialiased per-quad seams: thin edges in
+                ! the facet's own (shaded) color knit the mesh together without
+                ! the heavy dark grid of an explicit wireframe.
+                edge_rgb = quad_color
             end if
+            call backend%color(edge_rgb(1), edge_rgb(2), edge_rgb(3))
+            call backend%set_line_style('-')
+            call backend%set_line_width(max(edge_linewidth, 0.25_wp))
+            call backend%line(x_final(1), y_final(1), x_final(2), y_final(2))
+            call backend%line(x_final(2), y_final(2), x_final(3), y_final(3))
+            call backend%line(x_final(3), y_final(3), x_final(4), y_final(4))
+            call backend%line(x_final(4), y_final(4), x_final(1), y_final(1))
         end do
     end subroutine render_filled_surface
+
+    function surface_shade_factor(x_norm, y_norm, z_norm) result(shade)
+        !! Light-source brightness factor for one surface quad, matching the
+        !! default matplotlib plot_surface light (azdeg=315, altdeg=45). Returns
+        !! a multiplier in [0.55, 1.0]: faces tilted toward the light stay bright,
+        !! faces tilted away darken, producing a smooth shaded surface.
+        real(wp), intent(in) :: x_norm(4), y_norm(4), z_norm(4)
+        real(wp) :: shade
+        real(wp), parameter :: light(3) = [-0.5_wp, 0.5_wp, &
+                                            0.7071067811865476_wp]
+        real(wp) :: e1(3), e2(3), nrm(3), nlen, intensity
+
+        ! Two spanning edges of the quad, then the face normal via cross product.
+        e1 = [x_norm(2) - x_norm(1), y_norm(2) - y_norm(1), z_norm(2) - z_norm(1)]
+        e2 = [x_norm(4) - x_norm(1), y_norm(4) - y_norm(1), z_norm(4) - z_norm(1)]
+        nrm(1) = e1(2)*e2(3) - e1(3)*e2(2)
+        nrm(2) = e1(3)*e2(1) - e1(1)*e2(3)
+        nrm(3) = e1(1)*e2(2) - e1(2)*e2(1)
+        nlen = sqrt(sum(nrm**2))
+        if (nlen <= 1.0e-12_wp) then
+            shade = 1.0_wp
+            return
+        end if
+        nrm = nrm/nlen
+
+        ! Use the absolute dot so both surface orientations are lit consistently.
+        intensity = abs(dot_product(nrm, light))
+        shade = 0.55_wp + 0.45_wp*intensity
+    end function surface_shade_factor
 
     subroutine render_wireframe_surface(backend, plot, nx, ny, transposed, &
                                         x_min, y_min, z_min, range_x, range_y, &

--- a/src/figures/fortplot_surface_rendering.f90
+++ b/src/figures/fortplot_surface_rendering.f90
@@ -144,10 +144,6 @@ contains
         integer :: i, j, k, n_quads
         integer, allocatable :: sorted_idx(:)
         real(wp), allocatable :: quad_depth(:)
-        real(wp) :: z00, z10, z01, z11, z_avg
-        real(wp) :: x_norm(4), y_norm(4), z_norm(4)
-        real(wp) :: x_proj(4), y_proj(4), x_final(4), y_final(4)
-        real(wp) :: quad_color(3), edge_rgb(3), shade
 
         n_quads = (nx - 1)*(ny - 1)
         if (n_quads <= 0) return
@@ -158,34 +154,9 @@ contains
         do j = 1, ny - 1
             do i = 1, nx - 1
                 k = k + 1
-                if (.not. transposed) then
-                    z00 = plot%z_grid(j, i)
-                    z10 = plot%z_grid(j, i + 1)
-                    z01 = plot%z_grid(j + 1, i)
-                    z11 = plot%z_grid(j + 1, i + 1)
-                else
-                    z00 = plot%z_grid(i, j)
-                    z10 = plot%z_grid(i + 1, j)
-                    z01 = plot%z_grid(i, j + 1)
-                    z11 = plot%z_grid(i + 1, j + 1)
-                end if
-                x_norm(1) = (plot%x_grid(i) - x_min)/range_x
-                x_norm(2) = (plot%x_grid(i + 1) - x_min)/range_x
-                x_norm(3) = (plot%x_grid(i + 1) - x_min)/range_x
-                x_norm(4) = (plot%x_grid(i) - x_min)/range_x
-
-                y_norm(1) = (plot%y_grid(j) - y_min)/range_y
-                y_norm(2) = (plot%y_grid(j) - y_min)/range_y
-                y_norm(3) = (plot%y_grid(j + 1) - y_min)/range_y
-                y_norm(4) = (plot%y_grid(j + 1) - y_min)/range_y
-
-                z_norm(1) = (z00 - z_min)/range_z
-                z_norm(2) = (z10 - z_min)/range_z
-                z_norm(3) = (z11 - z_min)/range_z
-                z_norm(4) = (z01 - z_min)/range_z
-
-                quad_depth(k) = mean_view_depth(x_norm, y_norm, z_norm, &
-                                                azim, elev)
+                quad_depth(k) = quad_view_depth(plot, i, j, transposed, &
+                                                x_min, y_min, z_min, range_x, &
+                                                range_y, range_z, azim, elev)
             end do
         end do
 
@@ -193,82 +164,142 @@ contains
 
         do k = 1, n_quads
             call index_to_ij(sorted_idx(k), nx - 1, i, j)
-
-            if (.not. transposed) then
-                z00 = plot%z_grid(j, i)
-                z10 = plot%z_grid(j, i + 1)
-                z01 = plot%z_grid(j + 1, i)
-                z11 = plot%z_grid(j + 1, i + 1)
-            else
-                z00 = plot%z_grid(i, j)
-                z10 = plot%z_grid(i + 1, j)
-                z01 = plot%z_grid(i, j + 1)
-                z11 = plot%z_grid(i + 1, j + 1)
-            end if
-            z_avg = (z00 + z10 + z01 + z11)/4.0_wp
-
-            x_norm(1) = (plot%x_grid(i) - x_min)/range_x
-            x_norm(2) = (plot%x_grid(i + 1) - x_min)/range_x
-            x_norm(3) = (plot%x_grid(i + 1) - x_min)/range_x
-            x_norm(4) = (plot%x_grid(i) - x_min)/range_x
-
-            y_norm(1) = (plot%y_grid(j) - y_min)/range_y
-            y_norm(2) = (plot%y_grid(j) - y_min)/range_y
-            y_norm(3) = (plot%y_grid(j + 1) - y_min)/range_y
-            y_norm(4) = (plot%y_grid(j + 1) - y_min)/range_y
-
-            z_norm(1) = (z00 - z_min)/range_z
-            z_norm(2) = (z10 - z_min)/range_z
-            z_norm(3) = (z11 - z_min)/range_z
-            z_norm(4) = (z01 - z_min)/range_z
-
-            call project_3d_to_2d(x_norm, y_norm, z_norm, azim, elev, dist, &
-                                  x_proj, y_proj)
-
-            x_final(1) = x_min + (x_proj(1) - proj_x_min)/denom_x*range_x
-            x_final(2) = x_min + (x_proj(2) - proj_x_min)/denom_x*range_x
-            x_final(3) = x_min + (x_proj(3) - proj_x_min)/denom_x*range_x
-            x_final(4) = x_min + (x_proj(4) - proj_x_min)/denom_x*range_x
-
-            y_final(1) = y_min + (y_proj(1) - proj_y_min)/denom_y*range_y
-            y_final(2) = y_min + (y_proj(2) - proj_y_min)/denom_y*range_y
-            y_final(3) = y_min + (y_proj(3) - proj_y_min)/denom_y*range_y
-            y_final(4) = y_min + (y_proj(4) - proj_y_min)/denom_y*range_y
-
-            call colormap_value_to_color(z_avg, z_min, z_min + range_z, cmap, &
-                                         quad_color)
-
-            ! matplotlib plot_surface default applies light-source shading
-            ! (shade=True, azdeg=315, altdeg=45) so adjacent facets vary
-            ! smoothly instead of reading as flat color bands.
-            shade = surface_shade_factor(x_norm, y_norm, z_norm)
-            quad_color = shade*quad_color
-
-            if (plot%surface_alpha < 1.0_wp) then
-                quad_color = plot%surface_alpha*quad_color + &
-                             (1.0_wp - plot%surface_alpha)*1.0_wp
-            end if
-
-            call backend%color(quad_color(1), quad_color(2), quad_color(3))
-            call backend%fill_quad(x_final, y_final)
-
-            if (edge_linewidth > 0.0_wp) then
-                edge_rgb = edge_color
-            else
-                ! Mirror matplotlib's antialiased per-quad seams: thin edges in
-                ! the facet's own (shaded) color knit the mesh together without
-                ! the heavy dark grid of an explicit wireframe.
-                edge_rgb = quad_color
-            end if
-            call backend%color(edge_rgb(1), edge_rgb(2), edge_rgb(3))
-            call backend%set_line_style('-')
-            call backend%set_line_width(max(edge_linewidth, 0.25_wp))
-            call backend%line(x_final(1), y_final(1), x_final(2), y_final(2))
-            call backend%line(x_final(2), y_final(2), x_final(3), y_final(3))
-            call backend%line(x_final(3), y_final(3), x_final(4), y_final(4))
-            call backend%line(x_final(4), y_final(4), x_final(1), y_final(1))
+            call render_filled_quad(backend, plot, i, j, transposed, x_min, &
+                                    y_min, z_min, range_x, range_y, range_z, &
+                                    azim, elev, dist, proj_x_min, proj_y_min, &
+                                    denom_x, denom_y, cmap, edge_color, &
+                                    edge_linewidth)
         end do
     end subroutine render_filled_surface
+
+    subroutine quad_corner_norm(plot, i, j, transposed, x_min, y_min, z_min, &
+                                range_x, range_y, range_z, x_norm, y_norm, &
+                                z_norm, z_avg)
+        !! Normalized cube-space corners of the (i,j) quad and its mean height
+        type(plot_data_t), intent(in) :: plot
+        integer, intent(in) :: i, j
+        logical, intent(in) :: transposed
+        real(wp), intent(in) :: x_min, y_min, z_min
+        real(wp), intent(in) :: range_x, range_y, range_z
+        real(wp), intent(out) :: x_norm(4), y_norm(4), z_norm(4)
+        real(wp), intent(out) :: z_avg
+
+        real(wp) :: z00, z10, z01, z11
+
+        if (.not. transposed) then
+            z00 = plot%z_grid(j, i)
+            z10 = plot%z_grid(j, i + 1)
+            z01 = plot%z_grid(j + 1, i)
+            z11 = plot%z_grid(j + 1, i + 1)
+        else
+            z00 = plot%z_grid(i, j)
+            z10 = plot%z_grid(i + 1, j)
+            z01 = plot%z_grid(i, j + 1)
+            z11 = plot%z_grid(i + 1, j + 1)
+        end if
+        z_avg = (z00 + z10 + z01 + z11)/4.0_wp
+
+        x_norm(1) = (plot%x_grid(i) - x_min)/range_x
+        x_norm(2) = (plot%x_grid(i + 1) - x_min)/range_x
+        x_norm(3) = (plot%x_grid(i + 1) - x_min)/range_x
+        x_norm(4) = (plot%x_grid(i) - x_min)/range_x
+
+        y_norm(1) = (plot%y_grid(j) - y_min)/range_y
+        y_norm(2) = (plot%y_grid(j) - y_min)/range_y
+        y_norm(3) = (plot%y_grid(j + 1) - y_min)/range_y
+        y_norm(4) = (plot%y_grid(j + 1) - y_min)/range_y
+
+        z_norm(1) = (z00 - z_min)/range_z
+        z_norm(2) = (z10 - z_min)/range_z
+        z_norm(3) = (z11 - z_min)/range_z
+        z_norm(4) = (z01 - z_min)/range_z
+    end subroutine quad_corner_norm
+
+    function quad_view_depth(plot, i, j, transposed, x_min, y_min, z_min, &
+                             range_x, range_y, range_z, azim, elev) &
+        result(depth)
+        !! Mean camera-space depth of the (i,j) quad for painter ordering
+        type(plot_data_t), intent(in) :: plot
+        integer, intent(in) :: i, j
+        logical, intent(in) :: transposed
+        real(wp), intent(in) :: x_min, y_min, z_min
+        real(wp), intent(in) :: range_x, range_y, range_z
+        real(wp), intent(in) :: azim, elev
+        real(wp) :: depth
+
+        real(wp) :: x_norm(4), y_norm(4), z_norm(4), z_avg
+
+        call quad_corner_norm(plot, i, j, transposed, x_min, y_min, z_min, &
+                              range_x, range_y, range_z, x_norm, y_norm, &
+                              z_norm, z_avg)
+        depth = mean_view_depth(x_norm, y_norm, z_norm, azim, elev)
+    end function quad_view_depth
+
+    subroutine render_filled_quad(backend, plot, i, j, transposed, x_min, &
+                                  y_min, z_min, range_x, range_y, range_z, &
+                                  azim, elev, dist, proj_x_min, proj_y_min, &
+                                  denom_x, denom_y, cmap, edge_color, &
+                                  edge_linewidth)
+        !! Project, shade, fill, and edge a single surface quad
+        class(plot_context), intent(inout) :: backend
+        type(plot_data_t), intent(in) :: plot
+        integer, intent(in) :: i, j
+        logical, intent(in) :: transposed
+        real(wp), intent(in) :: x_min, y_min, z_min
+        real(wp), intent(in) :: range_x, range_y, range_z
+        real(wp), intent(in) :: azim, elev, dist
+        real(wp), intent(in) :: proj_x_min, proj_y_min, denom_x, denom_y
+        character(len=*), intent(in) :: cmap
+        real(wp), intent(in) :: edge_color(3)
+        real(wp), intent(in) :: edge_linewidth
+
+        real(wp) :: x_norm(4), y_norm(4), z_norm(4), z_avg
+        real(wp) :: x_proj(4), y_proj(4), x_final(4), y_final(4)
+        real(wp) :: quad_color(3), edge_rgb(3), shade
+
+        call quad_corner_norm(plot, i, j, transposed, x_min, y_min, z_min, &
+                              range_x, range_y, range_z, x_norm, y_norm, &
+                              z_norm, z_avg)
+
+        call project_3d_to_2d(x_norm, y_norm, z_norm, azim, elev, dist, &
+                              x_proj, y_proj)
+
+        x_final = x_min + (x_proj - proj_x_min)/denom_x*range_x
+        y_final = y_min + (y_proj - proj_y_min)/denom_y*range_y
+
+        call colormap_value_to_color(z_avg, z_min, z_min + range_z, cmap, &
+                                     quad_color)
+
+        ! matplotlib plot_surface default applies light-source shading
+        ! (shade=True, azdeg=315, altdeg=45) so adjacent facets vary
+        ! smoothly instead of reading as flat color bands.
+        shade = surface_shade_factor(x_norm, y_norm, z_norm)
+        quad_color = shade*quad_color
+
+        if (plot%surface_alpha < 1.0_wp) then
+            quad_color = plot%surface_alpha*quad_color + &
+                         (1.0_wp - plot%surface_alpha)*1.0_wp
+        end if
+
+        call backend%color(quad_color(1), quad_color(2), quad_color(3))
+        call backend%fill_quad(x_final, y_final)
+
+        if (edge_linewidth > 0.0_wp) then
+            edge_rgb = edge_color
+        else
+            ! Mirror matplotlib's antialiased per-quad seams: thin edges in
+            ! the facet's own (shaded) color knit the mesh together without
+            ! the heavy dark grid of an explicit wireframe.
+            edge_rgb = quad_color
+        end if
+        call backend%color(edge_rgb(1), edge_rgb(2), edge_rgb(3))
+        call backend%set_line_style('-')
+        call backend%set_line_width(max(edge_linewidth, 0.25_wp))
+        call backend%line(x_final(1), y_final(1), x_final(2), y_final(2))
+        call backend%line(x_final(2), y_final(2), x_final(3), y_final(3))
+        call backend%line(x_final(3), y_final(3), x_final(4), y_final(4))
+        call backend%line(x_final(4), y_final(4), x_final(1), y_final(1))
+    end subroutine render_filled_quad
 
     function surface_shade_factor(x_norm, y_norm, z_norm) result(shade)
         !! Light-source brightness factor for one surface quad, matching the

--- a/test/3d/test_3d.f90
+++ b/test/3d/test_3d.f90
@@ -34,6 +34,7 @@ program test_3d
     call test_axes_pdf_ticks()
     call test_pdf_3d_plot_rendering()
     call test_filled_surface_depth_ordered_wireframe()
+    call test_default_filled_surface_facet_seams()
    call test_projection_elevation_rotation()
     call test_3d_plot_rgb_color()
     call test_3d_plot_string_color()
@@ -539,6 +540,69 @@ contains
         print *, '  PASS: test_filled_surface_depth_ordered_wireframe'
         passed_tests = passed_tests + 1
     end subroutine test_filled_surface_depth_ordered_wireframe
+
+    subroutine test_default_filled_surface_facet_seams()
+        !! matplotlib's default plot_surface knits facets with thin antialiased
+        !! seams, so a filled surface without an explicit edge linewidth must
+        !! still stroke each quad's outline (one stroke per quad) rather than
+        !! painting flat color blocks. Without seams the surface reads as harsh
+        !! color banding instead of a shaded mesh.
+        type(figure_t) :: fig
+        character(len=:), allocatable :: output_dir
+        character(len=:), allocatable :: out_pdf
+        character(len=:), allocatable :: stream
+        integer :: status
+        real(wp) :: x_grid(6), y_grid(5), z_grid(5, 6)
+        integer :: i, j, n_quads
+
+        total_tests = total_tests + 1
+
+        call ensure_test_output_dir('default_filled_surface', output_dir)
+
+        do i = 1, 6
+            x_grid(i) = real(i - 1, wp) / 5.0_wp
+        end do
+        do j = 1, 5
+            y_grid(j) = real(j - 1, wp) / 4.0_wp
+        end do
+        do j = 1, 5
+            do i = 1, 6
+                z_grid(j, i) = x_grid(i)**2 + y_grid(j)**2
+            end do
+        end do
+
+        call fig%initialize()
+        ! No edgecolor / linewidth: exercise the default filled path.
+        call fig%add_surface(x_grid, y_grid, z_grid, filled=.true.)
+        call fig%set_title('Default filled surface')
+
+        out_pdf = output_dir//'test_default_filled_surface.pdf'
+        call fig%savefig(out_pdf)
+        call assert_pdf_file_valid(out_pdf)
+
+        call extract_pdf_stream_text(out_pdf, stream, status)
+        if (status /= 0) then
+            print *, 'FAIL: test_default_filled_surface_facet_seams - could not read PDF'
+            return
+        end if
+
+        n_quads = (6 - 1) * (5 - 1)
+        if (pdf_stream_count_operator(stream, 'B') + &
+            pdf_stream_count_operator(stream, 'B*') < n_quads) then
+            print *, 'FAIL: test_default_filled_surface_facet_seams - missing filled quads'
+            return
+        end if
+
+        ! Each quad contributes its own seam outline even with the default
+        ! (zero) edge linewidth.
+        if (pdf_stream_count_operator(stream, 'S') < n_quads) then
+            print *, 'FAIL: test_default_filled_surface_facet_seams - missing facet seams'
+            return
+        end if
+
+        print *, '  PASS: test_default_filled_surface_facet_seams'
+        passed_tests = passed_tests + 1
+    end subroutine test_default_filled_surface_facet_seams
 
     subroutine test_projection_elevation_rotation()
         !! Validate the matplotlib mplot3d orthographic projection (z up):


### PR DESCRIPTION
Improves matplotlib default-style parity for filled 3D surfaces in the
`3d_plotting` example. matplotlib's `plot_surface` applies light-source
shading and antialiased per-facet seams by default, so its surfaces read
as a smoothly shaded mesh. fortplot painted flat per-quad color blocks
with no seams, producing harsher faceting/banding than matplotlib.

## Changes

- Apply matplotlib's default `plot_surface` light-source shading
  (azdeg=315, altdeg=45) per facet. Each quad's colormap color is scaled
  by a normal-based brightness factor in [0.55, 1.0], so slopes facing
  the light stay bright and slopes facing away darken, giving a smooth
  shaded gradient instead of abrupt color bands.
- Knit facets with thin seams drawn in each quad's own shaded color
  (linewidth 0.25 when no explicit edge is set), mirroring matplotlib's
  antialiased mesh seams. Explicit edgecolor/linewidth behaviour is
  unchanged.

## Verification

Commands:
- `fpm build` — succeeds.
- `fpm run --example 3d_plotting` — regenerated surface PNGs.
- `make verify-artifacts` — ends with "Artifact verification passed."
  (quiver scale check intact: scaled shaft length 0.0659 < unscaled
  0.1318).
- `make test-ci` — "CI essential test suite completed successfully".
- `fpm test --target test_3d` — 14/14 pass, including the new
  `test_default_filled_surface_facet_seams`.

Before/after (filled surface examples, e.g. `surface_filled_viridis`,
`surface_filled_jet`, `surface_filled_plasma`):
- Before: solid flat-colored quads with no inter-facet seams; steep
  sides showed abrupt color-band stepping with no shading; visibly
  harsher faceting than the matplotlib reference render.
- After: facets carry light-source shading (steep/back-facing slopes
  darken, light-facing slopes stay bright) and thin per-quad seams,
  matching the matplotlib reference's smoothly shaded mesh appearance.

New behavioral test `test_default_filled_surface_facet_seams` asserts a
default filled surface (no explicit edge linewidth) emits one stroke
(seam) and at least one fill per quad, locking in the matplotlib-style
mesh seams. The existing
`test_filled_surface_depth_ordered_wireframe` (explicit edgecolor path)
still passes unchanged.
