### PR TITLE
fix: render negative tick labels with Unicode minus

### DIFF
--- a/src/backends/vector/pdf/fortplot_pdf_objects.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_objects.f90
@@ -254,7 +254,15 @@ contains
         call write_pdf_line(unit, '/Type /Font')
         call write_pdf_line(unit, '/Subtype /Type1')
         call write_pdf_line(unit, '/BaseFont /Helvetica')
-        call write_pdf_line(unit, '/Encoding /WinAnsiEncoding')
+        ! WinAnsiEncoding lacks the math minus glyph that matplotlib uses for
+        ! negative labels. Remap the unused control slot 31 to Helvetica's
+        ! /minus glyph (U+2212) via a Differences array so negative ticks
+        ! render and extract as a true typographic minus, not a hyphen.
+        call write_pdf_line(unit, '/Encoding <<')
+        call write_pdf_line(unit, '  /Type /Encoding')
+        call write_pdf_line(unit, '  /BaseEncoding /WinAnsiEncoding')
+        call write_pdf_line(unit, '  /Differences [31 /minus]')
+        call write_pdf_line(unit, '>>')
         call write_pdf_line(unit, '>>')
         call write_pdf_line(unit, 'endobj')
     end subroutine write_helvetica_font_object

--- a/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
@@ -103,6 +103,21 @@ contains
         found = .false.
 
         select case (codepoint)
+        case (8722)
+            ! U+2212 MINUS SIGN: the Helvetica font object remaps code 31
+            ! (octal \037) to the /minus glyph via a Differences array, so
+            ! this renders and extracts as a true typographic minus, matching
+            ! matplotlib's negative tick labels.
+            escape_seq = achar(92)//'037'
+            found = .true.
+        case (8211)
+            ! U+2013 EN DASH maps directly to the WinAnsi en dash.
+            escape_seq = achar(92)//'226'
+            found = .true.
+        case (8212)
+            ! U+2014 EM DASH maps to the WinAnsi em dash (octal \227).
+            escape_seq = achar(92)//'227'
+            found = .true.
         case (188)
             escape_seq = achar(92)//'274'
             found = .true.

--- a/src/backends/vector/pdf/fortplot_pdf_text_metrics.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_text_metrics.f90
@@ -134,6 +134,15 @@ contains
 
         if (codepoint >= 0 .and. codepoint <= 255) then
             wu = helvetica_width_table(codepoint)
+        else if (codepoint == 8722) then
+            ! U+2212 minus renders via the Helvetica /minus glyph.
+            wu = 584
+        else if (codepoint == 8211) then
+            ! U+2013 en dash renders as the WinAnsi en dash.
+            wu = 556
+        else if (codepoint == 8212) then
+            ! U+2014 em dash.
+            wu = 1000
         else
             wu = 500
         end if

--- a/src/text/truetype/fortplot_truetype.f90
+++ b/src/text/truetype/fortplot_truetype.f90
@@ -121,7 +121,7 @@ contains
             advance_width = 0; left_side_bearing = 0
             return
         end if
-        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        glyph_index = resolve_glyph_index(self, codepoint)
         call tt_get_glyph_hmetrics(self%data, self%hhea, self%hmtx, &
             glyph_index, advance_width, left_side_bearing)
     end subroutine font_hmetrics
@@ -136,7 +136,7 @@ contains
             glyph_index = 0
             return
         end if
