### PR TITLE
fix: place raster title snug above top spine

### DIFF
--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -5,7 +5,7 @@ module fortplot_raster_labels
                                   YLABEL_EXTRA_GAP, TITLE_VERTICAL_OFFSET, &
                                   REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
                                    MIN_LABEL_MARGIN_PX, CANVAS_EDGE_PADDING_PX, &
-                                   AXIS_LABEL_PAD_PT
+                                   AXIS_LABEL_PAD_PT, TITLE_PAD_PT
    use fortplot_text_rendering, only: calculate_text_descent, &
                                          calculate_text_width_with_size, &
                                          calculate_text_height_with_size, &
@@ -474,7 +474,10 @@ contains
             title_gap = TITLE_VERTICAL_OFFSET
             title_py = real(max(1, top_xlabel_top - title_gap - title_height), wp)
         else
-            title_py = real(plot_area%bottom - TITLE_VERTICAL_OFFSET, wp)
+            ! Place the title baseline a fixed pad above the top spine so it
+            ! sits snug over the axes box (matplotlib axes.titlepad = 6 pt),
+            ! rather than floating near the figure's top edge.
+            title_py = real(plot_area%bottom, wp) - pt2px(TITLE_PAD_PT, dpi_val)
             title_py = max(1.0_wp, title_py)
         end if
     end subroutine compute_title_position_sized

--- a/src/core/fortplot_constants.f90
+++ b/src/core/fortplot_constants.f90
@@ -86,6 +86,12 @@ module fortplot_constants
     !! spacing above the plot area while maintaining readability.
     integer, parameter, public :: TITLE_VERTICAL_OFFSET = 30
 
+    !! Title pad (points): gap between the top of the axes box (top spine) and
+    !! the title baseline. Matches matplotlib's default axes.titlepad of 6.0 pt.
+    !! Backends scale this to device units by DPI so the title sits snug above
+    !! the spine instead of floating near the figure's top edge.
+    real(wp), parameter, public :: TITLE_PAD_PT = 6.0_wp
+
     ! Tick label padding (pixels) for raster backends.
     ! Axis-to-label-top gap. matplotlib uses tick length (3.5pt) + xtick.major.pad
     ! (3.5pt) = 7pt ~= 10px at the reference 100 DPI; matches the y-axis pads below.

--- a/test/title/test_title_centering_raster.f90
+++ b/test/title/test_title_centering_raster.f90
@@ -1,7 +1,7 @@
 program test_title_centering_raster
     !! Verifies raster title centering over plot area
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_constants, only: TITLE_VERTICAL_OFFSET, REFERENCE_DPI
+    use fortplot_constants, only: TITLE_PAD_PT, REFERENCE_DPI
     use fortplot_text, only: calculate_text_width_with_size, TITLE_FONT_SIZE_PT
     use fortplot_raster_axes, only: compute_title_position
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -29,7 +29,10 @@ program test_title_centering_raster
         measured_width = len_trim(escaped_text) * 12
     end if
     expected_px = plot_area%left + plot_area%width/2 - measured_width/2
-    expected_py = plot_area%bottom - TITLE_VERTICAL_OFFSET
+    ! Title baseline sits a fixed pad above the top spine (matplotlib
+    ! axes.titlepad = 6 pt), scaled to pixels at the reference DPI.
+    expected_py = int(real(plot_area%bottom, wp) - &
+                      TITLE_PAD_PT * REFERENCE_DPI / 72.0_wp)
 
     if (int(title_px_r) /= expected_px) then
         print *, 'FAIL: Title X not centered; got ', int(title_px_r), ' expected ', expected_px


### PR DESCRIPTION
## Summary

Raster axis titles floated near the top edge of the figure with a large gap
above the top spine, instead of sitting snug above the axes box as in
matplotlib's default style.

The title baseline used a fixed 30 px offset above the top spine. matplotlib
places the title with `axes.titlepad = 6.0 pt` above the top spine. This change
positions the title baseline a DPI-scaled 6 pt pad above the spine, centered
over the axes box (not the figure including any colorbar).

## Changes

- Add `TITLE_PAD_PT = 6.0` constant (matplotlib `axes.titlepad`).
- In the non-twiny raster title branch, compute the baseline as
  `top_spine - pt2px(TITLE_PAD_PT, dpi)` instead of a fixed pixel offset.
- Update the raster title centering test to assert the titlepad-based baseline.

## Verification

Commands run:
- `fpm build` (succeeds)
- `fpm run --example basic_plots`, `pcolormesh_demo`, `annotation_demo`
- `make verify-artifacts` -> ends with `Artifact verification passed.`
- `make test-ci` -> ends with `CI essential test suite completed successfully`
- `fpm test --target test_title_centering_raster` -> PASS
- `fpm test --target test_title_position_twiny` -> PASS

Before/after (raster PNG, reference DPI 100):
- Before: title baseline at `top_spine - 30 px`; the title rendered with a wide
  empty band between it and the top spine, visually near the figure's top edge
  (basic_plots/simple_plot.png, multi_line.png, pcolormesh_demo/*.png,
  annotation_demo.png).
- After: title baseline at `top_spine - 8 px` (6 pt at 100 DPI); the title sits
  snug just above the top spine, centered over the axes box, matching the
  matplotlib reference renders for all three examples. The colorbar in
  pcolormesh_demo does not shift the title center (it stays over the axes box).

The quiver scale gate and all other artifact assertions remain green.
