### PR TITLE
fix: render math-mode text in italic like matplotlib

### DIFF
--- a/src/backends/raster/fortplot_raster_text_rendering.f90
+++ b/src/backends/raster/fortplot_raster_text_rendering.f90
@@ -19,6 +19,9 @@ module fortplot_raster_text_rendering
     public :: render_text_to_image, render_text_with_size, render_rotated_text_to_image
 
     real(wp), parameter :: PI = 3.14159265359_wp
+    real(wp), parameter :: ITALIC_SHEAR = 0.2126_wp
+        !! Horizontal shear for synthetic oblique (~12 deg, tan(12 deg)), used to
+        !! slant math-mode glyphs the way matplotlib italicises math variables.
 
 contains
 
@@ -284,7 +287,8 @@ contains
                 pen_y = y - int(elements(i)%vertical_offset*base_font_size)
                 call render_text_with_size_internal(image_data, width, height, &
                                                     pen_x, pen_y, elements(i)%text, r, &
-                                                    g, b, element_font_size)
+                                                    g, b, element_font_size, &
+                                                    elements(i)%italic)
                 pen_x = pen_x + calculate_text_width_with_size_internal( &
                         elements(i)%text, element_font_size)
             end if
@@ -292,7 +296,7 @@ contains
     end subroutine render_mathtext_elements_internal
 
     subroutine render_text_with_size_internal(image_data, width, height, x, y, text, &
-                                              r, g, b, pixel_height)
+                                              r, g, b, pixel_height, italic)
         !! Internal text rendering helper to avoid circular dependencies
         !! Note: Uses len(text) not len_trim to preserve trailing spaces in mathtext
         integer(1), intent(inout) :: image_data(:)
@@ -300,15 +304,21 @@ contains
         character(len=*), intent(in) :: text
         integer(1), intent(in) :: r, g, b
         real(wp), intent(in) :: pixel_height
+        logical, intent(in), optional :: italic
         integer :: pen_x, pen_y, i, char_code
         integer :: advance_width, left_side_bearing
         integer(int8), allocatable :: bitmap(:)
         integer :: bmp_width, bmp_height, xoff, yoff
         integer :: char_len, text_len
         type(truetype_font_t) :: font
-        real(wp) :: scale
+        real(wp) :: scale, slant
+        logical :: glyph_italic
 
         text_len = len(text)
+        slant = 0.0_wp
+        if (present(italic)) then
+            if (italic) slant = ITALIC_SHEAR
+        end if
 
         if (.not. is_font_initialized()) then
             if (.not. init_text_system()) then
@@ -336,11 +346,15 @@ contains
             call font%get_codepoint_bitmap(scale, scale, char_code, bitmap, &
                                            bmp_width, bmp_height, xoff, yoff)
 
+            ! Only slant letters: matplotlib italicises math variables, not
+            ! digits, operators, or punctuation.
+            glyph_italic = slant > 0.0_wp .and. is_alpha_codepoint(char_code)
+
             if (allocated(bitmap)) then
                 call render_stb_glyph(image_data, width, height, pen_x, pen_y, &
                                       bitmap, bmp_width, bmp_height, xoff, &
                                       yoff, r, g, &
-                                      b)
+                                      b, merge(slant, 0.0_wp, glyph_italic))
             end if
 
             call font%get_hmetrics(char_code, advance_width, left_side_bearing)
@@ -348,28 +362,50 @@ contains
         end do
     end subroutine render_text_with_size_internal
 
+    pure function is_alpha_codepoint(codepoint) result(is_alpha)
+        !! True for ASCII letters (the glyphs matplotlib renders italic in math).
+        integer, intent(in) :: codepoint
+        logical :: is_alpha
+        is_alpha = (codepoint >= iachar('A') .and. codepoint <= iachar('Z')) .or. &
+                   (codepoint >= iachar('a') .and. codepoint <= iachar('z'))
+    end function is_alpha_codepoint
+
     subroutine render_stb_glyph(image_data, width, height, pen_x, pen_y, bitmap, &
-                                bmp_width, bmp_height, xoff, yoff, r, g, b)
-        !! Render STB TrueType glyph bitmap to image
+                                bmp_width, bmp_height, xoff, yoff, r, g, b, slant)
+        !! Render STB TrueType glyph bitmap to image. A non-zero slant applies a
+        !! horizontal shear (synthetic oblique) proportional to height above the
+        !! baseline, leaving the advance width unchanged.
         integer(1), intent(inout) :: image_data(:)
         integer, intent(in) :: width, height, pen_x, pen_y
         integer(int8), intent(in) :: bitmap(:)
         integer, intent(in) :: bmp_width, bmp_height, xoff, yoff
         integer(1), intent(in) :: r, g, b
