### PR TITLE
fix: restore 2x2 subplot spacing and right-column y-label placement

### DIFF
--- a/src/figures/management/fortplot_subplot_layout.f90
+++ b/src/figures/management/fortplot_subplot_layout.f90
@@ -1,22 +1,34 @@
 module fortplot_subplot_layout
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: subplot_data_t
+    use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
+    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
+                                         format_tick_value_consistent
+    use fortplot_constants, only: TICK_MARK_LENGTH, TITLE_PAD_PT, &
+                                  AXIS_LABEL_PAD_PT, XLABEL_VERTICAL_OFFSET, &
+                                  X_TICK_LABEL_PAD, &
+                                  Y_TICK_LABEL_RIGHT_PAD, YLABEL_EXTRA_GAP
+    use fortplot_text_layout, only: calculate_text_width, calculate_text_height, &
+                                    calculate_text_height_with_size_internal, &
+                                    TITLE_FONT_SIZE
+    use fortplot_latex_parser, only: process_latex_in_text
+    use fortplot_text_helpers, only: prepare_mathtext_if_needed
+    use fortplot_unicode, only: escape_unicode_for_raster
     use fortplot_raster, only: raster_context
+    use fortplot_raster_core, only: pt2px
     use fortplot_pdf, only: pdf_context
+    use fortplot_pdf_text, only: estimate_pdf_text_width
+    use fortplot_pdf_core, only: PDF_TICK_LABEL_SIZE, PDF_LABEL_SIZE, PDF_TITLE_SIZE
     implicit none
 
     private
     public :: compute_tight_subplot_margins
 
-    ! matplotlib default fixed fractional subplot parameters
-    ! (rcParams figure.subplot.*). The axes box spans these fractions of the
-    ! figure and panels are separated by wspace/hspace of the per-axes size.
-    real(wp), parameter :: BASE_LEFT = 0.125_wp
-    real(wp), parameter :: BASE_RIGHT = 0.90_wp
-    real(wp), parameter :: BASE_BOTTOM = 0.11_wp
-    real(wp), parameter :: BASE_TOP = 0.88_wp
-    real(wp), parameter :: WSPACE = 0.20_wp
-    real(wp), parameter :: HSPACE = 0.20_wp
+    ! Minimum fraction of the figure height the panel rows should fill, so short
+    ! figures (e.g. a 1xN strip) do not waste vertical space the way a purely
+    ! decoration-driven layout does. Matches matplotlib's default axes band
+    ! (figure.subplot.top - figure.subplot.bottom).
+    real(wp), parameter :: MIN_AXES_FILL_FRAC = 0.77_wp
 
 contains
 
@@ -24,13 +36,14 @@ contains
                                              xscale, yscale, symlog_threshold, left_f, &
                                              right_f, bottom_f, top_f, &
                                              ok, suptitle_height_frac)
-        !! Compute per-cell subplot margins (fractional figure coordinates) on
-        !! matplotlib's default fixed subplot parameters. The layout depends only
-        !! on the grid shape, not on per-axes decoration sizes, so it reproduces
-        !! pyplot's size-independent default spacing. When a suptitle is present
-        !! the top row is lowered by its band so the figure-level title clears the
-        !! top-row subplot titles. The scale arguments are accepted for interface
-        !! stability but do not influence the box geometry.
+        !! Compute per-cell subplot margins in fractional figure coordinates.
+        !! Margins, inter-column gaps, and inter-row gaps are driven by each
+        !! panel's decoration sizes (tick labels, axis labels, titles) so every
+        !! panel's y-axis label sits to the left of its plot box and the top
+        !! row's x-axis label clears the title of the row below. Short figures
+        !! additionally reclaim excess margin so the panels fill at least
+        !! MIN_AXES_FILL_FRAC of the figure height, matching matplotlib's
+        !! default vertical fill.
         class(*), intent(in) :: backend
         type(subplot_data_t), intent(in) :: subplots_array(:, :)
         integer, intent(in) :: nr, nc
@@ -43,70 +56,444 @@ contains
 
         real(wp) :: sup_frac
 
