### PR TITLE
fix: align pie chart styling and label distance with matplotlib

### DIFF
--- a/src/backends/memory/fortplot_pie_rendering.f90
+++ b/src/backends/memory/fortplot_pie_rendering.f90
@@ -19,7 +19,7 @@ contains
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
 
-        integer :: slice_count, seg_count, i, j, required_size
+        integer :: slice_count, seg_count, i, j
         real(wp) :: angle_start, angle_end, angle_span, mid_angle
         real(wp) :: step_angle, angle_a, angle_b
         real(wp) :: center_x, center_y, radius, offset_value
@@ -27,10 +27,8 @@ contains
         real(wp) :: x_quad(4), y_quad(4)
         real(wp) :: x_a, y_a, x_b, y_b
         real(wp) :: x_a_t, y_a_t, x_b_t, y_b_t
-        real(wp), allocatable :: edge_x(:), edge_y(:)
         real(wp), parameter :: PI = acos(-1.0_wp)
         real(wp), parameter :: MIN_SEGMENT_ANGLE = 5.0_wp * PI / 180.0_wp
-        real(wp) :: edge_color(3)
 
         slice_count = plot_data%pie_slice_count
         if (slice_count <= 0) return
@@ -39,7 +37,6 @@ contains
         if (.not. allocated(plot_data%pie_colors)) return
 
         radius = plot_data%pie_radius
-        edge_color = [0.1_wp, 0.1_wp, 0.1_wp]
 
         do i = 1, slice_count
             angle_start = plot_data%pie_start(i)
@@ -61,9 +58,6 @@ contains
             center_y_t = apply_scale_transform(center_y, yscale, symlog_threshold)
 
             seg_count = max(8, int(abs(angle_span) / MIN_SEGMENT_ANGLE) + 1)
-            required_size = seg_count + 1
-            call ensure_edge_capacity(edge_x, required_size)
-            call ensure_edge_capacity(edge_y, required_size)
 
             call backend%color(plot_data%pie_colors(1, i), plot_data%pie_colors(2, i), &
                                plot_data%pie_colors(3, i))
@@ -83,9 +77,6 @@ contains
                 x_b_t = apply_scale_transform(x_b, xscale, symlog_threshold)
                 y_b_t = apply_scale_transform(y_b, yscale, symlog_threshold)
 
-                edge_x(j + 1) = x_a_t
-                edge_y(j + 1) = y_a_t
-
                 x_quad(1) = center_x_t
                 y_quad(1) = center_y_t
                 x_quad(2) = x_a_t
@@ -98,39 +89,9 @@ contains
                 call backend%fill_quad(x_quad, y_quad)
             end do
 
-            x_b = center_x + radius * cos(angle_end)
-            y_b = center_y + radius * sin(angle_end)
-            edge_x(seg_count + 1) = apply_scale_transform(x_b, xscale, symlog_threshold)
-            edge_y(seg_count + 1) = apply_scale_transform(y_b, yscale, symlog_threshold)
-
-            ! Draw only the outer arc edge, not the radial lines
-            call backend%color(edge_color(1), edge_color(2), edge_color(3))
-            call backend%set_line_width(1.0_wp)
-            ! Skip radial lines to prevent hairline artifacts in PDF
-            ! Only draw the arc outline
-            do j = 1, seg_count
-                call backend%line(edge_x(j), edge_y(j), edge_x(j + 1), edge_y(j + 1))
-            end do
+            ! matplotlib default pie wedges use edgecolor 'none': fill only,
+            ! no outline stroke around the slices.
         end do
     end subroutine render_pie_plot
-
-    subroutine ensure_edge_capacity(buffer, required)
-        !! Ensure that the working edge buffer has at least the required size
-        real(wp), allocatable, intent(inout) :: buffer(:)
-        integer, intent(in) :: required
-        real(wp), allocatable :: tmp(:)
-
-        if (required <= 0) then
-            if (allocated(buffer)) call move_alloc(buffer, tmp)
-            return
-        end if
-
-        if (.not. allocated(buffer)) then
-            allocate(buffer(required))
-        else if (size(buffer) < required) then
-            allocate(tmp(required))
-            call move_alloc(tmp, buffer)
-        end if
-    end subroutine ensure_edge_capacity
 
 end module fortplot_pie_rendering

