### PR TITLE
fix: render streamplot arrowheads as open glyphs

### DIFF
--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -275,19 +275,21 @@ contains
     end subroutine raster_draw_arrow
 
     module subroutine raster_draw_arrowhead(this, x, y, dx, dy, size, style)
-        !! Draw a streamplot-style arrowhead glyph at (x, y) with a fixed
-        !! pixel size. (dx, dy) is a unit direction; size controls head
-        !! length in pixels and does NOT scale with the data range, unlike
-        !! draw_arrow which carries quiver shaft semantics.
+        !! Draw a streamplot-style open arrowhead at (x, y), matching
+        !! matplotlib's FancyArrowPatch "->" glyph: two thin strokes meeting
+        !! at the tip, in the streamline color and line width. (dx, dy) is a
+        !! unit direction in data space; size is matplotlib's arrowsize and
+        !! controls the head length in pixels, independent of the data range.
         class(raster_context), intent(inout) :: this
         real(wp), intent(in) :: x, y, dx, dy, size
         character(len=*), intent(in) :: style
 
-        real(wp) :: arrow_length, arrow_width
-        real(wp) :: norm_dx, norm_dy, perp_x, perp_y
-        real(wp) :: px, py, ddx, ddy, magnitude
-        real(wp) :: x1, y1, x2, y2, x3, y3
-        integer(1) :: r, g, b
+        real(wp), parameter :: head_half_angle = 0.5235987756_wp  ! 30 degrees
+        real(wp) :: head_length, line_w
+        real(wp) :: norm_dx, norm_dy, magnitude
+        real(wp) :: px, py, ddx, ddy
+        real(wp) :: cos_a, sin_a
+        real(wp) :: lx, ly, rx, ry
         associate (dsl => len_trim(style)); end associate
 
         ! Transform tip position to pixel coordinates.
@@ -296,8 +298,9 @@ contains
         py = real(this%plot_area%bottom + this%plot_area%height, wp) - &
              (y - this%y_min)/(this%y_max - this%y_min)*real(this%plot_area%height, wp)
 
-        ! Reuse the data->pixel transform purely to flip Y for screen space;
-        ! direction magnitude is irrelevant since size is a pixel length.
+        ! Convert the data-space unit direction to a screen-space direction
+        ! (the Y axis is flipped and the axes have independent pixel scales),
+        ! then renormalize so the head length is a fixed pixel quantity.
         ddx = dx*(real(this%plot_area%width, wp)/max(1.0_wp, (this%x_max - this%x_min)))
         ddy = -dy*(real(this%plot_area%height, wp)/max(1.0_wp, (this%y_max - &
                                                                 this%y_min)))
@@ -306,25 +309,31 @@ contains
         norm_dx = ddx/magnitude
         norm_dy = ddy/magnitude
 
-        arrow_length = size*8.0_wp
-        arrow_width = arrow_length*0.5_wp
-        perp_x = -norm_dy
-        perp_y = norm_dx
+        ! matplotlib draws the "->" head from the tip backwards. mutation_scale
+        ! is 10*arrowsize points; the visible head spans roughly half of that.
+        head_length = size*6.0_wp
+        line_w = max(1.0_wp, this%raster%current_line_width)
 
-        x1 = px
-        y1 = py
-        x2 = px - arrow_length*norm_dx + arrow_width*perp_x
-        y2 = py - arrow_length*norm_dy + arrow_width*perp_y
-        x3 = px - arrow_length*norm_dx - arrow_width*perp_x
-        y3 = py - arrow_length*norm_dy - arrow_width*perp_y
+        cos_a = cos(head_half_angle)
+        sin_a = sin(head_half_angle)
 
-        call this%raster%get_color_bytes(r, g, b)
-        call fill_triangle(this%raster%image_data, this%width, this%height, &
-                           x1, y1, x2, y2, x3, y3, r, g, b)
+        ! Two backward strokes rotated by +/- the half angle from the
+        ! reverse direction, forming an open V whose vertex is the tip.
+        lx = px - head_length*(norm_dx*cos_a - norm_dy*sin_a)
+        ly = py - head_length*(norm_dy*cos_a + norm_dx*sin_a)
+        rx = px - head_length*(norm_dx*cos_a + norm_dy*sin_a)
+        ry = py - head_length*(norm_dy*cos_a - norm_dx*sin_a)
+
+        call draw_line_distance_aa(this%raster%image_data, this%width, this%height, &
+                                   px, py, lx, ly, this%raster%current_r, &
+                                   this%raster%current_g, this%raster%current_b, line_w)
+        call draw_line_distance_aa(this%raster%image_data, this%width, this%height, &
+                                   px, py, rx, ry, this%raster%current_r, &
+                                   this%raster%current_g, this%raster%current_b, line_w)
 
         this%has_rendered_arrows = .true.
