### PR TITLE
fix: cap polar radial tick labels at data max like matplotlib

### DIFF
--- a/src/backends/memory/fortplot_polar_rendering.f90
+++ b/src/backends/memory/fortplot_polar_rendering.f90
@@ -200,18 +200,30 @@ contains
         real(wp), intent(in) :: center_x, center_y, radius, r_max
         real(wp), intent(in), optional :: label_angle
 
+        ! matplotlib auto-scales the radial axis to the data maximum, while the
+        ! caller passes a padded outer radius (data_max * R_MAX_PAD) so the
+        ! boundary clears the curve. Undo that padding before picking tick
+        ! values so the labels stop at the data max (e.g. 1.2, not 1.4) the way
+        ! matplotlib does, but keep the geometry scaled by the padded r_max.
+        real(wp), parameter :: R_MAX_PAD = 1.1_wp
         character(len=20) :: labels(12)
-        real(wp) :: r_value, r_geom, angle, x_label, y_label
+        real(wp) :: r_value, r_geom, angle, x_label, y_label, r_data
         integer :: i, ios
 
         if (r_max <= 0.0_wp .or. radius <= 0.0_wp) return
 
-        angle = PI/8.0_wp  ! 22.5 degrees (matplotlib default rlabel position)
+        ! matplotlib's default rlabel position places the radial labels along a
+        ! ray 22.5 degrees above the horizontal (0-degree) axis, so they stack
+        ! up and to the right rather than running flat along the 0-degree spoke.
+        angle = PI/8.0_wp  ! 22.5 degrees in screen coordinates
         if (present(label_angle)) angle = label_angle
 
-        ! Use the linear tick algorithm to pick nice radial values over [0, r_max].
+        r_data = r_max/R_MAX_PAD
+
+        ! Use the linear tick algorithm to pick nice radial values over the data
+        ! range [0, r_data] so the outermost label matches the data maximum.
         labels = ''
-        call calculate_tick_labels(0.0_wp, r_max, size(labels), labels)
+        call calculate_tick_labels(0.0_wp, r_data, size(labels), labels)
 
         call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
 
@@ -219,7 +231,7 @@ contains
             if (len_trim(labels(i)) == 0) cycle
             read (labels(i), *, iostat=ios) r_value
             if (ios /= 0) cycle
-            if (r_value <= 0.0_wp .or. r_value > r_max + 1.0e-9_wp) cycle
+            if (r_value <= 0.0_wp .or. r_value > r_data + 1.0e-9_wp) cycle
 
             r_geom = radius*(r_value/r_max)
             x_label = center_x + r_geom*cos(angle)


### PR DESCRIPTION
## Summary

Two polar parity items for the `polar_demo` example, matched against the matplotlib default render.

1. Grid linewidth (spokes + radial circles) is already 0.8pt, matplotlib's `grid.linewidth` default. No change needed; verified in the current source and render.
2. Radial tick labels now stop at the data maximum like matplotlib, instead of running one tick past it.

matplotlib auto-scales the polar radial axis to the data max and labels nice values up to it. fortplot was labeling over the padded outer radius (`data_max * 1.1`), which added a spurious outer tick (1.4) beyond the data. The fix picks tick values over the unpadded data range while keeping the concentric-ring geometry on the padded radius, so the labels read 0.2, 0.4, 0.6, 0.8, 1.0, 1.2 and align with the rings. The label ray stays at matplotlib's default 22.5 degrees above the horizontal axis.

## Verification

Commands run:

- `fpm build` — passed.
- Regenerated `polar_demo` and compared PNG to the matplotlib reference: radial labels now read 0.2 .. 1.2 (previously 0.2 .. 1.4), stacked up-and-right at 22.5 degrees, matching the reference. No regression to spokes, rings, angular labels, or curves.
- `make verify-artifacts` — ended `Artifact verification passed.` (ylabel-left stripe checks and quiver geometry gates green).
- `make test-ci` — `CI essential test suite completed successfully`.
- `fpm test --target test_polar_theta_offset --target test_polar_angular_labels` — all passed.

Before -> after, radial tick labels (PDF text via pdftotext):

- before: `... 1.2 1.0 0.8 0.6 0.4 0.2 ... 1.4` (extra 1.4 tick past data max)
- after:  `1.2 1.0 0.8 0.6 0.4 0.2`
- matplotlib reference: `0.6 0.4 0.2 ... 1.2 1.0 0.8` (same set, no 1.4)
