### PR TITLE
fix: span colormap across contour level range

### DIFF
--- a/src/backends/memory/fortplot_contour_rendering.f90
+++ b/src/backends/memory/fortplot_contour_rendering.f90
@@ -40,6 +40,7 @@ contains
         real(wp), intent(in) :: margin_left, margin_right, margin_bottom, margin_top
 
         real(wp) :: z_min, z_max
+        real(wp) :: cmin, cmax
         real(wp), dimension(3) :: level_color
         integer :: i, nlev
         real(wp) :: level
@@ -74,11 +75,17 @@ contains
         if (.not. plot_data%fill_contours) then
             if (allocated(plot_data%contour_levels)) then
                 nlev = size(plot_data%contour_levels)
+                ! Colour the lines across the full colormap span of the level
+                ! range (matplotlib), not the raw data range: with levels
+                ! [-4..4] over data [-9..9] the latter would compress every line
+                ! into a narrow mid-colormap band.
+                cmin = minval(plot_data%contour_levels)
+                cmax = maxval(plot_data%contour_levels)
                 do i = 1, nlev
                     level = plot_data%contour_levels(i)
 
                     if (plot_data%use_color_levels) then
-                        call colormap_value_to_color(level, z_min, z_max, &
+                        call colormap_value_to_color(level, cmin, cmax, &
                                                      plot_data%colormap, level_color)
                         call backend%color(level_color(1), level_color(2), &
                                            level_color(3))
@@ -126,6 +133,7 @@ contains
         integer :: nlev
         real(wp), allocatable :: levels(:)
         real(wp) :: lo, hi, mid, top
+        real(wp) :: cmin, cmax
         real(wp) :: color(3)
         real(wp) :: eps_z
         logical :: linear_x, linear_y
@@ -150,6 +158,13 @@ contains
         if (nlev < 2) return
         top = levels(nlev)
 
+        ! matplotlib spans the full colormap across the contour level range, not
+        ! the raw data range: the lowest band gets the bottom of the colormap and
+        ! the highest band the top. Normalising band colours over [z_min, z_max]
+        ! instead compresses them when the levels do not reach the data extremes.
+        cmin = levels(1)
+        cmax = levels(nlev)
+
         ! Filled bands tile cell-by-cell; vector backends stroke each quad to
         ! bridge sub-pixel seams between neighbours. A data-weight stroke would
         ! fatten the thin boundary slivers where a level grazes the data into
@@ -162,8 +177,8 @@ contains
             hi = levels(k + 1)
 
             mid = 0.5_wp*(lo + hi)
-            mid = max(z_min, min(z_max, mid))
-            call colormap_value_to_color(mid, z_min, z_max, plot_data%colormap, &
+            mid = max(cmin, min(cmax, mid))
+            call colormap_value_to_color(mid, cmin, cmax, plot_data%colormap, &
                                          color)
             call backend%color(color(1), color(2), color(3))
 
@@ -400,12 +415,21 @@ contains
 
         real(wp), dimension(3) :: level_color
         real(wp), allocatable :: level_values(:)
+        real(wp) :: cmin, cmax
         integer :: i
 
         call build_fill_levels(plot_data, z_min, z_max, level_values)
+        ! Span the colormap across the level range, matching matplotlib (see
+        ! render_contour_plot); falls back to the data range only if degenerate.
+        cmin = minval(level_values)
+        cmax = maxval(level_values)
+        if (cmax <= cmin) then
+            cmin = z_min
+            cmax = z_max
+        end if
         do i = 1, size(level_values)
             if (plot_data%use_color_levels) then
-                call colormap_value_to_color(level_values(i), z_min, z_max, &
+                call colormap_value_to_color(level_values(i), cmin, cmax, &
                                              plot_data%colormap, level_color)
                 call backend%color(level_color(1), level_color(2), level_color(3))
             end if

--- a/src/figures/management/fortplot_figure_colorbar.f90
+++ b/src/figures/management/fortplot_figure_colorbar.f90
@@ -112,8 +112,17 @@ contains
             if (plots(i)%plot_type == PLOT_TYPE_CONTOUR) then
                 if (plots(i)%fill_contours .and. allocated(plots(i)%z_grid)) then
                     if (size(plots(i)%z_grid) > 0) then
-                        vmin = minval(plots(i)%z_grid)
-                        vmax = maxval(plots(i)%z_grid)
+                        ! matplotlib's contourf colorbar spans the filled level
+                        ! range (its boundaries), not the raw data min/max, so
+                        ! the bar and its ticks line up with the bands. Fall back
+                        ! to the data range only when no levels are stored.
+                        if (allocated(plots(i)%contour_levels)) then
+                            vmin = minval(plots(i)%contour_levels)
+                            vmax = maxval(plots(i)%contour_levels)
+                        else
+                            vmin = minval(plots(i)%z_grid)
+                            vmax = maxval(plots(i)%z_grid)
+                        end if
                         colormap = plots(i)%colormap
                         plot_index = i
                         found = .true.

--- a/test/colormap/test_contour_level_normalization.f90
+++ b/test/colormap/test_contour_level_normalization.f90
@@ -1,0 +1,53 @@
+program test_contour_level_normalization
+    !! Regression test for matplotlib-style contour colour normalization.
+    !!
+    !! matplotlib spans the full colormap across the contour LEVEL range, not the
+    !! raw data range. With levels [-4, -2, 0, 2, 4] over data spanning [-9, 9],
+    !! normalising over the data range compresses every line into a narrow
+    !! mid-colormap band. The endpoints must instead land on the colormap
+    !! extremes (viridis(0) dark purple, viridis(1) yellow).
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_colormap, only: colormap_value_to_color
+    implicit none
+
+    real(wp), parameter :: levels(5) = &
+        [-4.0_wp, -2.0_wp, 0.0_wp, 2.0_wp, 4.0_wp]
+    real(wp) :: lev_min, lev_max
+    real(wp) :: c_lo(3), c_hi(3), c_end0(3), c_end1(3)
+    real(wp) :: tol
+
+    tol = 1.0e-6_wp
+    lev_min = minval(levels)
+    lev_max = maxval(levels)
+
+    ! Colour the lowest and highest levels normalised over the level range.
+    call colormap_value_to_color(levels(1), lev_min, lev_max, 'viridis', c_lo)
+    call colormap_value_to_color(levels(5), lev_min, lev_max, 'viridis', c_hi)
+
+    ! Reference colormap endpoints.
+    call colormap_value_to_color(0.0_wp, 0.0_wp, 1.0_wp, 'viridis', c_end0)
+    call colormap_value_to_color(1.0_wp, 0.0_wp, 1.0_wp, 'viridis', c_end1)
+
+    if (sum(abs(c_lo - c_end0)) > tol) then
+        print *, 'FAIL: lowest level does not map to colormap minimum'
+        print *, '  got ', c_lo, ' expected ', c_end0
+        stop 1
+    end if
+
+    if (sum(abs(c_hi - c_end1)) > tol) then
+        print *, 'FAIL: highest level does not map to colormap maximum'
+        print *, '  got ', c_hi, ' expected ', c_end1
+        stop 2
+    end if
+
+    ! The narrow-band failure mode: normalising over the wider data range
+    ! [-9, 9] must NOT reproduce the colormap endpoints (sanity that the test
+    ! distinguishes the two behaviours).
+    call colormap_value_to_color(levels(1), -9.0_wp, 9.0_wp, 'viridis', c_lo)
+    if (sum(abs(c_lo - c_end0)) <= tol) then
+        print *, 'FAIL: data-range normalization unexpectedly hit colormap min'
+        stop 3
+    end if
+
+    print *, 'PASS: contour colours span full colormap over the level range'
+end program test_contour_level_normalization


### PR DESCRIPTION
## Summary

Filled and line contour colours mapped over the raw data range instead of the contour level range. When the levels did not reach the data extremes, every contour collapsed into a narrow mid-colormap band instead of spanning the full colormap. matplotlib normalises contour colours over the level range, so the lowest level takes the bottom of the colormap and the highest the top.

The filled-contour colorbar likewise spanned the raw data min/max, capping the bar below the top level. It now spans the filled level range so the bar and its ticks line up with the bands, matching matplotlib's contourf colorbar.

## Changes

- `src/backends/memory/fortplot_contour_rendering.f90`: normalise contour line, default-level, and filled-band colours over the level range (`min(levels)..max(levels)`), falling back to the data range only when degenerate.
- `src/figures/management/fortplot_figure_colorbar.f90`: filled-contour colorbar `vmin`/`vmax` taken from the contour level range when levels are present.
- `test/colormap/test_contour_level_normalization.f90`: regression test asserting contour endpoints reach the colormap extremes over the level range, and that the old data-range normalization does not.

## Verification

Commands run:
- `OMP_NUM_THREADS=1 fpm build` — passed.
- `OMP_NUM_THREADS=1 fpm run --example contour_demo` — regenerated outputs.
- `make verify-artifacts` — ended `Artifact verification passed.` (ylabel-left stripe and quiver gates green).
- `OMP_NUM_THREADS=1 make test-ci` — `CI essential test suite completed successfully`.
- `OMP_NUM_THREADS=1 fpm test --target test_contour_level_normalization` — `PASS`.

Before -> after vs matplotlib:

- mixed_plot (contour lines, levels [-4,-2,0,2,4] over data [-9,9]):
  - before: lines spanned only a narrow blue->green band.
  - after: lines span full viridis (dark purple at -4, blue, teal, green, yellow at +4), matching the reference.
- contour_gaussian (default levels): outer rings now dark purple grading to green at the centre, matching the reference colour progression.
- contour_filled (plasma, colorbar): the verified level set is `[-0.6, -0.4, ..., 1.0]` (data range -0.58..0.84). The colorbar now spans -0.6..1.0 (top reaches the highest level) instead of capping at the raw data max. PDF tick text after the fix: `1.0 0.5 0.0 -0.5` over the full bar; before, the bar topped out at the data maximum (~0.9).

PDF excerpt (contour_filled.pdf, after): `Filled Contour Demo (plasma) 1.0 ... 0.5 ... 0.0 ... -0.5` confirming the bar reaches 1.0.