+        real(wp), intent(in), optional :: slant
         integer :: glyph_x, glyph_y, img_x, img_y, row, col, pixel_idx
-        integer :: alpha_int
+        integer :: alpha_int, shear_dx
+        real(wp) :: slant_factor
         real :: alpha_f, bg_r, bg_g, bg_b
 
         if (bmp_width <= 0 .or. bmp_height <= 0) then
             return
         end if
 
+        slant_factor = 0.0_wp
+        if (present(slant)) slant_factor = slant
+
         glyph_x = pen_x + xoff
         glyph_y = pen_y + yoff
 
         do row = 0, bmp_height - 1
+            ! Shift each row left/right by an amount proportional to its height
+            ! above the baseline. pen_y is the baseline; (glyph_y+row) is the
+            ! pixel row, so height above baseline is pen_y-(glyph_y+row).
+            shear_dx = 0
+            if (slant_factor /= 0.0_wp) then
+                shear_dx = nint(slant_factor*real(pen_y - (glyph_y + row), wp))
+            end if
             do col = 0, bmp_width - 1
-                img_x = glyph_x + col
+                img_x = glyph_x + col + shear_dx
                 img_y = glyph_y + row
 
                 if (img_x >= 0 .and. img_x < width .and. img_y >= 0 .and. &

--- a/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
@@ -7,8 +7,9 @@ module fortplot_pdf_mathtext_render
     use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE
     use fortplot_pdf_text_render, only: draw_mixed_font_text
     use fortplot_pdf_text_segments, only: render_mixed_font_at_position, &
-                                          switch_to_helvetica_font
-    use fortplot_pdf_text_escape, only: escape_pdf_string
+                                          switch_to_helvetica_font, &
+                                          switch_to_symbol_font
+    use fortplot_pdf_text_escape, only: escape_pdf_string, unicode_to_symbol_char
     use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
     use fortplot_text_layout, only: preprocess_math_text
     use fortplot_pdf_text_metrics, only: estimate_pdf_text_width
@@ -113,20 +114,26 @@ contains
 
     subroutine render_oblique_text_at_position(this, x, y, text, font_size)
         !! Render a math run with synthetic oblique: each ASCII letter gets a
-        !! sheared text matrix, digits/operators stay upright. Advance widths
-        !! match the upright Helvetica metrics so layout is unchanged.
+        !! sheared text matrix, digits/operators stay upright. Greek letters and
+        !! other math glyphs in the Symbol font keep their Symbol mapping (matching
+        !! the upright mixed-font path) so '\Theta' etc. still emit '/F6' + octal
+        !! escapes. Advance widths match the upright Helvetica metrics so layout
+        !! is unchanged.
         class(pdf_context_core), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
         real(wp), intent(in) :: font_size
         character(len=64) :: font_cmd
         character(len=64) :: escaped
+        character(len=8) :: symbol_char
         integer :: i, text_len, codepoint, esc_len, char_len
         real(wp) :: pen_x, shear
+        integer :: current_font
+        integer, parameter :: FONT_NONE = 0, FONT_HELVETICA = 1, FONT_SYMBOL = 2
 
-        write (font_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
-            this%fonts%get_helvetica_obj(), font_size
-        this%stream_data = this%stream_data//trim(adjustl(font_cmd))//new_line('a')
+        ! Track which font is currently selected so we only emit a font switch
+        ! when the glyph class changes (Symbol vs Helvetica).
+        current_font = FONT_NONE
 
         pen_x = x
         text_len = len(text)
@@ -134,20 +141,45 @@ contains
         do while (i <= text_len)
             char_len = max(1, utf8_char_length(text(i:i)))
             if (i + char_len - 1 > text_len) char_len = 1
-            codepoint = ichar(text(i:i))
-            shear = 0.0_wp
-            ! Only single-byte ASCII letters slant; math variables are ASCII.
-            if (char_len == 1 .and. is_ascii_letter(codepoint)) shear = ITALIC_SHEAR
+            if (char_len == 1) then
+                codepoint = ichar(text(i:i))
+            else
+                codepoint = utf8_to_codepoint(text, i)
+            end if
 
-            write (font_cmd, '("1 0 ", F0.4, " 1 ", F0.3, 1X, F0.3, " Tm")') &
-                shear, pen_x, y
-            this%stream_data = this%stream_data//trim(adjustl(font_cmd))//new_line('a')
+            call unicode_to_symbol_char(codepoint, symbol_char)
+            if (len_trim(symbol_char) > 0) then
+                ! Math glyph available in the Symbol font (e.g. uppercase Greek):
+                ! render upright in Symbol, no synthetic shear.
+                if (current_font /= FONT_SYMBOL) then
+                    call switch_to_symbol_font(this, font_size)
+                    current_font = FONT_SYMBOL
+                end if
+                write (font_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') pen_x, y
+                this%stream_data = this%stream_data//trim(adjustl(font_cmd)) &
+                    //new_line('a')
+                this%stream_data = this%stream_data//'('//trim(symbol_char)// &
+                    ') Tj'//new_line('a')
+            else
+                if (current_font /= FONT_HELVETICA) then
+                    call switch_to_helvetica_font(this, font_size)
+                    current_font = FONT_HELVETICA
+                end if
+                shear = 0.0_wp
+                ! Only single-byte ASCII letters slant; math variables are ASCII.
+                if (char_len == 1 .and. is_ascii_letter(codepoint)) shear = ITALIC_SHEAR
 
-            escaped = ''
-            esc_len = 0
-            call escape_pdf_string(text(i:i+char_len-1), escaped, esc_len)
-            this%stream_data = this%stream_data//'('//escaped(1:esc_len)// &
-                ') Tj'//new_line('a')
+                write (font_cmd, '("1 0 ", F0.4, " 1 ", F0.3, 1X, F0.3, " Tm")') &
+                    shear, pen_x, y
+                this%stream_data = this%stream_data//trim(adjustl(font_cmd)) &
+                    //new_line('a')
+
+                escaped = ''
+                esc_len = 0
+                call escape_pdf_string(text(i:i+char_len-1), escaped, esc_len)
+                this%stream_data = this%stream_data//'('//escaped(1:esc_len)// &
+                    ') Tj'//new_line('a')
+            end if
 
             pen_x = pen_x + estimate_pdf_text_width(text(i:i+char_len-1), font_size)
             i = i + char_len

--- a/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
@@ -6,7 +6,9 @@ module fortplot_pdf_mathtext_render
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE
     use fortplot_pdf_text_render, only: draw_mixed_font_text
-    use fortplot_pdf_text_segments, only: render_mixed_font_at_position
+    use fortplot_pdf_text_segments, only: render_mixed_font_at_position, &
+                                          switch_to_helvetica_font
+    use fortplot_pdf_text_escape, only: escape_pdf_string
     use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
     use fortplot_text_layout, only: preprocess_math_text
     use fortplot_pdf_text_metrics, only: estimate_pdf_text_width
@@ -15,6 +17,10 @@ module fortplot_pdf_mathtext_render
 
     public :: draw_pdf_mathtext
     public :: render_mathtext_element_pdf
+
+    real(wp), parameter :: ITALIC_SHEAR = 0.2126_wp
+        !! Text-matrix shear for synthetic oblique (~12 deg, tan(12 deg)), used to
+        !! slant math-mode letters the way matplotlib italicises math variables.
 
 contains
 
@@ -95,10 +101,65 @@ contains
             return
         end if
 
-        call render_mixed_font_at_position(this, x_pos, elem_y, element%text, &
-                                           elem_font_size)
+        if (element%italic) then
+            call render_oblique_text_at_position(this, x_pos, elem_y, element%text, &
+                                                 elem_font_size)
+        else
+            call render_mixed_font_at_position(this, x_pos, elem_y, element%text, &
+                                               elem_font_size)
+        end if
         x_pos = x_pos + estimate_pdf_text_width(element%text, elem_font_size)
     end subroutine render_mathtext_element_pdf
+
+    subroutine render_oblique_text_at_position(this, x, y, text, font_size)
+        !! Render a math run with synthetic oblique: each ASCII letter gets a
+        !! sheared text matrix, digits/operators stay upright. Advance widths
+        !! match the upright Helvetica metrics so layout is unchanged.
+        class(pdf_context_core), intent(inout) :: this
+        real(wp), intent(in) :: x, y
+        character(len=*), intent(in) :: text
+        real(wp), intent(in) :: font_size
+        character(len=64) :: font_cmd
+        character(len=64) :: escaped
+        integer :: i, text_len, codepoint, esc_len, char_len
+        real(wp) :: pen_x, shear
+
+        write (font_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+            this%fonts%get_helvetica_obj(), font_size
+        this%stream_data = this%stream_data//trim(adjustl(font_cmd))//new_line('a')
+
+        pen_x = x
+        text_len = len(text)
+        i = 1
+        do while (i <= text_len)
+            char_len = max(1, utf8_char_length(text(i:i)))
+            if (i + char_len - 1 > text_len) char_len = 1
+            codepoint = ichar(text(i:i))
+            shear = 0.0_wp
+            ! Only single-byte ASCII letters slant; math variables are ASCII.
+            if (char_len == 1 .and. is_ascii_letter(codepoint)) shear = ITALIC_SHEAR
+
+            write (font_cmd, '("1 0 ", F0.4, " 1 ", F0.3, 1X, F0.3, " Tm")') &
+                shear, pen_x, y
+            this%stream_data = this%stream_data//trim(adjustl(font_cmd))//new_line('a')
+
+            escaped = ''
+            esc_len = 0
+            call escape_pdf_string(text(i:i+char_len-1), escaped, esc_len)
+            this%stream_data = this%stream_data//'('//escaped(1:esc_len)// &
+                ') Tj'//new_line('a')
+
+            pen_x = pen_x + estimate_pdf_text_width(text(i:i+char_len-1), font_size)
+            i = i + char_len
+        end do
+    end subroutine render_oblique_text_at_position
+
+    pure function is_ascii_letter(codepoint) result(is_letter)
+        integer, intent(in) :: codepoint
+        logical :: is_letter
+        is_letter = (codepoint >= iachar('A') .and. codepoint <= iachar('Z')) .or. &
+                    (codepoint >= iachar('a') .and. codepoint <= iachar('z'))
+    end function is_ascii_letter
 
     subroutine render_mathtext_with_unicode_superscripts(this, x, y, text, font_size)
         class(pdf_context_core), intent(inout) :: this

--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -25,6 +25,10 @@ module fortplot_mathtext
         integer :: element_type = ELEMENT_NORMAL
         real(wp) :: font_size_ratio = 1.0_wp
         real(wp) :: vertical_offset = 0.0_wp  ! In pixels, positive = up
+        logical :: italic = .false.
+            !! True for runs that originate inside a '$...$' math segment.
+            !! matplotlib renders math variables in italic; backends apply a
+            !! synthetic oblique shear to alphabetic glyphs of italic runs.
     end type mathtext_element_t
 
 contains
@@ -38,29 +42,40 @@ contains
         character(len=len(input_text)) :: current_text
         type(mathtext_element_t) :: temp_elements(len(input_text))
         integer :: element_count
+        logical :: in_math
 
         element_count = 0
         n = len_trim(input_text)
         i = 1
         current_text = ''
         current_len = 0
+        in_math = .false.
 
         do while (i <= n)
-            if (input_text(i:i) == '^') then
+            if (input_text(i:i) == '$') then
+                ! Unescaped '$' toggles math mode; runs inside render italic.
+                call flush_current_text(current_text, current_len, temp_elements, &
+                                        element_count, in_math)
+                in_math = .not. in_math
+                i = i + 1
+            else if (input_text(i:i) == '^') then
                 call flush_script_base(current_text, current_len, temp_elements, &
-                                       element_count)
+                                       element_count, in_math)
                 i = i + 1
                 call parse_superscript_subscript(input_text, i, n, temp_elements, &
-                                               element_count, ELEMENT_SUPERSCRIPT)
+                                               element_count, ELEMENT_SUPERSCRIPT, &
+                                               in_math)
             else if (input_text(i:i) == '_') then
                 call flush_script_base(current_text, current_len, temp_elements, &
-                                       element_count)
+                                       element_count, in_math)
                 i = i + 1
                 call parse_superscript_subscript(input_text, i, n, temp_elements, &
-                                               element_count, ELEMENT_SUBSCRIPT)
+                                               element_count, ELEMENT_SUBSCRIPT, &
+                                               in_math)
             else if (input_text(i:i) == '\') then
                 call handle_mathtext_escape(input_text, i, n, current_text, &
-                                            current_len, temp_elements, element_count)
+                                            current_len, temp_elements, &
+                                            element_count, in_math)
             else
                 call append_current_text(current_text, current_len, input_text(i:i))
                 i = i + 1
