### PR TITLE
fix: preserve 3D projected box aspect ratio

### DIFF
--- a/src/core/fortplot_projection.f90
+++ b/src/core/fortplot_projection.f90
@@ -12,8 +12,23 @@ module fortplot_projection
 
     private
     public :: project_3d_to_2d, get_default_view_angles
+    public :: projected_box_metrics, map_projected_to_axes
 
     real(wp), parameter :: PI = 3.14159265358979323846_wp
+    ! Fraction of the data window the projected cube fills. matplotlib mplot3d
+    ! leaves a margin around the projected box; this matches that framing while
+    ! preserving the projected aspect ratio.
+    real(wp), parameter :: BOX_FILL_FRACTION = 0.9_wp
+
+    type, public :: projected_axes_map_t
+        !! Aspect-preserving mapping from projected 2D coordinates into the data
+        !! window. A single shared pixel scale keeps the projected box from being
+        !! independently stretched on x and y, so the cube stays tilted with the
+        !! correct proportions in every backend.
+        real(wp) :: proj_cx = 0.0_wp, proj_cy = 0.0_wp  ! projected box center
+        real(wp) :: data_cx = 0.0_wp, data_cy = 0.0_wp  ! data window center
+        real(wp) :: scale_x = 1.0_wp, scale_y = 1.0_wp  ! data units per proj unit
+    end type projected_axes_map_t
 
 contains
 
@@ -65,5 +80,72 @@ contains
             if (present(depth)) depth(i) = planar*cos_elev + z3d(i)*sin_elev
         end do
     end subroutine project_3d_to_2d
+
+    subroutine projected_box_metrics(azim, elev, dist, x_min, x_max, y_min, &
+                                     y_max, width_px_per_data, height_px_per_data, &
+                                     map)
+        !! Build the aspect-preserving projection map for one 3D axes box.
+        !!
+        !! Projects the unit cube, then chooses a single pixel scale so the
+        !! projected box fits the data window in pixel space (the window spans
+        !! width_px_per_data*range_x by height_px_per_data*range_y pixels) while
+        !! preserving the projected aspect ratio and centering the box.
+        real(wp), intent(in) :: azim, elev, dist
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        real(wp), intent(in) :: width_px_per_data, height_px_per_data
+        type(projected_axes_map_t), intent(out) :: map
+
+        real(wp) :: x_cube(8), y_cube(8), z_cube(8)
+        real(wp) :: x_proj(8), y_proj(8)
+        real(wp) :: proj_x_min, proj_x_max, proj_y_min, proj_y_max
+        real(wp) :: proj_x_span, proj_y_span
+        real(wp) :: range_x, range_y, win_w_px, win_h_px, scale_px
+
+        x_cube = [0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, &
+                  0.0_wp]
+        y_cube = [0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
+                  1.0_wp]
+        z_cube = [0.0_wp, 0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 1.0_wp, &
+                  1.0_wp]
+        call project_3d_to_2d(x_cube, y_cube, z_cube, azim, elev, dist, &
+                              x_proj, y_proj)
+
+        proj_x_min = minval(x_proj)
+        proj_x_max = maxval(x_proj)
+        proj_y_min = minval(y_proj)
+        proj_y_max = maxval(y_proj)
+        proj_x_span = max(1.0e-12_wp, proj_x_max - proj_x_min)
+        proj_y_span = max(1.0e-12_wp, proj_y_max - proj_y_min)
+
+        map%proj_cx = 0.5_wp*(proj_x_min + proj_x_max)
+        map%proj_cy = 0.5_wp*(proj_y_min + proj_y_max)
+        map%data_cx = 0.5_wp*(x_min + x_max)
+        map%data_cy = 0.5_wp*(y_min + y_max)
+
+        range_x = max(1.0e-12_wp, x_max - x_min)
+        range_y = max(1.0e-12_wp, y_max - y_min)
+        win_w_px = max(1.0e-12_wp, abs(width_px_per_data)*range_x)
+        win_h_px = max(1.0e-12_wp, abs(height_px_per_data)*range_y)
+
+        ! Single pixel scale that fits the projected box in both directions,
+        ! preserving the projected aspect ratio.
+        scale_px = BOX_FILL_FRACTION*min(win_w_px/proj_x_span, &
+                                         win_h_px/proj_y_span)
+
+        ! Convert that shared pixel scale back into per-axis data units so the
+        ! backend pixel transform reproduces the chosen pixel scale exactly.
+        map%scale_x = scale_px/max(1.0e-12_wp, abs(width_px_per_data))
+        map%scale_y = scale_px/max(1.0e-12_wp, abs(height_px_per_data))
+    end subroutine projected_box_metrics
+
+    elemental subroutine map_projected_to_axes(map, x_proj, y_proj, x_out, y_out)
+        !! Apply an aspect-preserving projection map to one projected point.
+        type(projected_axes_map_t), intent(in) :: map
+        real(wp), intent(in) :: x_proj, y_proj
+        real(wp), intent(out) :: x_out, y_out
+
+        x_out = map%data_cx + (x_proj - map%proj_cx)*map%scale_x
+        y_out = map%data_cy + (y_proj - map%proj_cy)*map%scale_y
+    end subroutine map_projected_to_axes
 
 end module fortplot_projection