+        real(wp), allocatable :: dec_left(:, :), dec_right(:, :)
+        real(wp), allocatable :: dec_bottom(:, :), dec_top(:, :)
+
+        integer :: i, j
+        real(wp) :: fig_w, fig_h
+
         ok = .false.
+        sup_frac = 0.0_wp
+        if (present(suptitle_height_frac)) sup_frac = max(0.0_wp, suptitle_height_frac)
 
         if (nr <= 0 .or. nc <= 0) return
         if (size(subplots_array, 1) /= nr) return
         if (size(subplots_array, 2) /= nc) return
 
-        ! Only raster and PDF backends use fractional subplot positioning.
+        allocate (left_f(nr, nc), right_f(nr, nc))
+        allocate (bottom_f(nr, nc), top_f(nr, nc))
+        allocate (dec_left(nr, nc), dec_right(nr, nc))
+        allocate (dec_bottom(nr, nc), dec_top(nr, nc))
+
         select type (bk => backend)
         class is (raster_context)
+            fig_w = real(max(1, bk%width), wp)
+            fig_h = real(max(1, bk%height), wp)
+            do i = 1, nr
+                do j = 1, nc
+                    call estimate_subplot_decorations_raster(subplots_array(i, j), &
+                                                             xscale, yscale, &
+                                                             symlog_threshold, &
+                                                             bk%raster%dpi, &
+                                                             dec_left(i, j), &
+                                                             dec_right(i, j), &
+                                                             dec_bottom(i, j), &
+                                                             dec_top(i, j))
+                end do
+            end do
         class is (pdf_context)
+            fig_w = real(max(1, bk%width), wp)
+            fig_h = real(max(1, bk%height), wp)
+            do i = 1, nr
+                do j = 1, nc
+                    call estimate_subplot_decorations_pdf(subplots_array(i, j), &
+                                                          xscale, yscale, &
+                                                          symlog_threshold, &
+                                                          dec_left(i, j), &
+                                                          dec_right(i, j), &
+                                                          dec_bottom(i, j), &
+                                                          dec_top(i, j))
+                end do
+            end do
         class default
             return
         end select
 
-        sup_frac = 0.0_wp
-        if (present(suptitle_height_frac)) sup_frac = max(0.0_wp, suptitle_height_frac)
-
-        allocate (left_f(nr, nc), right_f(nr, nc))
-        allocate (bottom_f(nr, nc), top_f(nr, nc))
-
-        call solve_default_grid(nr, nc, sup_frac, left_f, right_f, bottom_f, &
-                                top_f, ok)
+        call solve_tight_grid(fig_w, fig_h, dec_left, dec_right, dec_bottom, &
+                              dec_top, left_f, right_f, bottom_f, top_f, ok, sup_frac)
     end subroutine compute_tight_subplot_margins
 
-    subroutine solve_default_grid(nr, nc, sup_frac, left_f, right_f, bottom_f, &
-                                  top_f, ok)
-        !! Place an nr x nc grid on matplotlib's default subplot parameters.
-        integer, intent(in) :: nr, nc
-        real(wp), intent(in) :: sup_frac
+    subroutine solve_tight_grid(fig_w, fig_h, dec_left, dec_right, dec_bottom, &
+                                dec_top, left_f, right_f, bottom_f, top_f, ok, &
+                                suptitle_height_frac)
+        real(wp), intent(in) :: fig_w, fig_h
+        real(wp), contiguous, intent(in) :: dec_left(:, :), dec_right(:, :)
+        real(wp), contiguous, intent(in) :: dec_bottom(:, :), dec_top(:, :)
         real(wp), intent(out) :: left_f(:, :), right_f(:, :)
         real(wp), intent(out) :: bottom_f(:, :), top_f(:, :)
         logical, intent(out) :: ok
+        real(wp), intent(in) :: suptitle_height_frac
 