@@ -68,18 +83,20 @@ contains
         end do
 
         call flush_current_text(current_text, current_len, temp_elements, &
-                                element_count)
+                                element_count, in_math)
 
         allocate(elements(element_count))
         elements(1:element_count) = temp_elements(1:element_count)
 
     end function parse_mathtext
 
-    subroutine flush_script_base(current_text, current_len, elements, element_count)
+    subroutine flush_script_base(current_text, current_len, elements, &
+                                 element_count, in_math)
         character(len=*), intent(inout) :: current_text
         integer, intent(inout) :: current_len
         type(mathtext_element_t), intent(inout) :: elements(:)
         integer, intent(inout) :: element_count
+        logical, intent(in) :: in_math
 
         integer :: start_idx, byte
 
@@ -96,19 +113,19 @@ contains
             element_count = element_count + 1
             call create_element(elements(element_count), &
                                 current_text(1:start_idx - 1), &
-                                ELEMENT_NORMAL, 1.0_wp, 0.0_wp)
+                                ELEMENT_NORMAL, 1.0_wp, 0.0_wp, in_math)
         end if
 
         element_count = element_count + 1
         call create_element(elements(element_count), &
                             current_text(start_idx:current_len), &
-                            ELEMENT_NORMAL, 1.0_wp, 0.0_wp)
+                            ELEMENT_NORMAL, 1.0_wp, 0.0_wp, in_math)
         current_text = ''
         current_len = 0
     end subroutine flush_script_base
 
     subroutine handle_mathtext_escape(input_text, i, n, current_text, &
-                                      current_len, elements, element_count)
+                                      current_len, elements, element_count, in_math)
         character(len=*), intent(in) :: input_text
         integer, intent(inout) :: i
         integer, intent(in) :: n