--- a/src/figures/fortplot_3d_data_rendering.f90
+++ b/src/figures/fortplot_3d_data_rendering.f90
@@ -5,7 +5,8 @@ module fortplot_3d_data_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context, only: plot_context
     use fortplot_plot_data, only: plot_data_t
-    use fortplot_projection, only: project_3d_to_2d
+    use fortplot_projection, only: project_3d_to_2d, projected_axes_map_t, &
+                                   projected_box_metrics, map_projected_to_axes
     use fortplot_rendering, only: render_line_plot, render_markers
     implicit none
 
@@ -31,7 +32,9 @@ contains
         call project_3d_samples_to_axes(plot%x, plot%y, plot%z, x_min, x_max, &
                                         y_min, y_max, z_min, z_max, &
                                         backend%view_azim, backend%view_elev, &
-                                        backend%view_dist, x_out, y_out)
+                                        backend%view_dist, &
+                                        backend%get_width_scale(), &
+                                        backend%get_height_scale(), x_out, y_out)
         projected = plot
         call replace_xy(projected, x_out, y_out)
         call render_line_plot(backend, projected, 'linear', 'linear', 1.0_wp)
@@ -51,7 +54,9 @@ contains
         call project_3d_samples_to_axes(plot%x, plot%y, plot%z, x_min, x_max, &
                                         y_min, y_max, z_min, z_max, &
                                         backend%view_azim, backend%view_elev, &
-                                        backend%view_dist, x_out, y_out)
+                                        backend%view_dist, &
+                                        backend%get_width_scale(), &
+                                        backend%get_height_scale(), x_out, y_out)
         projected = plot
         call replace_xy(projected, x_out, y_out)
         call render_markers(backend, projected, x_min, x_max, y_min, y_max, &
@@ -60,17 +65,22 @@ contains
 
     subroutine project_3d_samples_to_axes(x, y, z, x_min, x_max, y_min, y_max, &
                                           z_min, z_max, azim, elev, dist, &
+                                          width_scale, height_scale, &
                                           x_out, y_out)
+        !! Project 3D samples into the data window using a single shared scale
+        !! that preserves the projected box aspect ratio (no independent x/y
+        !! stretch). width_scale/height_scale are the backend pixel scales
+        !! (pixels per data unit) used to keep the box aspect correct on screen.
         real(wp), contiguous, intent(in) :: x(:), y(:), z(:)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, z_min, z_max
         real(wp), intent(in) :: azim, elev, dist
+        real(wp), intent(in) :: width_scale, height_scale
         real(wp), allocatable, intent(out) :: x_out(:), y_out(:)
 
         real(wp), allocatable :: x_norm(:), y_norm(:), z_norm(:)
         real(wp), allocatable :: x_proj(:), y_proj(:)
         real(wp) :: range_x, range_y, range_z
-        real(wp) :: proj_x_min, proj_x_max, proj_y_min, proj_y_max
-        real(wp) :: denom_x, denom_y
+        type(projected_axes_map_t) :: map
         integer :: i, n
 
         n = min(size(x), min(size(y), size(z)))
@@ -88,42 +98,14 @@ contains
             z_norm(i) = (z(i) - z_min)/range_z
         end do
 
-        call projected_unit_cube_bounds(azim, elev, dist, proj_x_min, proj_x_max, &
-                                        proj_y_min, proj_y_max)
-        denom_x = max(EPSILON, proj_x_max - proj_x_min)
-        denom_y = max(EPSILON, proj_y_max - proj_y_min)
+        call projected_box_metrics(azim, elev, dist, x_min, x_max, y_min, y_max, &
+                                   width_scale, height_scale, map)
 
         call project_3d_to_2d(x_norm, y_norm, z_norm, azim, elev, dist, &
                               x_proj, y_proj)
 
-        do i = 1, n
-            x_out(i) = x_min + (x_proj(i) - proj_x_min)/denom_x*range_x
-            y_out(i) = y_min + (y_proj(i) - proj_y_min)/denom_y*range_y
-        end do
+        call map_projected_to_axes(map, x_proj, y_proj, x_out, y_out)
     end subroutine project_3d_samples_to_axes
-
-    subroutine projected_unit_cube_bounds(azim, elev, dist, x_min, x_max, &
-                                          y_min, y_max)
-        real(wp), intent(in) :: azim, elev, dist
-        real(wp), intent(out) :: x_min, x_max, y_min, y_max
-
-        real(wp) :: x_cube(8), y_cube(8), z_cube(8)
-        real(wp) :: x_proj(8), y_proj(8)
-
-        x_cube = [0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, &
-                  0.0_wp]
-        y_cube = [0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
-                  1.0_wp]
-        z_cube = [0.0_wp, 0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 1.0_wp, &
-                  1.0_wp]
-
-        call project_3d_to_2d(x_cube, y_cube, z_cube, azim, elev, dist, &
-                              x_proj, y_proj)
-        x_min = minval(x_proj)
-        x_max = maxval(x_proj)
-        y_min = minval(y_proj)
-        y_max = maxval(y_proj)
-    end subroutine projected_unit_cube_bounds
 
     logical function valid_3d_samples(plot)
         type(plot_data_t), intent(in) :: plot

--- a/src/figures/fortplot_surface_rendering.f90
+++ b/src/figures/fortplot_surface_rendering.f90
@@ -7,7 +7,8 @@ module fortplot_surface_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_plot_data, only: plot_data_t
-    use fortplot_projection, only: project_3d_to_2d
+    use fortplot_projection, only: project_3d_to_2d, projected_axes_map_t, &
+                                   projected_box_metrics, map_projected_to_axes
     use fortplot_colormap, only: colormap_value_to_color
     implicit none
 
@@ -31,10 +32,7 @@ contains
         real(wp) :: x_min, x_max, y_min, y_max, z_min, z_max
         real(wp) :: range_x, range_y, range_z
         real(wp) :: azim, elev, dist
-        real(wp) :: x_corners(8), y_corners(8), z_corners(8)
-        real(wp) :: x_proj_corners(8), y_proj_corners(8)
-        real(wp) :: proj_x_min, proj_x_max, proj_y_min, proj_y_max
-        real(wp) :: denom_x, denom_y
+        type(projected_axes_map_t) :: map
         logical :: transposed
         character(len=20) :: cmap
 
@@ -84,21 +82,11 @@ contains
         elev = backend%view_elev
         dist = backend%view_dist
 
-        x_corners = [0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, &
-                     0.0_wp]
-        y_corners = [0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
-                     1.0_wp]
-        z_corners = [0.0_wp, 0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp, 1.0_wp, &
-                     1.0_wp]
-        call project_3d_to_2d(x_corners, y_corners, z_corners, azim, elev, &
-                              dist, x_proj_corners, y_proj_corners)
-
-        proj_x_min = minval(x_proj_corners)
-        proj_x_max = maxval(x_proj_corners)
-        proj_y_min = minval(y_proj_corners)
-        proj_y_max = maxval(y_proj_corners)
-        denom_x = max(1.0e-9_wp, proj_x_max - proj_x_min)
-        denom_y = max(1.0e-9_wp, proj_y_max - proj_y_min)
+        ! Aspect-preserving projection map shared with the data and frame so the
+        ! surface, curves, and box stay registered (no independent x/y stretch).
+        call projected_box_metrics(azim, elev, dist, x_min, x_max, y_min, y_max, &
+                                   backend%get_width_scale(), &
+                                   backend%get_height_scale(), map)
 
         cmap = 'viridis'
         if (allocated(plot%surface_colormap)) then
@@ -110,22 +98,19 @@ contains
         if (plot%surface_filled) then
             call render_filled_surface(backend, plot, nx, ny, transposed, &
                                        x_min, y_min, z_min, range_x, range_y, &
-                                       range_z, azim, elev, dist, proj_x_min, &
-                                       proj_y_min, denom_x, denom_y, cmap, &
+                                       range_z, azim, elev, dist, map, cmap, &
                                        plot%surface_edgecolor, &
                                        plot%surface_linewidth)
         else
             call render_wireframe_surface(backend, plot, nx, ny, transposed, &
                                           x_min, y_min, z_min, range_x, range_y, &
-                                          range_z, azim, elev, dist, proj_x_min, &
-                                          proj_y_min, denom_x, denom_y)
+                                          range_z, azim, elev, dist, map)
         end if
     end subroutine render_surface_plot
 
     subroutine render_filled_surface(backend, plot, nx, ny, transposed, &
                                      x_min, y_min, z_min, range_x, range_y, &
-                                     range_z, azim, elev, dist, proj_x_min, &
-                                     proj_y_min, denom_x, denom_y, cmap, &
+                                     range_z, azim, elev, dist, map, cmap, &
                                      edge_color, edge_linewidth)
         !! Render filled surface quads using painters algorithm with interleaved
         !! wireframe edges for correct depth ordering