-        integer :: i, j
-        real(wp) :: grid_top
-        real(wp) :: total_w, total_h
-        real(wp) :: ax_w, ax_h, gap_w, gap_h
-        real(wp) :: sub_left, sub_top
+        integer :: nr, nc, i, j
+        real(wp), allocatable :: gap_x(:), gap_y(:)
+        real(wp) :: margin_l, margin_r, margin_b, margin_t
+        real(wp) :: axes_w, axes_h
+        real(wp) :: avail_w, avail_h
+        real(wp) :: pad
+        real(wp) :: x0, x1, y0, y1
 
+        nr = size(dec_left, 1)
+        nc = size(dec_left, 2)
         ok = .false.
 
-        grid_top = BASE_TOP - sup_frac
-        total_w = BASE_RIGHT - BASE_LEFT
-        total_h = grid_top - BASE_BOTTOM
+        pad = 6.0_wp
 
-        ax_w = total_w/(real(nc, wp) + WSPACE*real(max(0, nc - 1), wp))
-        gap_w = WSPACE*ax_w
-        ax_h = total_h/(real(nr, wp) + HSPACE*real(max(0, nr - 1), wp))
-        gap_h = HSPACE*ax_h
+        allocate (gap_x(max(0, nc - 1)))
+        allocate (gap_y(max(0, nr - 1)))
 
-        if (ax_w <= 0.0_wp .or. ax_h <= 0.0_wp) return
+        call compute_margins_and_gaps(dec_left, dec_right, dec_bottom, dec_top, &
+                                      pad, fig_h, suptitle_height_frac, &
+                                      margin_l, margin_r, margin_b, margin_t, &
+                                      gap_x, gap_y)
+
+        call reclaim_vertical_margin(fig_h, pad, suptitle_height_frac, &
+                                     sum(gap_y), nr, margin_t, margin_b)
+
+        avail_w = fig_w - margin_l - margin_r
+        if (nc > 1) avail_w = avail_w - sum(gap_x)
+        avail_h = fig_h - margin_t - margin_b
+        if (nr > 1) avail_h = avail_h - sum(gap_y)
+
+        if (avail_w <= real(nc, wp) .or. avail_h <= real(nr, wp)) return
+
+        axes_w = avail_w/real(nc, wp)
+        axes_h = avail_h/real(nr, wp)
 
         do i = 1, nr
-            sub_top = grid_top - real(i - 1, wp)*(ax_h + gap_h)
+            y1 = fig_h - margin_t
+            if (i > 1) then
+                y1 = y1 - real(i - 1, wp)*axes_h - sum(gap_y(1:i - 1))
+            end if
+            y0 = y1 - axes_h
             do j = 1, nc
-                sub_left = BASE_LEFT + real(j - 1, wp)*(ax_w + gap_w)
-                left_f(i, j) = sub_left
-                right_f(i, j) = sub_left + ax_w
-                top_f(i, j) = sub_top
-                bottom_f(i, j) = sub_top - ax_h
+                x0 = margin_l
+                if (j > 1) then
+                    x0 = x0 + real(j - 1, wp)*axes_w + sum(gap_x(1:j - 1))
+                end if
+                x1 = x0 + axes_w
+
+                left_f(i, j) = x0/fig_w
+                right_f(i, j) = x1/fig_w
+                bottom_f(i, j) = y0/fig_h
+                top_f(i, j) = y1/fig_h
             end do
         end do
 
         ok = .true.