-        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        glyph_index = resolve_glyph_index(self, codepoint)
     end function font_find_glyph
 
     subroutine font_bitmap_box(self, codepoint, scale_x, scale_y, &
@@ -150,7 +150,7 @@ contains
 
         ix0 = 0; iy0 = 0; ix1 = 0; iy1 = 0
         if (.not. self%initialized) return
-        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        glyph_index = resolve_glyph_index(self, codepoint)
         call tt_get_glyph_bitmap_box(self%data, self%loca, self%glyf, &
             self%index_to_loc_format, self%num_glyphs, glyph_index, &
             scale_x, scale_y, ix0, iy0, ix1, iy1)
@@ -178,7 +178,7 @@ contains
         if (.not. self%initialized) return
         if (scale_x == 0.0_dp .and. scale_y == 0.0_dp) return
 
-        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        glyph_index = resolve_glyph_index(self, codepoint)
 
         call tt_get_glyph_shape(self%data, self%loca, self%glyf, &
             self%index_to_loc_format, self%num_glyphs, glyph_index, &
@@ -236,7 +236,7 @@ contains
         if (.not. self%initialized) return
         if (out_w <= 0 .or. out_h <= 0) return
 
-        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        glyph_index = resolve_glyph_index(self, codepoint)
 
         call tt_get_glyph_shape(self%data, self%loca, self%glyf, &
             self%index_to_loc_format, self%num_glyphs, glyph_index, &
@@ -261,5 +261,26 @@ contains
                 ix0, iy0, .true.)
         end if
     end subroutine font_make_bitmap
+
+    function resolve_glyph_index(self, codepoint) result(glyph_index)
+        !! Map a codepoint to a glyph index with typographic fallbacks.
+        !! When a font lacks the requested glyph (cmap returns 0 = .notdef,
+        !! which renders as a tofu box), substitute a near-equivalent that
+        !! the base fonts always carry. U+2212 MINUS and U+2013 EN DASH fall
+        !! back to the ASCII hyphen-minus so negative tick labels never show
+        !! tofu, matching matplotlib's visible minus.
+        class(truetype_font_t), intent(in) :: self
+        integer, intent(in) :: codepoint
+        integer :: glyph_index
+
+        glyph_index = tt_find_glyph_index(self%data, self%index_map, codepoint)
+        if (glyph_index /= 0) return
+
+        select case (codepoint)
+        case (8722, 8211, 8212)  ! U+2212 minus, U+2013 en dash, U+2014 em dash
+            glyph_index = tt_find_glyph_index(self%data, self%index_map, &
+                iachar('-'))
+        end select
+    end function resolve_glyph_index
 
 end module fortplot_truetype

--- a/src/utilities/text/fortplot_unicode.f90
+++ b/src/utilities/text/fortplot_unicode.f90
@@ -15,8 +15,33 @@ module fortplot_unicode
     public :: utf8_to_codepoint
     public :: utf8_char_length
     public :: contains_unicode, is_unicode_char, check_utf8_sequence, is_greek_letter_codepoint
+    public :: ascii_minus_to_unicode
+
+    ! UTF-8 byte sequence for U+2212 MINUS SIGN (E2 88 92)
+    character(len=*), parameter :: UNICODE_MINUS = achar(226)//achar(136)//achar(146)
 
 contains
+
+    function ascii_minus_to_unicode(label) result(converted)
+        !! Replace a leading ASCII hyphen-minus (U+002D) marking a negative
+        !! number with the typographic minus sign U+2212, matching
+        !! matplotlib's default tick/colorbar labels. Only the sign position
+        !! is converted; interior hyphens (none occur in numeric labels) and
+        !! non-negative labels pass through unchanged.
+        character(len=*), intent(in) :: label
+        character(len=len(label)+2) :: converted
+        character(len=:), allocatable :: trimmed
+
+        converted = label
+        trimmed = adjustl(label)
+        if (len_trim(trimmed) < 2) return
+        if (trimmed(1:1) /= '-') return
+        ! Require a digit or decimal point right after the sign so we only
+        ! rewrite numeric labels, never words that begin with a hyphen.
+        if (index('0123456789.', trimmed(2:2)) == 0) return
+
+        converted = UNICODE_MINUS//trim(trimmed(2:))
+    end function ascii_minus_to_unicode
 
     subroutine escape_unicode_for_raster(input_text, escaped_text)
         !! Pass through Unicode for raster rendering (STB TrueType supports Unicode)

--- a/src/utilities/ticks/fortplot_tick_calculation.f90
+++ b/src/utilities/ticks/fortplot_tick_calculation.f90
@@ -7,8 +7,9 @@ module fortplot_tick_calculation
     !! - Linear scale tick generation
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_unicode, only: ascii_minus_to_unicode
     implicit none
-    
+
     intrinsic :: floor, log10
     
     private
@@ -220,6 +221,7 @@ contains
         end if
         
         call ensure_leading_zero(formatted)
+        formatted = ascii_minus_to_unicode(formatted)
     end function format_tick_value_consistent
 
     subroutine ensure_leading_zero(str)

--- a/src/utilities/ticks/fortplot_tick_formatting.f90
+++ b/src/utilities/ticks/fortplot_tick_formatting.f90
@@ -9,6 +9,7 @@ module fortplot_tick_formatting
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_constants, only: SCIENTIFIC_THRESHOLD_HIGH
+    use fortplot_unicode, only: ascii_minus_to_unicode
     implicit none
     
     private
@@ -47,6 +48,7 @@ contains
             call ensure_leading_zero(formatted)
             call remove_trailing_zeros(formatted)
         end if
+        formatted = ascii_minus_to_unicode(formatted)
     end function format_tick_value
 
     function format_tick_value_smart(value, max_chars) result(formatted)
@@ -96,6 +98,7 @@ contains
         end if
         
         call ensure_leading_zero(formatted)
+        formatted = ascii_minus_to_unicode(formatted)
     end function format_tick_value_smart
 
     function format_log_tick_value(value) result(formatted)

--- a/test/regression/test_logarithmic_working.f90
+++ b/test/regression/test_logarithmic_working.f90
@@ -48,6 +48,7 @@ contains
     subroutine test_debug_symlog_range_behavior()
         !! Test symlog-like ranges crossing zero
         character(len=20) :: labels(5)
+        character(len=20) :: decoded
         real(wp) :: values(5)
         integer :: i, valid_labels
         logical :: crosses_zero, has_negative, has_positive
@@ -63,7 +64,10 @@ contains
         do i = 1, 5
             if (trim(labels(i)) /= '') then
                 valid_labels = valid_labels + 1
-                read(labels(i), *) values(i)
+                ! Tick labels now carry the typographic minus U+2212 like
+                ! matplotlib; decode it to ASCII before list-directed read.
+                decoded = decode_unicode_minus(labels(i))
+                read(decoded, *) values(i)
                 
                 if (values(i) < 0.0_wp) has_negative = .true.
                 if (values(i) > 0.0_wp) has_positive = .true.
@@ -83,5 +87,22 @@ contains
         
         ! This test validates that zero-crossing ranges are handled
     end subroutine test_debug_symlog_range_behavior
+
+    function decode_unicode_minus(label) result(ascii_label)
+        !! Replace a leading U+2212 (UTF-8 E2 88 92) with ASCII '-' so the
+        !! numeric value can be recovered by list-directed read.
+        character(len=*), intent(in) :: label
+        character(len=len(label)) :: ascii_label
+        character(len=:), allocatable :: t
+
+        t = adjustl(label)
+        if (len(t) >= 3) then
+            if (t(1:3) == achar(226)//achar(136)//achar(146)) then
+                ascii_label = '-'//t(4:)
+                return
+            end if
+        end if
+        ascii_label = label
+    end function decode_unicode_minus
 
 end program test_logarithmic_working


### PR DESCRIPTION
## Summary

Negative tick and colorbar labels emitted the ASCII hyphen U+002D, a visibly shorter bar than matplotlib's default typographic minus U+2212. The shared numeric formatters (`format_tick_value_consistent`, `format_tick_value_smart`, `format_tick_value`) now emit U+2212, and both raster and vector backends render it cleanly with no tofu and no PNG/PDF divergence.

- PNG: the TrueType backend renders the active font's U+2212 glyph directly (DejaVu/Liberation carry it). A glyph-index fallback maps U+2212, en dash, and em dash to the ASCII hyphen-minus when a font lacks the glyph, so .notdef tofu cannot appear.
- PDF: base-14 Helvetica WinAnsi has no minus glyph. The Helvetica font object now adds a `/Differences [31 /minus]` array, and the escape path emits octal 037 for U+2212. The label renders as a true minus and extracts as U+2212. En dash / em dash map to their WinAnsi codes. Helvetica advance widths updated (minus 584, en dash 556, em dash 1000).
- ASCII backend keeps converting U+2212 to a plain hyphen, so text output is unchanged.

## Before -> after vs matplotlib

X axis of scatter_gaussian (PNG): before `-3 -2 -1` with short ASCII hyphens; after `−3 −2 −1` rendering the font U+2212 glyph, matching matplotlib's wide minus bar. Tick positions, counts, and ranges unchanged.

styling_demo/scatter_plot.pdf Y ticks: before `-0.25 -0.50 -0.75 -1.00`; after `−0.25 −0.50 −0.75 −1.00`.

## Verification

Commands run:

- `fpm build` succeeds.
- `fpm run --example scatter_demo`, `fpm run --example styling_demo`; read PNGs against the matplotlib reference. Negative ticks render as a wide minus, no tofu.
- `pdftoppm` render of scatter_plot.pdf shows clean minus glyphs.
- `pdftotext styling_demo/scatter_plot.pdf` extracts the negative ticks as U+2212 (bytes E2 88 92 confirmed via hexdump), zero `?` characters in any styling PDF.
- `make verify-artifacts` ends with `Artifact verification passed.` The quiver negative-axis-label gate (regex `[-−][0-9]`) and the ylabel gate stay green; the PDF now satisfies the gate with a real U+2212.
- `make test-ci` passes.
- `fpm test` full suite exits 0.

## Recalibrated test

`test/regression/test_logarithmic_working.f90` parses tick labels with list-directed read to recover their numeric values. With U+2212 in the label, the read raised `Bad real number in item 1 of list input`. The test now decodes the leading U+2212 back to ASCII `-` before reading. This recalibrates the test to the new matplotlib-correct label content; it does not weaken any assertion (it still verifies the symlog-like range spans negative and positive values).