@@ -136,7 +121,7 @@ contains
         real(wp), intent(in) :: x_min, y_min, z_min
         real(wp), intent(in) :: range_x, range_y, range_z
         real(wp), intent(in) :: azim, elev, dist
-        real(wp), intent(in) :: proj_x_min, proj_y_min, denom_x, denom_y
+        type(projected_axes_map_t), intent(in) :: map
         character(len=*), intent(in) :: cmap
         real(wp), intent(in) :: edge_color(3)
         real(wp), intent(in) :: edge_linewidth
@@ -166,8 +151,7 @@ contains
             call index_to_ij(sorted_idx(k), nx - 1, i, j)
             call render_filled_quad(backend, plot, i, j, transposed, x_min, &
                                     y_min, z_min, range_x, range_y, range_z, &
-                                    azim, elev, dist, proj_x_min, proj_y_min, &
-                                    denom_x, denom_y, cmap, edge_color, &
+                                    azim, elev, dist, map, cmap, edge_color, &
                                     edge_linewidth)
         end do
     end subroutine render_filled_surface
@@ -237,8 +221,7 @@ contains
 
     subroutine render_filled_quad(backend, plot, i, j, transposed, x_min, &
                                   y_min, z_min, range_x, range_y, range_z, &
-                                  azim, elev, dist, proj_x_min, proj_y_min, &
-                                  denom_x, denom_y, cmap, edge_color, &
+                                  azim, elev, dist, map, cmap, edge_color, &
                                   edge_linewidth)
         !! Project, shade, fill, and edge a single surface quad
         class(plot_context), intent(inout) :: backend