-    end subroutine solve_default_grid
+    end subroutine solve_tight_grid
+
+    subroutine compute_margins_and_gaps(dec_left, dec_right, dec_bottom, dec_top, &
+                                        pad, fig_h, suptitle_height_frac, &
+                                        margin_l, margin_r, margin_b, margin_t, &
+                                        gap_x, gap_y)
+        !! Outer margins and inter-panel gaps from per-cell decoration sizes.
+        !! Margins reserve room for the outermost decorations plus a uniform pad
+        !! (and a suptitle band on top); each gap reserves room for the adjacent
+        !! decorations facing it, so y-labels stay left of every panel and the
+        !! top row's x-label clears the title of the row below.
+        real(wp), contiguous, intent(in) :: dec_left(:, :), dec_right(:, :)
+        real(wp), contiguous, intent(in) :: dec_bottom(:, :), dec_top(:, :)
+        real(wp), intent(in) :: pad, fig_h, suptitle_height_frac
+        real(wp), intent(out) :: margin_l, margin_r, margin_b, margin_t
+        real(wp), intent(out) :: gap_x(:), gap_y(:)
+
+        integer :: nr, nc, i, j
+
+        nr = size(dec_left, 1)
+        nc = size(dec_left, 2)
+
+        margin_l = pad
+        margin_r = pad
+        margin_b = pad
+        margin_t = pad
+        do i = 1, nr
+            margin_l = max(margin_l, dec_left(i, 1) + pad)
+            margin_r = max(margin_r, dec_right(i, nc) + pad)
+        end do
+        do j = 1, nc
+            margin_b = max(margin_b, dec_bottom(nr, j) + pad)
+            margin_t = max(margin_t, dec_top(1, j) + pad)
+        end do
+        if (suptitle_height_frac > 0.0_wp) then
+            margin_t = margin_t + suptitle_height_frac*fig_h + 2.0_wp*pad
+        end if
+
+        do j = 1, nc - 1
+            gap_x(j) = pad
+            do i = 1, nr
+                gap_x(j) = max(gap_x(j), dec_right(i, j) + dec_left(i, j + 1) + pad)
+            end do
+        end do
+        do i = 1, nr - 1
+            gap_y(i) = pad
+            do j = 1, nc
+                gap_y(i) = max(gap_y(i), dec_bottom(i, j) + dec_top(i + 1, j) + pad)
+            end do
+        end do
+    end subroutine compute_margins_and_gaps
+
+    subroutine reclaim_vertical_margin(fig_h, pad, suptitle_height_frac, &
+                                       gap_y_sum, nr, margin_t, margin_b)
+        !! Shrink excess outer vertical margin so short figures fill the height
+        !! like matplotlib, without clipping decorations off the figure. Only the
+        !! outer-margin padding and the suptitle clearance padding are reclaimed;
+        !! the decoration sizes and inter-row gaps stay as overlap guards.
+        real(wp), intent(in) :: fig_h, pad, suptitle_height_frac, gap_y_sum
+        integer, intent(in) :: nr
+        real(wp), intent(inout) :: margin_t, margin_b
+
+        real(wp) :: target_h, panels_h, slack, factor
+
+        target_h = MIN_AXES_FILL_FRAC*fig_h
+        if (nr > 1) target_h = target_h - gap_y_sum
+        panels_h = fig_h - margin_t - margin_b
+        if (panels_h >= target_h) return
+
+        slack = 2.0_wp*pad
+        if (suptitle_height_frac > 0.0_wp) slack = slack + 2.0_wp*pad
+        if (slack <= 0.0_wp) return
+
+        factor = min(1.0_wp, (target_h - panels_h)/slack)
+        margin_b = margin_b - factor*pad
+        margin_t = margin_t - factor*pad
+        if (suptitle_height_frac > 0.0_wp) margin_t = margin_t - factor*2.0_wp*pad
+    end subroutine reclaim_vertical_margin
+
+    subroutine estimate_subplot_decorations_raster(subplot, xscale, yscale, &
+                                                   symlog_threshold, dpi, dec_left, &
+                                                   dec_right, dec_bottom, dec_top)
+        type(subplot_data_t), intent(in) :: subplot
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(in) :: dpi
+        real(wp), intent(out) :: dec_left, dec_right, dec_bottom, dec_top
+
+        real(wp) :: x_tick_positions(MAX_TICKS), y_tick_positions(MAX_TICKS)
+        integer :: n_x, n_y, i, decimals
+        character(len=50) :: x_labels(MAX_TICKS), y_labels(MAX_TICKS)
+        integer :: max_y_w, max_x_h
+        integer :: xlabel_h, ylabel_h, title_h
+        character(len=:), allocatable :: title, xlabel, ylabel
+
+        max_y_w = 0
+        max_x_h = 0
+
+        call compute_scale_ticks(xscale, subplot%x_min, subplot%x_max, &
+                                 symlog_threshold, x_tick_positions, n_x)
+        call compute_scale_ticks(yscale, subplot%y_min, subplot%y_max, &
+                                 symlog_threshold, y_tick_positions, n_y)
+
+        if (n_x > 0) then
+            decimals = 0
+            if (trim(xscale) == 'linear' .and. n_x >= 2) then
+                decimals = determine_decimals_from_ticks(x_tick_positions, n_x)
+            end if
+            do i = 1, n_x
+                if (trim(xscale) == 'linear') then
+                    x_labels(i) = format_tick_value_consistent(x_tick_positions(i), &
+                                                               decimals)
+                else
+                    x_labels(i) = format_tick_label(x_tick_positions(i), xscale, &
+                                                    data_min=subplot%x_min, &
+                                                    data_max=subplot%x_max)
+                end if
+                max_x_h = max(max_x_h, measure_raster_height(trim(x_labels(i))))
+            end do
+        end if
+
+        if (n_y > 0) then
+            decimals = 0
+            if (trim(yscale) == 'linear' .and. n_y >= 2) then
+                decimals = determine_decimals_from_ticks(y_tick_positions, n_y)
+            end if
+            do i = 1, n_y
+                if (trim(yscale) == 'linear') then
+                    y_labels(i) = format_tick_value_consistent(y_tick_positions(i), &
+                                                               decimals)
+                else
+                    y_labels(i) = format_tick_label(y_tick_positions(i), yscale, &
+                                                    data_min=subplot%y_min, &
+                                                    data_max=subplot%y_max)
+                end if
+                max_y_w = max(max_y_w, measure_raster_width(trim(y_labels(i))))
+            end do
+        end if
+
+        title = ''
+        xlabel = ''
+        ylabel = ''
+        if (allocated(subplot%title)) title = subplot%title
+        if (allocated(subplot%xlabel)) xlabel = subplot%xlabel
+        if (allocated(subplot%ylabel)) ylabel = subplot%ylabel
+
+        xlabel_h = 0
+        if (len_trim(xlabel) > 0) xlabel_h = measure_raster_height(xlabel)
+
+        ylabel_h = 0
+        if (len_trim(ylabel) > 0) ylabel_h = measure_raster_height(ylabel)
+
+        title_h = 0
+        if (len_trim(title) > 0) then
+            title_h = &
+                calculate_text_height_with_size_internal(real(TITLE_FONT_SIZE, wp))
+        end if
+
+        dec_left = real(Y_TICK_LABEL_RIGHT_PAD + max_y_w, wp)
+        dec_left = max(dec_left, real(TICK_MARK_LENGTH, wp))
+        if (len_trim(ylabel) > 0) then
+            dec_left = real(TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + max_y_w + &
+                            YLABEL_EXTRA_GAP + ylabel_h, wp)
+        end if
+        dec_right = 0.0_wp
+
+        ! Tick labels sit X_TICK_LABEL_PAD below the spine; the x-axis label is
+        ! placed an additional pt2px(AXIS_LABEL_PAD_PT) below the tick-label
+        ! bottom edge (matplotlib axes.labelpad), matching the raster renderer.
+        dec_bottom = real(X_TICK_LABEL_PAD + max_x_h, wp)
+        if (len_trim(xlabel) > 0) then
+            dec_bottom = dec_bottom + pt2px(AXIS_LABEL_PAD_PT, dpi) + &
+                         real(xlabel_h, wp)
+        end if
+
+        dec_top = 0.0_wp
+        if (len_trim(title) > 0) then
+            ! Title baseline sits pt2px(TITLE_PAD_PT) above the top spine
+            ! (matplotlib axes.titlepad); the glyphs rise title_h above it.
+            dec_top = pt2px(TITLE_PAD_PT, dpi) + real(title_h, wp)
+        end if
+    end subroutine estimate_subplot_decorations_raster
+
+    subroutine estimate_subplot_decorations_pdf(subplot, xscale, yscale, &
+                                                symlog_threshold, dec_left, dec_right, &
+                                                dec_bottom, dec_top)
+        type(subplot_data_t), intent(in) :: subplot
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+        real(wp), intent(out) :: dec_left, dec_right, dec_bottom, dec_top
+
+        real(wp) :: x_tick_positions(MAX_TICKS), y_tick_positions(MAX_TICKS)
+        integer :: n_x, n_y, i, decimals
+        character(len=50) :: x_labels(MAX_TICKS), y_labels(MAX_TICKS)
+        real(wp) :: max_y_w, max_x_h
+        real(wp) :: xlabel_h, title_h
+        character(len=:), allocatable :: title, xlabel, ylabel
+
+        real(wp), parameter :: X_TICK_GAP = 15.0_wp
+        real(wp), parameter :: Y_TICK_GAP = 1.0_wp
+        real(wp), parameter :: TITLE_GAP = 6.0_wp
+        real(wp), parameter :: YLABEL_PAD = 1.0_wp
+        real(wp), parameter :: LABEL_THICKNESS = 1.2_wp*PDF_LABEL_SIZE
+
+        max_y_w = 0.0_wp
+        max_x_h = 0.0_wp
+
+        call compute_scale_ticks(xscale, subplot%x_min, subplot%x_max, &
+                                 symlog_threshold, x_tick_positions, n_x)
+        call compute_scale_ticks(yscale, subplot%y_min, subplot%y_max, &
+                                 symlog_threshold, y_tick_positions, n_y)
+
+        if (n_x > 0) then
+            decimals = 0
+            if (trim(xscale) == 'linear' .and. n_x >= 2) then
+                decimals = determine_decimals_from_ticks(x_tick_positions, n_x)
+            end if
+            do i = 1, n_x
+                if (trim(xscale) == 'linear') then
+                    x_labels(i) = format_tick_value_consistent(x_tick_positions(i), &
+                                                               decimals)
+                else
+                    x_labels(i) = format_tick_label(x_tick_positions(i), xscale, &
+                                                    data_min=subplot%x_min, &
+                                                    data_max=subplot%x_max)
+                end if
+                max_x_h = max(max_x_h, PDF_TICK_LABEL_SIZE*1.2_wp)
+            end do
+        end if
+
+        if (n_y > 0) then
+            decimals = 0
+            if (trim(yscale) == 'linear' .and. n_y >= 2) then
+                decimals = determine_decimals_from_ticks(y_tick_positions, n_y)
+            end if
+            do i = 1, n_y
+                if (trim(yscale) == 'linear') then
+                    y_labels(i) = format_tick_value_consistent(y_tick_positions(i), &
+                                                               decimals)
+                else
+                    y_labels(i) = format_tick_label(y_tick_positions(i), yscale, &
+                                                    data_min=subplot%y_min, &
+                                                    data_max=subplot%y_max)
+                end if
+                max_y_w = max(max_y_w, estimate_pdf_text_width(trim(y_labels(i)), &
+                                                               PDF_TICK_LABEL_SIZE))
+            end do
+        end if
+
+        title = ''
+        xlabel = ''
+        ylabel = ''
+        if (allocated(subplot%title)) title = subplot%title
+        if (allocated(subplot%xlabel)) xlabel = subplot%xlabel
+        if (allocated(subplot%ylabel)) ylabel = subplot%ylabel
+
+        xlabel_h = 0.0_wp
+        if (len_trim(xlabel) > 0) xlabel_h = PDF_LABEL_SIZE*1.2_wp
+
+        title_h = 0.0_wp
+        if (len_trim(title) > 0) title_h = PDF_TITLE_SIZE*1.2_wp
+
+        dec_left = Y_TICK_GAP + max_y_w
+        if (len_trim(ylabel) > 0) then
+            dec_left = dec_left + YLABEL_PAD + LABEL_THICKNESS
+        end if
+        dec_right = 0.0_wp
+
+        dec_bottom = X_TICK_GAP + max_x_h
+        if (len_trim(xlabel) > 0) then
+            dec_bottom = max(dec_bottom, real(XLABEL_VERTICAL_OFFSET, wp) + xlabel_h)
+        end if
+
+        dec_top = 0.0_wp
+        if (len_trim(title) > 0) then
+            dec_top = TITLE_GAP + title_h
+        end if
+    end subroutine estimate_subplot_decorations_pdf
+
+    integer function measure_raster_width(text) result(w)
+        character(len=*), intent(in) :: text
+        character(len=500) :: processed
+        integer :: plen, mlen
+        character(len=600) :: math_ready
+        character(len=600) :: escaped
+
+        if (len_trim(text) == 0) then
+            w = 0
+            return
+        end if
+
+        call process_latex_in_text(trim(text), processed, plen)
+        call prepare_mathtext_if_needed(processed(1:plen), math_ready, mlen)
+        call escape_unicode_for_raster(math_ready(1:mlen), escaped)
+        w = calculate_text_width(trim(escaped))
+    end function measure_raster_width
+
+    integer function measure_raster_height(text) result(h)
+        character(len=*), intent(in) :: text
+        character(len=500) :: processed
+        integer :: plen, mlen
+        character(len=600) :: math_ready
+        character(len=600) :: escaped
+
+        if (len_trim(text) == 0) then
+            h = 0
+            return
+        end if
+
+        call process_latex_in_text(trim(text), processed, plen)
+        call prepare_mathtext_if_needed(processed(1:plen), math_ready, mlen)
+        call escape_unicode_for_raster(math_ready(1:mlen), escaped)
+        h = calculate_text_height(trim(escaped))
+        if (h <= 0) h = 12
+    end function measure_raster_height
 
 end module fortplot_subplot_layout