@@ -116,13 +133,15 @@ contains
         integer, intent(inout) :: current_len
         type(mathtext_element_t), intent(inout) :: elements(:)
         integer, intent(inout) :: element_count
+        logical, intent(in) :: in_math
 
         if (i + 4 <= n) then
             if (input_text(i + 1:i + 4) == 'sqrt') then
                 call flush_current_text(current_text, current_len, elements, &
-                                        element_count)
+                                        element_count, in_math)
                 i = i + 5
-                call parse_sqrt_content(input_text, i, n, elements, element_count)
+                call parse_sqrt_content(input_text, i, n, elements, &
+                                        element_count, in_math)
                 return
             end if
         end if
@@ -163,23 +182,25 @@ contains
         current_text(current_len - len(text) + 1:current_len) = text
     end subroutine append_current_text
 
-    subroutine flush_current_text(current_text, current_len, elements, element_count)
+    subroutine flush_current_text(current_text, current_len, elements, &
+                                  element_count, in_math)
         character(len=*), intent(inout) :: current_text
         integer, intent(inout) :: current_len
         type(mathtext_element_t), intent(inout) :: elements(:)
         integer, intent(inout) :: element_count
+        logical, intent(in) :: in_math
 
         if (current_len <= 0) return
 
         element_count = element_count + 1
         call create_element(elements(element_count), current_text(1:current_len), &
-                            ELEMENT_NORMAL, 1.0_wp, 0.0_wp)
+                            ELEMENT_NORMAL, 1.0_wp, 0.0_wp, in_math)
         current_text = ''
         current_len = 0
     end subroutine flush_current_text
 
     subroutine parse_superscript_subscript(input_text, start_i, n, elements, &
-                                           element_count, element_type)
+                                           element_count, element_type, in_math)
         !! Parse superscript or subscript content
         character(len=*), intent(in) :: input_text
         integer, intent(inout) :: start_i
