### PR TITLE
fix: route hist/bar/scatter to active subplot (#2021)

### DIFF
--- a/src/figures/core/fortplot_figure_core_impl_layout.f90
+++ b/src/figures/core/fortplot_figure_core_impl_layout.f90
@@ -127,6 +127,52 @@ contains
                                   linestyle, color, self%state%colors, 6)
     end subroutine subplot_plot
 
+    module subroutine relocate_last_plot_to_subplot(self)
+        !! Copy the most recently added figure-level plot into the currently
+        !! selected subplot. Plot commands other than plot() (hist, bar,
+        !! scatter, ...) build their plot_data into the figure-level plots
+        !! array; when a subplot grid is active that array is never rendered,
+        !! so the data silently vanishes (issue #2021). Mirroring the entry
+        !! into the active subplot makes those commands honour subplot
+        !! selection exactly like plot() does.
+        !!
+        !! The figure-level slot is left in place rather than removed: the add
+        !! routines assume monotonically growing slots and reuse would
+        !! double-allocate plot storage. The figure-level array is not rendered
+        !! while a subplot grid is active, so the retained copy is inert.
+        class(figure_t), intent(inout) :: self
+        integer :: idx, rows, cols, row, col, sidx
+        type(plot_data_t), allocatable :: grown(:)
+
+        rows = self%subplot_rows
+        cols = self%subplot_cols
+        idx = self%current_subplot
+        if (rows <= 0 .or. cols <= 0) return
+        if (idx < 1 .or. idx > rows*cols) return
+        if (.not. allocated(self%subplots_array)) return
+        if (.not. allocated(self%plots)) return
+        if (self%plot_count < 1 .or. self%plot_count > size(self%plots)) return
+
+        row = (idx - 1)/cols + 1
+        col = mod(idx - 1, cols) + 1
+
+        associate (sp => self%subplots_array(row, col))
+            if (.not. allocated(sp%plots)) then
+                allocate (sp%plots(sp%max_plots))
+                sp%plot_count = 0
+            end if
+            sidx = sp%plot_count + 1
+            if (sidx > sp%max_plots) then
+                allocate (grown(sp%max_plots*2))
+                grown(1:sp%plot_count) = sp%plots(1:sp%plot_count)
+                call move_alloc(grown, sp%plots)
+                sp%max_plots = sp%max_plots*2
+            end if
+            sp%plots(sidx) = self%plots(self%plot_count)
+            sp%plot_count = sidx
+        end associate
+    end subroutine relocate_last_plot_to_subplot
+
     module function subplot_plot_count(self, row, col) result(count)
         class(figure_t), intent(in) :: self
         integer, intent(in) :: row, col

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -143,6 +143,7 @@ module fortplot_figure_core
         procedure :: subplots
         procedure :: suptitle
         procedure :: subplot_plot
+        procedure :: relocate_last_plot_to_subplot
         procedure :: subplot_plot_count
         procedure :: subplot_set_title
         procedure :: subplot_set_xlabel
@@ -751,6 +752,10 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             character(len=*), intent(in), optional :: label, linestyle
             real(wp), intent(in), optional :: color(3)
         end subroutine subplot_plot
+
+        module subroutine relocate_last_plot_to_subplot(self)
+            class(figure_t), intent(inout) :: self
+        end subroutine relocate_last_plot_to_subplot
 
         module function subplot_plot_count(self, row, col) result(count)
             class(figure_t), intent(in) :: self

--- a/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
@@ -142,6 +142,7 @@ contains
         call core_hist(fig%plots, fig%state, fig%plot_count, data, bins, density, label, &
                        color_rgb, range, weights, cumulative, orientation, alpha)
         call finalise_histogram(alpha, histtype, stacked, log)
+        call fig%relocate_last_plot_to_subplot()
     end subroutine dispatch_histogram
 
     subroutine compute_weighted_histogram(data, n_bins, range, weights, density, &

--- a/src/interfaces/fortplot_matplotlib_scatter_dispatch.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter_dispatch.f90
@@ -105,6 +105,7 @@ contains
                                 linewidth=lw_effective)
         end if
         call store_scatter_style_arrays(size(x), edgecolors, linewidths, no_edges)
+        call fig%relocate_last_plot_to_subplot()
     end subroutine scatter_2d_dispatch
 
     subroutine scatter_3d_dispatch(x, y, z, s, s_scalar, c, label, marker, &

--- a/src/plotting/fortplot_plot_bars.f90
+++ b/src/plotting/fortplot_plot_bars.f90
@@ -36,6 +36,7 @@ contains
         call bar_plot_state(self%plots, self%state, self%plot_count, x, heights, &
                             width, bottom, label, color, edgecolor, &
                             color_per_bar, edgecolor_per_bar)
+        call self%relocate_last_plot_to_subplot()
     end subroutine bar_impl
 
     subroutine barh_impl(self, y, widths, height, left, label, color, edgecolor, &
@@ -54,6 +55,7 @@ contains
         call barh_plot_state(self%plots, self%state, self%plot_count, y, widths, &
                              height, left, label, color, edgecolor, &
                              color_per_bar, edgecolor_per_bar)
+        call self%relocate_last_plot_to_subplot()
     end subroutine barh_impl
 
   subroutine bar_plot_state(plots, state, plot_count, x, heights, width, bottom, &

--- a/test/state/test_stateful_subplots_routing.f90
+++ b/test/state/test_stateful_subplots_routing.f90
@@ -3,7 +3,7 @@ program test_stateful_subplots_routing
     !! to the selected subplot when a grid is active.
 
     use fortplot, only: wp, figure_t, plot, title, subplot, subplots, &
-                        get_global_figure
+                        hist, bar, scatter, figure, get_global_figure
     implicit none
 
     real(wp) :: x(5), y1(5), y2(5)
@@ -55,6 +55,42 @@ program test_stateful_subplots_routing
 
     if (f%subplot_title(2, 2) /= 'A4') then
         print *, '  FAIL: title routing for (2,2)'
+        stop 1
+    end if
+
+    ! Regression for issue #2021: hist/bar/scatter must route to the active
+    ! subplot instead of vanishing into the unrendered figure-level plots.
+    call figure()
+    call subplots(2, 2)
+
+    call subplot(2, 2, 1)
+    call hist(y1, bins=5)
+
+    call subplot(2, 2, 2)
+    call bar(x, y1)
+
+    call subplot(2, 2, 3)
+    call scatter(x, y2)
+
+    f => get_global_figure()
+
+    if (f%subplot_plot_count(1, 1) /= 1) then
+        print *, '  FAIL: hist not routed to subplot (1,1)'
+        stop 1
+    end if
+
+    if (f%subplot_plot_count(1, 2) /= 1) then
+        print *, '  FAIL: bar not routed to subplot (1,2)'
+        stop 1
+    end if
+
+    if (f%subplot_plot_count(2, 1) /= 1) then
+        print *, '  FAIL: scatter not routed to subplot (2,1)'
+        stop 1
+    end if
+
+    if (f%subplot_plot_count(2, 2) /= 0) then
+        print *, '  FAIL: unexpected plot in subplot (2,2)'
         stop 1
     end if
 


### PR DESCRIPTION
Closes #2021.

## Problem

Switching a plotting call from `plot(x, y)` to `hist`, `bar`, `barh`, or
`scatter` inside a subplot grid produced blank white axes: the figure
compiled and ran without error, but no data appeared.

Root cause: `plot()` routes into the selected subplot via `subplot_plot`,
while `hist`/`bar`/`scatter` build their `plot_data` into the figure-level
`plots` array. When a subplot grid is active the renderer draws the subplot
cells and never touches the figure-level array, so that data silently
vanishes.

## Fix

Add `figure_t%relocate_last_plot_to_subplot`, which mirrors the most
recently added figure-level plot into the active subplot, and call it from
the `hist`, `bar`/`barh` (`bar_impl`/`barh_impl`), and `scatter`
(`scatter_2d_dispatch`) chokepoints. The figure-level slot is retained
rather than removed because the add routines assume monotonically growing
slots; the figure-level array is inert while a subplot grid is active.

## Verification

Build (serial to avoid the unrelated fpm parallel-build SIGABRT):

```
OMP_NUM_THREADS=1 fpm build
```

### Regression test (extends test/state/test_stateful_subplots_routing.f90)

Failing before the fix:

```
$ fpm test --target test_stateful_subplots_routing
 Running stateful subplot routing tests...
   FAIL: hist not routed to subplot (1,1)
STOP 1
```

Passing after the fix:

```
$ fpm test --target test_stateful_subplots_routing
 Running stateful subplot routing tests...
 All stateful subplot routing tests PASSED!
```

The test asserts `hist`, `bar`, and `scatter` each land in the selected
subplot (`subplot_plot_count == 1`) and do not leak into the others.

### Rendering gate

```
$ OMP_NUM_THREADS=1 make verify-artifacts
...
[png] subplots_grid_demo.png size=44465
Artifact verification passed.
```

Reproduced the issue's 2x2 grid (hist / bar / scatter / plot) to
`/tmp/repro_2021.pdf`. `pdftotext -layout` shows every cell now carries
data-derived tick ranges instead of the blank 0.0-1.0 default:

```
hist  (top-left):    x 1.0..5.0,  y 0..4
bar   (top-right):   x 0..20,     y 0..5
scatter (bottom-left): x 2.5..20, y 1..5
plot  (bottom-right):  x 2.5..20, y 1..5
```

Full test suite passes (`OMP_NUM_THREADS=1 fpm test`; no test reports FAIL).