--- a/src/figures/plot_types/fortplot_figure_pie.f90
+++ b/src/figures/plot_types/fortplot_figure_pie.f90
@@ -247,7 +247,8 @@ contains
         if (present(startangle)) start_angle_rad = startangle * PI / 180.0_wp
 
         radius = plot%pie_radius
-        label_radius = radius * 0.65_wp
+        ! matplotlib default pctdistance places percentage labels at 0.6 radius
+        label_radius = radius * 0.6_wp
         palette_size = max(1, size(state%colors, 2))
         current_angle = start_angle_rad
 

--- a/test/plot_types/2d/test_pie_chart.f90
+++ b/test/plot_types/2d/test_pie_chart.f90
@@ -83,7 +83,29 @@ contains
         call assert_true(found_north .and. found_east .and. found_west, &
                          'label annotations placed')
 
+        call assert_pctdistance(fig%plots(1))
+
     end subroutine run_pie_data_checks
+
+    subroutine assert_pctdistance(plot)
+        !! Percentage labels sit at matplotlib's default pctdistance = 0.6 radius
+        !! measured from each (possibly exploded) wedge centroid.
+        use fortplot_plot_data, only: plot_data_t
+        type(plot_data_t), intent(in) :: plot
+        integer :: i
+        real(wp) :: mid_angle, off, cx, cy, dist
+
+        do i = 1, plot%pie_slice_count
+            mid_angle = 0.5_wp * (plot%pie_start(i) + plot%pie_end(i))
+            off = plot%pie_offsets(i)
+            cx = plot%pie_center(1) + off * cos(mid_angle)
+            cy = plot%pie_center(2) + off * sin(mid_angle)
+            dist = hypot(plot%pie_label_pos(1, i) - cx, &
+                         plot%pie_label_pos(2, i) - cy)
+            call assert_close(dist, 0.6_wp * plot%pie_radius, 1.0e-9_wp, &
+                              'autopct label at 0.6 radius (pctdistance)')
+        end do
+    end subroutine assert_pctdistance
 
     subroutine run_auto_autopct_checks()
         type(figure_t) :: fig


### PR DESCRIPTION
## Summary

Fixes matplotlib-parity defects in the `pie_chart_demo` example (both the
stateful and object-oriented pie charts).

- Removed the near-black outline drawn around every wedge. matplotlib's
  default pie wedges use `edgecolor='none'`, so slices are filled with no
  stroke. Previously fortplot stroked each arc with an RGB (0.1, 0.1, 0.1)
  line at 1.0pt, producing heavy dark borders absent in matplotlib.
- Moved percentage (autopct) labels from 0.65 radius to 0.6 radius, matching
  matplotlib's default `pctdistance=0.6`.

## Verification

Commands run:

- `fpm build` - succeeds.
- `fpm run --example pie_chart_demo` - regenerates the PNG/PDF/TXT outputs.
- `make verify-artifacts` - ends with "Artifact verification passed."
- `make test-ci` - "CI essential test suite completed successfully".
- `fpm test --target test_pie_chart` - exit 0.
- `fpm test --target test_pie_axis_equal_oo` - exit 0.

Before vs after (PNG, oo_energy and stateful_sales):

- Before: each wedge was outlined with a thick near-black border; the radial
  and arc edges were stroked in dark gray. Percentage labels sat at 0.65
  radius.
- After: wedges are filled with their face color only and no border, matching
  the matplotlib reference. Percentage labels sit at 0.6 radius. Slice angles,
  colors (C0 #1f77b4, C1 #ff7f0e, C2 #2ca02c, C3 #d62728, C4 purple), explode
  offsets, category labels outside the wedges, and the right-side legend are
  unchanged and match matplotlib.

PDF text (oo_energy.pdf) continues to carry the category labels and
percentages (Solar/Wind/Hydro/Storage with 42%/28%/18%/12%), confirmed via
`pdftotext -layout`.

A new behavioral check in `test_pie_chart` asserts each autopct label lies at
0.6 * radius from its wedge centroid, locking in the matplotlib pctdistance.