### PR DESCRIPTION
## Summary

The subplot grid layout had switched to matplotlib's fixed fractional
subplot parameters, which ignored per-panel decoration sizes. That fixed
1x3 vertical fill but regressed the 2x2 grid:

- The top row's x-axis tick labels and x-axis label collided with the
  bottom row's subplot titles.
- The right column's y-axis labels rendered inside the plot area, over
  the data, instead of to the left of their panels.

This change drives the grid margins and inter-panel gaps from each
panel's decoration sizes again, so every panel's y-axis label sits to
the left of its plot box and the top row's x-axis label clears the title
of the row below. The reserved title and x-axis-label space now matches
the actual raster draw offsets (axes titlepad and labelpad), and only the
outer-margin padding is reclaimed for short figures so they still fill
the vertical space without clipping labels.

## Verification

Commands run:
- `fpm build` -> succeeds.
- `fpm run --example subplot_demo` -> regenerates the 2x2 and 1x3 PNG/PDF.
- `make test-ci` -> "CI essential test suite completed successfully".
- `make verify-artifacts` -> "Artifact verification passed."
- `fpm test --target test_suptitle` -> all pass, including
  "1x3 subplot grid fills the figure height" (frac 0.77) and
  "2x2 subplot rows keep visible clearance".
- `fpm test --target test_subplots`, `test_tight_layout`,
  `test_stateful_subplots_routing` -> all pass.

Before/after, measured from the rendered 2x2 PNG (800x600):
- Before: top-row x-axis labels touched the bottom-row titles; the
  right-column y-labels ("cos(x)", "x^2/50") were drawn inside the data
  near the right edge of the panels.
- After: top-row spines end at row 265 and bottom-row spines start at
  row 347 (an 82 px clear band that separates the top-row x-labels from
  the bottom-row titles); the right-column y-labels now sit to the left
  of their panels (column edges 93/396/490/793).

1x3 PNG (900x300) vertical fill preserved:
- Panel rows span 49..251 (about 67% of the figure height, up from the
  decoration-driven ~49%) with all x-axis labels fully on the figure and
  each panel's y-label ("x", "x^2", "x^3") to the left of its panel.
- The suptitle test's own height-fill metric reports frac 0.77.

PDF text (subplot_2x2_demo.pdf via pdftotext) still shows the panel
titles and axis labels (Sine Wave / Cosine Wave / Damped Oscillation /
Quadratic Function, sin(x), cos(x), y, x^2/50) with the y-labels at the
left edge of each column.