@@ -248,7 +231,7 @@ contains
         real(wp), intent(in) :: x_min, y_min, z_min
         real(wp), intent(in) :: range_x, range_y, range_z
         real(wp), intent(in) :: azim, elev, dist
-        real(wp), intent(in) :: proj_x_min, proj_y_min, denom_x, denom_y
+        type(projected_axes_map_t), intent(in) :: map
         character(len=*), intent(in) :: cmap
         real(wp), intent(in) :: edge_color(3)
         real(wp), intent(in) :: edge_linewidth
@@ -264,8 +247,7 @@ contains
         call project_3d_to_2d(x_norm, y_norm, z_norm, azim, elev, dist, &
                               x_proj, y_proj)
 
-        x_final = x_min + (x_proj - proj_x_min)/denom_x*range_x
-        y_final = y_min + (y_proj - proj_y_min)/denom_y*range_y
+        call map_projected_to_axes(map, x_proj, y_proj, x_final, y_final)
 
         call colormap_value_to_color(z_avg, z_min, z_min + range_z, cmap, &
                                      quad_color)
@@ -332,8 +314,7 @@ contains
 
     subroutine render_wireframe_surface(backend, plot, nx, ny, transposed, &
                                         x_min, y_min, z_min, range_x, range_y, &
-                                        range_z, azim, elev, dist, proj_x_min, &
-                                        proj_y_min, denom_x, denom_y)
+                                        range_z, azim, elev, dist, map)
         !! Render wireframe lines for surface plot
         class(plot_context), intent(inout) :: backend
         type(plot_data_t), intent(in) :: plot