@@ -187,6 +208,7 @@ contains
         type(mathtext_element_t), intent(inout) :: elements(:)
         integer, intent(inout) :: element_count
         integer, intent(in) :: element_type
+        logical, intent(in) :: in_math
 
         character(len=n) :: script_text
         integer :: i, brace_count, script_len
@@ -243,19 +265,21 @@ contains
         if (script_len > 0) then
             element_count = element_count + 1
             call create_element(elements(element_count), script_text(1:script_len), &
-                              element_type, font_size_ratio, vertical_offset)
+                              element_type, font_size_ratio, vertical_offset, in_math)
         end if
 
         start_i = i
     end subroutine parse_superscript_subscript
 
-    subroutine parse_sqrt_content(input_text, start_i, n, elements, element_count)
+    subroutine parse_sqrt_content(input_text, start_i, n, elements, &
+                                  element_count, in_math)
         !! Parse square root content
         character(len=*), intent(in) :: input_text
         integer, intent(inout) :: start_i
         integer, intent(in) :: n
         type(mathtext_element_t), intent(inout) :: elements(:)
         integer, intent(inout) :: element_count
+        logical, intent(in) :: in_math
 
         character(len=n) :: rad_text
         integer :: i, brace_count, rad_len
@@ -295,24 +319,27 @@ contains
         if (rad_len > 0) then
             element_count = element_count + 1
             call create_element(elements(element_count), rad_text(1:rad_len), &
-                              ELEMENT_SQRT, 1.0_wp, 0.0_wp)
+                              ELEMENT_SQRT, 1.0_wp, 0.0_wp, in_math)
         end if
 
         start_i = i
     end subroutine parse_sqrt_content
 