-        this%uses_vector_arrows = .false.
-        this%has_triangular_arrows = .true.
+        this%uses_vector_arrows = .true.
+        this%has_triangular_arrows = .false.
     end subroutine raster_draw_arrowhead
 
 end submodule fortplot_raster_impl

--- a/src/backends/vector/pdf/fortplot_pdf_drawing.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_drawing.f90
@@ -488,13 +488,19 @@ contains
 
         if (index(style, '>') > 0 .or. index(style, '<') > 0 .or. &
             style == 'filled' .or. style == 'open') then
-            call this%write_move(x, y)
-            call this%write_line(left_x, left_y)
-            call this%write_line(right_x, right_y)
-            call this%write_command("h")
             if (style == 'filled') then
+                ! Filled triangular head: close the path and fill+stroke.
+                call this%write_move(x, y)
+                call this%write_line(left_x, left_y)
+                call this%write_line(right_x, right_y)
+                call this%write_command("h")
                 call this%write_command("B")
             else
+                ! Open "->" head: two strokes meeting at the tip, no back edge,
+                ! matching matplotlib's FancyArrowPatch glyph.
+                call this%write_move(left_x, left_y)
+                call this%write_line(x, y)
+                call this%write_line(right_x, right_y)
                 call this%write_stroke()
             end if
         end if


### PR DESCRIPTION
Match matplotlib's streamplot arrowhead glyph in the raster (PNG) and PDF backends.

## Background

A direct comparison against matplotlib's `streamplot(..., density=1.0)` on the
demo circular flow shows the streamline trajectories were already matplotlib-faithful:

- matplotlib: 62 streamlines, 905 vertices, avg 14.6 verts, 31 streamlines < 10 verts
- fortplot:   61 streamlines, 865 vertices, avg 14.2 verts, 33 streamlines < 10 verts

The "fragmented" look is present in matplotlib too; the trajectory lengths,
counts, and break pattern already align. The remaining structural mismatch was
the arrowhead glyph: fortplot drew large solid filled triangles (raster) and a
closed stroked triangle outline (PDF), while matplotlib draws a thin open "->"
V whose vertex is the tip, in the streamline color and line width. The heavier
glyphs also visually swamped nearby short arcs, making arrows look fewer.

## Change

- Raster `raster_draw_arrowhead`: draw two antialiased strokes meeting at the
  tip (half-angle 30 deg), using the current streamline color and line width,
  head length scaled from `arrowsize`. No more solid triangle.
- PDF `draw_pdf_arrowhead`: for `->`/open styles, move to one barb, line to the
  tip, line to the other barb, stroke (open V, no back edge). `filled` style
  keeps the closed fill+stroke path.
- Quiver `raster_draw_arrow` is untouched and keeps its filled triangular head.

Arrow count and placement were already one-per-streamline at the trajectory
mid-arc-length point, matching matplotlib; only the glyph shape changed.

## Before -> after vs matplotlib

- Arrow glyph: filled triangle / closed triangle outline -> open "->" V (matplotlib match).
- Arrow color/width: solid fill -> streamline color + line width (matplotlib match).
- Arrow direction: tangent to flow, unchanged (already correct).
- Streamline count: 61 vs matplotlib 62, unchanged by this PR.
- Line-mode demo (`arrowsize=0`): unchanged, still matches matplotlib's line demo.

## Verification

Commands run (all from a clean worktree on this branch):

```
fpm build                          # Project compiled successfully.
fpm test --target test_streamplot                 # pass
fpm test --target test_streamplot_arrows          # pass
fpm test --target test_streamplot_arrow_data_ranges  # PASS: streamplot arrow-mode data range preserved
fpm test --target test_streamplot_interface_color # all streamplot interface color tests passed
make test-ci                       # CI essential test suite completed successfully
make verify-artifacts              # Artifact verification passed.
```

`make verify-artifacts` ends with `Artifact verification passed.` with the
quiver and ylabel-left gates green. The regenerated example PNG (arrow variant)
shows thin open arrowheads matching the matplotlib reference; the PDF rendered
to image shows the same open V heads.