@@ -342,7 +323,7 @@ contains
         real(wp), intent(in) :: x_min, y_min, z_min
         real(wp), intent(in) :: range_x, range_y, range_z
         real(wp), intent(in) :: azim, elev, dist
-        real(wp), intent(in) :: proj_x_min, proj_y_min, denom_x, denom_y
+        type(projected_axes_map_t), intent(in) :: map
 
         integer :: i, j, m, max_points
         real(wp), allocatable :: x_vals(:), y_vals(:), z_vals(:)
@@ -383,12 +364,8 @@ contains
             call project_3d_to_2d(x_norm(1:m), y_norm(1:m), z_norm(1:m), &
                                   azim, elev, dist, x_proj(1:m), y_proj(1:m))
 
-            do i = 1, m
-                x_final(i) = x_min + (x_proj(i) - proj_x_min)/denom_x* &
-                             range_x
-                y_final(i) = y_min + (y_proj(i) - proj_y_min)/denom_y* &
-                             range_y
-            end do
+            call map_projected_to_axes(map, x_proj(1:m), y_proj(1:m), &
+                                       x_final(1:m), y_final(1:m))
 
             do i = 1, m - 1
                 call backend%line(x_final(i), y_final(i), x_final(i + 1), &
@@ -413,12 +390,8 @@ contains
             call project_3d_to_2d(x_norm(1:m), y_norm(1:m), z_norm(1:m), &
                                   azim, elev, dist, x_proj(1:m), y_proj(1:m))
 
-            do j = 1, m
-                x_final(j) = x_min + (x_proj(j) - proj_x_min)/denom_x* &
-                             range_x
-                y_final(j) = y_min + (y_proj(j) - proj_y_min)/denom_y* &
-                             range_y
-            end do
+            call map_projected_to_axes(map, x_proj(1:m), y_proj(1:m), &
+                                       x_final(1:m), y_final(1:m))
 
             do j = 1, m - 1
                 call backend%line(x_final(j), y_final(j), x_final(j + 1), &

--- a/src/plotting/fortplot_3d_axes.f90
+++ b/src/plotting/fortplot_3d_axes.f90
@@ -9,7 +9,8 @@ module fortplot_3d_axes
     use fortplot_tick_calculation, only: find_nice_tick_locations, &
                                          format_tick_value_consistent, &
                                          determine_decimal_places_from_step
-    use fortplot_projection, only: project_3d_to_2d
+    use fortplot_projection, only: project_3d_to_2d, projected_axes_map_t, &
+                                   projected_box_metrics, map_projected_to_axes
     use fortplot_3d_box, only: draw_back_panes, draw_pane_gridlines, &
                                draw_back_spines, draw_front_spines, &
                                CORNER_MIN_MIN_MIN, CORNER_MAX_MIN_MIN, &
@@ -105,13 +106,19 @@ contains
 
         real(wp) :: corners_3d(3, 8)
         real(wp) :: azim, elev, dist
+        type(projected_axes_map_t) :: map
 
         azim = ctx%view_azim
         elev = ctx%view_elev
         dist = ctx%view_dist
         call create_unit_cube(corners_3d)
         call project_to_2d(corners_3d, azim, elev, dist, corners_2d, corners_depth)
-        call scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
+        ! Aspect-preserving map shared with the data and surface renderers so
+        ! the frame, gridlines, ticks, and data stay registered.
+        call projected_box_metrics(azim, elev, dist, x_min, x_max, y_min, y_max, &
+                                   ctx%get_width_scale(), ctx%get_height_scale(), &
+                                   map)
+        call scale_to_data_range(corners_2d, map)
     end subroutine project_box_corners
 
     subroutine compute_axis_tick_fractions(axis_min, axis_max, frac, n_frac)
@@ -175,30 +182,20 @@ contains
         corners_2d(2, :) = y2d
     end subroutine project_to_2d
 
-    subroutine scale_to_data_range(corners_2d, x_min, x_max, y_min, y_max)
-        !! Scale projected coordinates to actual data ranges
+    subroutine scale_to_data_range(corners_2d, map)
+        !! Map projected corners into the data window with the shared
+        !! aspect-preserving projection map (no independent x/y stretch).
         real(wp), intent(inout) :: corners_2d(2, 8)
-        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(projected_axes_map_t), intent(in) :: map
 
-        real(wp) :: proj_bounds(4), data_ranges(2)
+        real(wp) :: x_out, y_out
         integer :: i
 
-        ! Find projection bounds
-        proj_bounds(1) = minval(corners_2d(1, :))  ! proj_x_min
-        proj_bounds(2) = maxval(corners_2d(1, :))  ! proj_x_max
-        proj_bounds(3) = minval(corners_2d(2, :))  ! proj_y_min
-        proj_bounds(4) = maxval(corners_2d(2, :))  ! proj_y_max
-
-        ! Calculate scaling factors
-        data_ranges(1) = max(EPSILON, x_max - x_min)
-        data_ranges(2) = max(EPSILON, y_max - y_min)
-
-        ! Scale all corners
         do i = 1, 8
-            corners_2d(1, i) = x_min + (corners_2d(1, i) - proj_bounds(1))/ &
-                            max(EPSILON, proj_bounds(2) - proj_bounds(1))*data_ranges(1)
-            corners_2d(2, i) = y_min + (corners_2d(2, i) - proj_bounds(3))/ &
-                            max(EPSILON, proj_bounds(4) - proj_bounds(3))*data_ranges(2)
+            call map_projected_to_axes(map, corners_2d(1, i), corners_2d(2, i), &
+                                       x_out, y_out)
+            corners_2d(1, i) = x_out
+            corners_2d(2, i) = y_out
         end do
     end subroutine scale_to_data_range
 

--- a/test/3d/test_3d.f90
+++ b/test/3d/test_3d.f90
@@ -29,7 +29,7 @@ program test_3d
     call test_type_detection()
     call test_line_projection()
     call test_scatter_projection()
-    call test_project_3d_samples_fill_axis_box()
+    call test_project_3d_samples_aspect_preserving()
     call test_tick_orientation()
     call test_axes_pdf_ticks()
     call test_pdf_3d_plot_rendering()
@@ -243,11 +243,22 @@ contains
         passed_tests = passed_tests + 1
     end subroutine test_scatter_projection
 
-    subroutine test_project_3d_samples_fill_axis_box()
+    subroutine test_project_3d_samples_aspect_preserving()
+        !! The sample projection maps the 3D box into the data window with a
+        !! single shared scale that preserves the projected aspect ratio
+        !! (matplotlib mplot3d), not the old independent x/y stretch that filled
+        !! [-2,2]x[-3,3] exactly. With unit pixel scales the projected unit cube
+        !! has bounding box 1.3660254 wide by 1.5490381 tall; a 0.9 fill of the
+        !! 4x6 window scales by 0.9*min(4/1.3660254, 6/1.5490381) = 2.6352..., so
+        !! the box centers at (0,0) and spans +/-1.8 in x and +/-2.0411543 in y,
+        !! keeping the projected aspect ratio identical.
         real(wp) :: x(8), y(8), z(8)
         real(wp), allocatable :: x_out(:), y_out(:)
         real(wp) :: azim, elev, dist
-        real(wp) :: tol
+        real(wp) :: tol, x_span, y_span
+        real(wp) :: proj_aspect, out_aspect
+        real(wp), parameter :: PROJ_X_SPAN = 1.3660254037844388_wp
+        real(wp), parameter :: PROJ_Y_SPAN = 1.5490381056766580_wp
 
         total_tests = total_tests + 1
 
@@ -259,25 +270,48 @@ contains
              4.5_wp, 4.5_wp]
 
         call get_default_view_angles(azim, elev, dist)
+        ! Unit pixel scales (1 pixel per data unit on both axes) make the
+        ! pixel aspect equal the data-window aspect for a clean assertion.
         call project_3d_samples_to_axes(x, y, z, -2.0_wp, 2.0_wp, -3.0_wp, &
                                         3.0_wp, 0.5_wp, 4.5_wp, azim, elev, &
-                                        dist, x_out, y_out)
+                                        dist, 1.0_wp, 1.0_wp, x_out, y_out)
 
