### PR TITLE
fix: stop ASCII subplot save from segfaulting (#2019)

### DIFF
--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -70,9 +70,15 @@ contains
             wspace = 0.20_wp
             hspace = 0.20_wp
 
-            ! Reserve space for suptitle above subplot area
-            if (allocated(state%suptitle) .and. len_trim(state%suptitle) > 0) then
-                base_top = base_top - suptitle_height_frac
+            ! Reserve space for suptitle above subplot area. Use a nested test
+            ! rather than a compound .and.: Fortran does not guarantee
+            ! short-circuit evaluation, so len_trim must not see an unallocated
+            ! suptitle (this path runs for the ASCII backend, where suptitle is
+            ! often unallocated; issue #2019).
+            if (allocated(state%suptitle)) then
+                if (len_trim(state%suptitle) > 0) then
+                    base_top = base_top - suptitle_height_frac
+                end if
             end if
 
             total_w = base_right - base_left

--- a/test/ascii/test_ascii_subplots_2019.f90
+++ b/test/ascii/test_ascii_subplots_2019.f90
@@ -1,0 +1,62 @@
+program test_ascii_subplots_2019
+    !! Regression test for issue #2019: saving a subplot grid to the ASCII
+    !! backend segfaulted. render_subplots took the non-tight margin path for
+    !! ASCII (compute_tight_subplot_margins only supports raster/PDF) and there
+    !! evaluated len_trim on an unallocated suptitle via a compound .and.,
+    !! relying on short-circuit evaluation that Fortran does not guarantee.
+    !! Assert the save completes and writes a non-empty file.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, subplot, plot, savefig
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    real(wp) :: x(5), y(5)
+    integer :: i, unit, ios, line_count
+    character(len=*), parameter :: outfile = &
+        'build/test/output/ascii_subplots_2019.txt'
+    character(len=512) :: line
+    logical :: dir_ok, file_exists
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    do i = 1, 5
+        x(i) = real(i, wp)
+        y(i) = real(i*i, wp)
+    end do
+
+    ! No suptitle: this is what exposed the unallocated-string crash.
+    call figure()
+    call subplot(1, 2, 1)
+    call plot(x, y)
+    call subplot(1, 2, 2)
+    call plot(x, y)
+    call savefig(outfile)
+
+    inquire(file=outfile, exist=file_exists)
+    if (.not. file_exists) then
+        print *, 'FAIL: ASCII subplot save did not create output file'
+        stop 1
+    end if
+
+    line_count = 0
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: could not open ASCII subplot output'
+        stop 1
+    end if
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        if (len_trim(line) > 0) line_count = line_count + 1
+    end do
+    close(unit)
+
+    if (line_count == 0) then
+        print *, 'FAIL: ASCII subplot output is empty'
+        stop 1
+    end if
+
+    print *, 'PASS: ASCII subplot save renders without crashing'
+
+end program test_ascii_subplots_2019


### PR DESCRIPTION
Closes #2019.

## Problem

Saving a figure that uses a subplot grid to the ASCII backend
(`savefig('plot.txt')`) crashed with a segmentation fault. The same figure
saved fine to PNG/PDF.

```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
#3  __fortplot_subplot_rendering_MOD_render_subplots
#4  __fortplot_figure_render_engine_MOD_figure_render
#5  __fortplot_figure_core_io_MOD_render_figure_impl
...
```

Under gdb the fault is a `len_trim` on a null string:

```
#0  _gfortran_string_len_trim (len=..., s=0x0)
#2  __fortplot_subplot_rendering_MOD_render_subplots
```

Root cause: `compute_tight_subplot_margins` only supports the raster and PDF
backends, so for ASCII it returns `ok=.false.` and `render_subplots` takes
the non-tight margin branch. That branch reserves suptitle space with

```fortran
if (allocated(state%suptitle) .and. len_trim(state%suptitle) > 0) then
```

which relies on short-circuit evaluation that Fortran does not guarantee (and
which the project rules explicitly forbid assuming). With no suptitle set,
`len_trim` dereferenced the unallocated string. Raster/PDF take the tight
path and skip this block, so they were unaffected.

## Fix

Split the compound `.and.` into a nested `if` so `len_trim` never sees an
unallocated `suptitle`.

## Verification

Build (serial to avoid the unrelated fpm parallel-build SIGABRT):

```
OMP_NUM_THREADS=1 fpm build
```

Failing before the fix (minimal 1x2 grid, no suptitle, save to .txt):

```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
#3  __fortplot_subplot_rendering_MOD_render_subplots
```

Passing after the fix:

```
$ fpm test --target test_ascii_subplots_2019
 PASS: ASCII subplot save renders without crashing
```

Added `test/ascii/test_ascii_subplots_2019.f90`, which saves a subplot grid
(no suptitle) to ASCII and asserts the file is written and non-empty.

Related ASCII/subplot tests pass: `test_ascii`, `test_subplots`,
`test_suptitle`, `test_utf8_text_preprocessing`. Rendering gate
(`make verify-artifacts`) passes.