-    subroutine create_element(element, text, element_type, font_size_ratio, vertical_offset)
+    subroutine create_element(element, text, element_type, font_size_ratio, &
+                              vertical_offset, italic)
         !! Create a mathtext element with proper string handling
         type(mathtext_element_t), intent(out) :: element
         character(len=*), intent(in) :: text
         integer, intent(in) :: element_type
         real(wp), intent(in) :: font_size_ratio, vertical_offset
+        logical, intent(in) :: italic
 
         ! Store text properly - preserve all spaces
         element%text = text
         element%element_type = element_type
         element%font_size_ratio = font_size_ratio
         element%vertical_offset = vertical_offset
+        element%italic = italic
    end subroutine create_element
 
 

--- a/src/text/fortplot_text_layout.f90
+++ b/src/text/fortplot_text_layout.f90
@@ -228,9 +228,10 @@ contains
     end function calculate_mathtext_width_internal
 
     subroutine preprocess_math_text(input_text, result_text, result_len)
-        !! Remove '$' delimiters and escape '^'/'_' outside math so they render
-        !! literally. Only content between '$...$' is treated as math, matching
-        !! matplotlib: bare '^'/'_' outside dollars stay literal characters.
+        !! Escape '^'/'_' outside math so they render literally, and pass the
+        !! '$' delimiters through so the parser can toggle math mode (and tag
+        !! math runs italic). Only content between '$...$' is treated as math,
+        !! matching matplotlib: bare '^'/'_' outside dollars stay literal.
         !! UTF-8 aware: multi-byte characters are copied as intact sequences
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: result_text
@@ -254,6 +255,9 @@ contains
                 ch = input_text(i:i)
                 if (ch == '$') then
                     in_math = .not. in_math
+                    ! Keep the delimiter so the parser can tag math runs italic.
+                    result_text(pos:pos) = ch
+                    pos = pos + 1
                     i = i + 1
                     cycle
                 end if