-        tol = get_windows_safe_tolerance(1.0e-12_wp)
-        if (abs(minval(x_out) + 2.0_wp) > tol .or. &
-            abs(maxval(x_out) - 2.0_wp) > tol) then
-            print *, 'FAIL: test_project_3d_samples_fill_axis_box - x bounds'
-            return
-        end if
-        if (abs(minval(y_out) + 3.0_wp) > tol .or. &
-            abs(maxval(y_out) - 3.0_wp) > tol) then
-            print *, 'FAIL: test_project_3d_samples_fill_axis_box - y bounds'
+        tol = get_windows_safe_tolerance(1.0e-10_wp)
+
+        ! Box centered at the data-window center (0, 0).
+        if (abs(minval(x_out) + maxval(x_out)) > tol .or. &
+            abs(minval(y_out) + maxval(y_out)) > tol) then
+            print *, 'FAIL: test_project_3d_samples_aspect_preserving - not centered'
             return
         end if
 
-        print *, '  PASS: test_project_3d_samples_fill_axis_box'
+        ! Exact aspect-preserving bounds: x in [-1.8, 1.8], y in
+        ! [-2.0411543, 2.0411543].
+        if (abs(minval(x_out) + 1.8_wp) > tol .or. &
+            abs(maxval(x_out) - 1.8_wp) > tol) then
+            print *, 'FAIL: test_project_3d_samples_aspect_preserving - x bounds'
+            return
+        end if
+        if (abs(minval(y_out) + 2.0411542731880100_wp) > tol .or. &
+            abs(maxval(y_out) - 2.0411542731880100_wp) > tol) then
+            print *, 'FAIL: test_project_3d_samples_aspect_preserving - y bounds'
+            return
+        end if
+
+        ! The output aspect ratio (pixel scales equal) must match the projected
+        ! cube aspect ratio, i.e. no independent x/y stretch.
+        x_span = maxval(x_out) - minval(x_out)
+        y_span = maxval(y_out) - minval(y_out)
+        proj_aspect = PROJ_X_SPAN/PROJ_Y_SPAN
+        out_aspect = x_span/y_span
+        if (abs(out_aspect - proj_aspect) > tol) then
+            print *, 'FAIL: test_project_3d_samples_aspect_preserving - aspect lost'
+            return
+        end if
+
+        print *, '  PASS: test_project_3d_samples_aspect_preserving'
         passed_tests = passed_tests + 1
