### PR TITLE
fix: keep quiver arrows in-frame with matplotlib-proportioned heads

### DIFF
--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -232,9 +232,10 @@ contains
         norm_dx = ddx/magnitude
         norm_dy = ddy/magnitude
 
-        ! Calculate arrow dimensions based on size
+        ! Calculate arrow dimensions based on size. Slim head aspect
+        ! (full width ~0.7*length) matches matplotlib's head_width/head_length.
         arrow_length = size*8.0_wp  ! Scale factor for reasonable arrow size
-        arrow_width = arrow_length*0.5_wp
+        arrow_width = arrow_length*0.35_wp
 
         ! Calculate perpendicular vector for arrow width
         perp_x = -norm_dy

--- a/src/backends/vector/svg/fortplot_svg_draw.f90
+++ b/src/backends/vector/svg/fortplot_svg_draw.f90
@@ -101,8 +101,8 @@ contains
       px = -ny
       py = nx
 
-      arrow_len = max(4.0_wp, 1.5_wp*size)
-      arrow_w = 0.55_wp*arrow_len
+      arrow_len = max(3.0_wp, 8.0_wp*size)
+      arrow_w = 0.35_wp*arrow_len
       base_x = sx - arrow_len*nx
       base_y = sy - arrow_len*ny
       left_x = base_x + arrow_w*px

--- a/src/figures/rendering/fortplot_figure_plot_renderers.f90
+++ b/src/figures/rendering/fortplot_figure_plot_renderers.f90
@@ -137,11 +137,13 @@ contains
         end do
         if (max_mag < 1.0e-12_wp) max_mag = 1.0_wp
 
-        ! Autoscaled shaft length: matplotlib's default makes the longest
-        ! arrow span a sizeable fraction of the axes. The user-facing scale
-        ! acts as a direct length multiplier (scale=0.5 -> half-length shafts),
-        ! matching this library's example/gate semantics.
-        data_scale = min(x_range, y_range)*0.28_wp*scale/max_mag
+        ! Autoscaled shaft length: matplotlib's default keeps the longest
+        ! arrow close to one grid step so arrows stay inside the axes box.
+        ! The coefficient multiplies the shorter data range; the longest
+        ! arrow then spans coef*range regardless of magnitude. The
+        ! user-facing scale acts as a direct length multiplier (scale=0.5 ->
+        ! half-length shafts), matching this library's example/gate semantics.
+        data_scale = min(x_range, y_range)*0.095_wp*scale/max_mag
 
         ! On-screen pixels per data unit (canvas approximation); used to size
         ! arrow heads proportionally to shaft length, like matplotlib.
@@ -227,12 +229,13 @@ contains
             call backend%set_line_style('-')
 
             ! Size the arrow head proportionally to the on-screen shaft length
-            ! (matplotlib draws longer arrows with larger heads). raster/vector
-            ! backends draw a head of length size*8 pixels, so divide the
-            ! desired head pixel length by 8. Clamp so short shafts keep a
-            ! visible head and long shafts do not overwhelm the shaft.
+            ! with matplotlib-like proportions: a slim head about a third of the
+            ! shaft, clamped so short shafts keep a visible head and long shafts
+            ! do not get overwhelmed by it. raster/vector backends draw a head
+            ! of length size*8 pixels, so divide the desired head pixel length
+            ! by 8.
             shaft_px = mag/max(1.0e-12_wp, data_units_per_px)
-            arrow_size = min(2.5_wp, max(0.5_wp, shaft_px*0.12_wp/8.0_wp))
+            arrow_size = min(16.0_wp, max(4.0_wp, shaft_px*0.33_wp))/8.0_wp
 
             ! Draw the arrow
             call backend%draw_arrow(x_pos, y_pos, u_scaled, v_scaled, &


### PR DESCRIPTION
Reduce the quiver autoscale coefficient and slim the arrowheads so the
default quiver plot matches matplotlib's compact, proportional look.

Before this change the autoscale coefficient (~0.28 over the data range)
produced arrows roughly 2.8 grid cells long that overshot the axes box,
and the heads were rendered as oversized solid triangles (head length up
to ~20 px with a fat 1:1 aspect). After: the coefficient drops to 0.095,
keeping the longest arrow near one grid step so arrows stay inside the
frame, and heads are sized as a slim triangle about a third of the
on-screen shaft length with a matplotlib-style head_width/head_length
aspect.

Shaft length stays magnitude-proportional and the user-facing scale
remains a direct length multiplier (scale=0.5 -> half-length shafts).

## Changes

- `src/figures/rendering/fortplot_figure_plot_renderers.f90`: autoscale
  coefficient 0.28 -> 0.095; head size = clamp(0.33 * shaft_px, 4, 16) px.
- `src/backends/raster/fortplot_raster_impl.f90`: quiver head aspect
  0.5 -> 0.35 (full width ~0.7 of head length).
- `src/backends/vector/svg/fortplot_svg_draw.f90`: quiver head length
  aligned with the raster backend (size*8) and slimmed to the same aspect.

## Verification

Commands run:

- `fo build` -> library links, warnings only.
- `fpm run --example quiver_demo` (single-threaded) -> regenerates PNG/PDF/SVG/TXT.
- `make verify-artifacts` -> `Artifact verification passed.`
- `make test-ci` -> `CI essential test suite completed successfully`.

Rendering gate, quiver assertions (from `make verify-artifacts`):

```
[quiver-geometry] mean shaft length unscaled=30.9860 scaled=15.4929
[ok] quiver shaft geometry: scaled < unscaled (scale-dependent)
```

- Shaft lengths still vary with vector magnitude (gate requires >=2 unique lengths).
- scaled mean (15.49) is exactly half the unscaled mean (30.99), confirming
  scale=0.5 -> half-length is preserved.

PDF axis labels intact (`pdftotext`): `2.0 1.5 1.0 Y 0.5 0.0 -0.5 -1.0 -1.5 -2.0`
and `-2.0 ... X ... 2.0`, including negative labels required by the gate.

Before/after observations:

- Arrows no longer overshoot the axes box; the circular-flow field stays
  inside the frame as in the matplotlib reference.
- Arrowheads are slim and proportional to the shaft instead of large
  solid triangles.
- Interior short-vector arrows shrink toward the field center as expected;
  magnitude-proportional lengths preserved.