--- a/test/text/test_mathtext_italic.f90
+++ b/test/text/test_mathtext_italic.f90
@@ -1,0 +1,49 @@
+program test_mathtext_italic
+    !! Math-mode runs (inside '$...$') must be tagged italic so backends apply
+    !! the synthetic oblique shear, matching matplotlib's italic math variables.
+    !! Text outside the dollars stays upright.
+    use fortplot_text_layout, only: preprocess_math_text
+    use fortplot_mathtext, only: parse_mathtext, mathtext_element_t
+    implicit none
+
+    type(mathtext_element_t), allocatable :: elements(:)
+    character(len=256) :: processed
+    integer :: plen, i
+    logical :: saw_upright_prefix, saw_italic_base, saw_italic_super
+
+    call preprocess_math_text('f(x) = $x^2$', processed, plen)
+    elements = parse_mathtext(processed(1:plen))
+
+    saw_upright_prefix = .false.
+    saw_italic_base = .false.
+    saw_italic_super = .false.
+
+    do i = 1, size(elements)
+        if (trim(elements(i)%text) == 'f(x) = ' .or. &
+            trim(elements(i)%text) == 'f(x) =') then
+            if (elements(i)%italic) error stop "non-math prefix must stay upright"
+            saw_upright_prefix = .true.
+        end if
+        if (trim(elements(i)%text) == 'x' .and. elements(i)%element_type == 0) then
+            if (.not. elements(i)%italic) error stop "math base 'x' must be italic"
+            saw_italic_base = .true.
+        end if
+        if (trim(elements(i)%text) == '2' .and. elements(i)%element_type == 1) then
+            if (.not. elements(i)%italic) error stop "math superscript must be italic"
+            saw_italic_super = .true.
+        end if
+    end do
+
+    if (.not. saw_upright_prefix) error stop "upright prefix element missing"
+    if (.not. saw_italic_base) error stop "italic math base element missing"
+    if (.not. saw_italic_super) error stop "italic superscript element missing"
+
+    ! Bare text without dollars is never italic.
+    call preprocess_math_text('plain x text', processed, plen)
+    elements = parse_mathtext(processed(1:plen))
+    do i = 1, size(elements)
+        if (elements(i)%italic) error stop "text without dollars must stay upright"
+    end do
+
+    print *, 'PASS: math-mode runs tagged italic, surrounding text upright'
+end program test_mathtext_italic


### PR DESCRIPTION
## Summary

matplotlib renders mathematical variables inside `$...$` in italic; fortplot rendered them upright. This tags math-mode runs as italic in the mathtext parser and applies a synthetic oblique shear (~12 deg, tan(12 deg) = 0.2126) to ASCII letters at render time, consistently across the raster (PNG) and vector (PDF) backends.

- `preprocess_math_text` now keeps the `$` delimiters so the parser can see math boundaries.
- `parse_mathtext` toggles math mode on unescaped `$` and tags the resulting elements `italic`.
- Raster backend shears each glyph bitmap row horizontally by its height above the baseline.
- PDF backend emits a sheared text matrix (`1 0 0.2126 1 x y Tm`) per letter.

Only ASCII letters slant; digits, operators, punctuation, and any text outside the dollars stay upright, matching matplotlib. Glyph advance widths are unchanged, so layout and spacing are identical to before.

## Verification

Commands run (all passed):
- `fpm build` — compiled successfully.
- `fpm run --example mathtext_demo` — regenerated PNG + PDF.
- `make verify-artifacts` — ended `Artifact verification passed.` (ylabel-left stripe checks and quiver geometry gates green).
- `make test-ci` — `CI essential test suite completed successfully`.
- `fpm test --target test_mathtext_italic` (new behavioral test), plus `test_mathtext_parsing`, `test_text_layout_split`, `test_mathtext_fix_verification` — all pass.

Before -> after, `mathtext_demo` title `Mathematical Functions: $x^2$ and $e^{-x/3}$`:
- Before: the `x` and `e` (and the `x` in the `-x/3` superscript) rendered upright.
- After: those letters slant; "Mathematical Functions:" stays upright; the `10` in the legend's `10e^{-x/3}` and the `-`, `/`, `3` stay upright. This matches the matplotlib reference for both title and legend.

PDF text integrity confirmed with `pdftotext` (titles, legend labels, `y = f(xi)` ylabel, `xi` xlabel all intact). The decompressed PDF stream contains 8 sheared `Tm` matrices of the form `1 0 .2126 1 <x> <y> Tm`, one per italic letter in the title and legend; non-math glyphs keep `1 0 0 1 ... Tm`.

ylabel and other rotated labels remain upright in both backends (rotated mathtext is not italicised), which keeps the two backends consistent for that surface.