-    end subroutine test_project_3d_samples_fill_axis_box
+    end subroutine test_project_3d_samples_aspect_preserving
 
     subroutine test_tick_orientation()
         !! Test 3D axis tick orientations


### PR DESCRIPTION
Replaces the independent per-axis normalization used by the 3D renderers with a single shared scale that preserves the projected box aspect ratio, so 3D plots render as a tilted cube with the floor grid exposed (matplotlib mplot3d defaults: elevation 30, azimuth -60) instead of a box stretched to fill the data window.

## Root cause

Three renderers (sample lines/markers, surface, 3D axes frame) mapped projected coordinates into the data window with separate `denom_x`/`denom_y` divisors:

    x_out = x_min + (x_proj - proj_x_min)/denom_x*range_x
    y_out = y_min + (y_proj - proj_y_min)/denom_y*range_y

That stretches the projected box to exactly fill `[x_min,x_max] x [y_min,y_max]` independently on each axis, which the backend pixel transform then maps onto the full plot area. The projected aspect ratio is destroyed and the cube flattens to near head-on.

## Fix

A shared aspect-preserving map (`projected_box_metrics` / `map_projected_to_axes` in `fortplot_projection`) projects the unit cube once, then chooses one pixel scale that fits the projected box into the data window in pixel space while preserving the projected aspect ratio and centering the box. The map is used by the sample renderer, the filled and wireframe surface renderers, and the 3D axes frame so data, surfaces, gridlines, and spines stay registered. Default view angles were already elev=30/azim=-60. A 0.9 fill fraction reproduces matplotlib's framing margin. Depth ordering (painter sort) is unchanged.

## Recalibrated test

`test_project_3d_samples_fill_axis_box` asserted that the projected samples fill `[-2,2] x [-3,3]` exactly to 1e-12 - this encoded the old aspect-destroying stretch. Renamed to `test_project_3d_samples_aspect_preserving` and recalibrated to the new mapping: with unit pixel scales the projected unit cube (bbox 1.3660254 wide by 1.5490381 tall) at 0.9 fill of the 4x6 window scales by 0.9*min(4/1.3660254, 6/1.5490381) = 2.6352..., so the box centers at (0,0) and spans +/-1.8 in x and +/-2.0411543 in y. The test now also asserts the output aspect ratio equals the projected cube aspect ratio (0.8818540), i.e. no independent x/y stretch. The reference values are derived directly from the redesigned mapping. No coordinate-pinning tests other than this one existed; the depth-ordering and projection-formula tests (`test_filled_surface_depth_ordered_wireframe`, `test_projection_elevation_rotation`) check operator counts and the raw `project_3d_to_2d` formula, both untouched.

## Before -> after vs matplotlib

- Cube tilt: was near head-on / flattened -> now tilted with floor grid exposed, matching `/tmp/mpl_parity/3d_plotting` references for helix, paraboloid, gaussian, scatter.
- Projected aspect ratio: was distorted by independent x/y fill -> now preserved at 0.8818540 (projected unit-cube x-span/y-span).
- Box framing: was filling the full plot area -> now 0.9 fill, centered, with matplotlib-like margin.
- Data/frame registration: helix curve and surfaces now sit inside and registered to the box frame in both PNG (raster) and PDF (vector) backends.
- Marker types, colors, legend, tick labels unchanged and correct.

## Verification

Commands run:

    OMP_NUM_THREADS=1 fpm build            # compiled successfully
    OMP_NUM_THREADS=1 fpm run --example 3d_plotting
    OMP_NUM_THREADS=1 fpm test --target test_3d              # 14/14 PASS
    OMP_NUM_THREADS=1 fpm test --target test_3d_backend_parity   # PASS
    OMP_NUM_THREADS=1 fpm test --target test_surface_plot_storage # PASS
    make verify-artifacts                  # "Artifact verification passed." (quiver + ylabel gates green)
    make test-ci                           # "CI essential test suite completed successfully"

Failing-before: `test_project_3d_samples_fill_axis_box` asserted x_out in [-2,2], y_out in [-3,3] (old stretch). Passing-after: `test_project_3d_samples_aspect_preserving` asserts centered box, x_out in [-1.8,1.8], y_out in [-2.0411543,2.0411543], aspect 0.8818540.

3D PDF tick labels verified via pdftotext on the generated axes PDF:

    3D Tick Orientation Test 4 3 2 1 0 1.0 0.5 0.0 -0.5 -1.0 1.0 0.5 0.0 -0.5 -1.0

Both raster and vector backends render the same tilted, aspect-preserving box.
