### PR TITLE
fix: accept integer capsize in errorbar (#2020)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_errorbar.f90
+++ b/src/interfaces/fortplot_matplotlib_errorbar.f90
@@ -20,11 +20,15 @@ module fortplot_matplotlib_errorbar
     interface errorbar
         module procedure errorbar_rgb
         module procedure errorbar_string
+        module procedure errorbar_rgb_icap
+        module procedure errorbar_string_icap
     end interface errorbar
 
     interface add_errorbar
         module procedure add_errorbar_rgb
         module procedure add_errorbar_string
+        module procedure add_errorbar_rgb_icap
+        module procedure add_errorbar_string_icap
     end interface add_errorbar
 
 contains
@@ -109,6 +113,58 @@ contains
         call note_unsupported_barsabove(barsabove)
     end subroutine errorbar_string
 
+    subroutine errorbar_rgb_icap(x, y, capsize, xerr, yerr, fmt, label, linestyle, &
+                                 marker, color, ecolor, elinewidth, capthick, &
+                                 barsabove, errorevery, lolims, uplims, xlolims, &
+                                 xuplims)
+        !! Integer-capsize overload so matplotlib-style errorbar(..., capsize=4)
+        !! works without forcing a real literal. capsize is required (not
+        !! optional) so this stays distinguishable from errorbar_rgb (#2020).
+        real(wp), contiguous, intent(in) :: x(:), y(:)
+        integer, intent(in) :: capsize
+        real(wp), intent(in), optional :: xerr(:), yerr(:)
+        character(len=*), intent(in), optional :: fmt, label, linestyle, marker
+        real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: ecolor(3)
+        real(wp), intent(in), optional :: elinewidth, capthick
+        logical, intent(in), optional :: barsabove
+        integer, intent(in), optional :: errorevery
+        logical, intent(in), optional :: lolims, uplims, xlolims, xuplims
+
+        call errorbar_rgb(x, y, xerr=xerr, yerr=yerr, fmt=fmt, label=label, &
+                          capsize=real(capsize, wp), linestyle=linestyle, &
+                          marker=marker, color=color, ecolor=ecolor, &
+                          elinewidth=elinewidth, capthick=capthick, &
+                          barsabove=barsabove, errorevery=errorevery, &
+                          lolims=lolims, uplims=uplims, xlolims=xlolims, &
+                          xuplims=xuplims)
+    end subroutine errorbar_rgb_icap
+
+    subroutine errorbar_string_icap(x, y, color, capsize, xerr, yerr, fmt, label, &
+                                    linestyle, marker, ecolor, elinewidth, capthick, &
+                                    barsabove, errorevery, lolims, uplims, xlolims, &
+                                    xuplims)
+        !! Integer-capsize overload of the string-color errorbar (#2020).
+        real(wp), contiguous, intent(in) :: x(:), y(:)
+        character(len=*), intent(in) :: color
+        integer, intent(in) :: capsize
+        real(wp), intent(in), optional :: xerr(:), yerr(:)
+        character(len=*), intent(in), optional :: fmt, label, linestyle, marker
+        character(len=*), intent(in), optional :: ecolor
+        real(wp), intent(in), optional :: elinewidth, capthick
+        logical, intent(in), optional :: barsabove
+        integer, intent(in), optional :: errorevery
+        logical, intent(in), optional :: lolims, uplims, xlolims, xuplims
+
+        call errorbar_string(x, y, color=color, xerr=xerr, yerr=yerr, fmt=fmt, &
+                             label=label, capsize=real(capsize, wp), &
+                             linestyle=linestyle, marker=marker, ecolor=ecolor, &
+                             elinewidth=elinewidth, capthick=capthick, &
+                             barsabove=barsabove, errorevery=errorevery, &
+                             lolims=lolims, uplims=uplims, xlolims=xlolims, &
+                             xuplims=xuplims)
+    end subroutine errorbar_string_icap
+
     subroutine add_errorbar_rgb(x, y, xerr, yerr, fmt, label, capsize, &
                                  linestyle, marker, color, ecolor, elinewidth, &
                                  capthick, barsabove, errorevery, lolims, uplims, &
@@ -153,6 +209,55 @@ contains
                              errorevery=errorevery, lolims=lolims, uplims=uplims, &
                              xlolims=xlolims, xuplims=xuplims)
     end subroutine add_errorbar_string
+
+    subroutine add_errorbar_rgb_icap(x, y, capsize, xerr, yerr, fmt, label, &
+                                     linestyle, marker, color, ecolor, elinewidth, &
+                                     capthick, barsabove, errorevery, lolims, &
+                                     uplims, xlolims, xuplims)
+        !! Integer-capsize overload of add_errorbar (#2020).
+        real(wp), contiguous, intent(in) :: x(:), y(:)
+        integer, intent(in) :: capsize
+        real(wp), intent(in), optional :: xerr(:), yerr(:)
+        character(len=*), intent(in), optional :: fmt, label, linestyle, marker
+        real(wp), intent(in), optional :: color(3), ecolor(3)
+        real(wp), intent(in), optional :: elinewidth, capthick
+        logical, intent(in), optional :: barsabove
+        integer, intent(in), optional :: errorevery
+        logical, intent(in), optional :: lolims, uplims, xlolims, xuplims
+
+        call add_errorbar_rgb(x, y, xerr=xerr, yerr=yerr, fmt=fmt, label=label, &
+                              capsize=real(capsize, wp), linestyle=linestyle, &
+                              marker=marker, color=color, ecolor=ecolor, &
+                              elinewidth=elinewidth, capthick=capthick, &
+                              barsabove=barsabove, errorevery=errorevery, &
+                              lolims=lolims, uplims=uplims, xlolims=xlolims, &
+                              xuplims=xuplims)
+    end subroutine add_errorbar_rgb_icap
+
+    subroutine add_errorbar_string_icap(x, y, color, capsize, xerr, yerr, fmt, &
+                                        label, linestyle, marker, ecolor, &
+                                        elinewidth, capthick, barsabove, errorevery, &
+                                        lolims, uplims, xlolims, xuplims)
+        !! Integer-capsize overload of the string-color add_errorbar (#2020).
+        real(wp), contiguous, intent(in) :: x(:), y(:)
+        character(len=*), intent(in) :: color
+        integer, intent(in) :: capsize
+        real(wp), intent(in), optional :: xerr(:), yerr(:)
+        character(len=*), intent(in), optional :: fmt, label, linestyle, marker
+        character(len=*), intent(in), optional :: ecolor
+        real(wp), intent(in), optional :: elinewidth, capthick
+        logical, intent(in), optional :: barsabove
+        integer, intent(in), optional :: errorevery
+        logical, intent(in), optional :: lolims, uplims, xlolims, xuplims
+
+        call add_errorbar_string(x, y, color=color, xerr=xerr, yerr=yerr, fmt=fmt, &
+                                 label=label, capsize=real(capsize, wp), &
+                                 linestyle=linestyle, marker=marker, ecolor=ecolor, &
+                                 elinewidth=elinewidth, capthick=capthick, &
+                                 barsabove=barsabove, errorevery=errorevery, &
+                                 lolims=lolims, uplims=uplims, xlolims=xlolims, &
+                                 xuplims=xuplims)
+    end subroutine add_errorbar_string_icap
 
     subroutine build_errorbar_arrays(x, y, xerr, yerr, errorevery, xlolims, &
                                      xuplims, lolims, uplims, xerr_out, yerr_out)

--- a/test/plot_types/errorbar/test_errorbar_capsize_integer.f90
+++ b/test/plot_types/errorbar/test_errorbar_capsize_integer.f90
@@ -1,0 +1,46 @@
+program test_errorbar_capsize_integer
+    !! Regression test for issue #2020: matplotlib-style errorbar(..., capsize=4)
+    !! with an integer capsize must compile and store the same cap length as the
+    !! real-literal form. capsize was real-only, so the integer literal matched
+    !! no specific procedure of the errorbar generic and failed to compile.
+    use fortplot, only: wp, figure_t, figure, errorbar, get_global_figure
+    use fortplot_plot_data, only: plot_data_t
+    implicit none
+
+    real(wp), dimension(5) :: x, y, yerr
+    type(figure_t), pointer :: f
+    type(plot_data_t), pointer :: plots(:)
+    real(wp) :: cap_from_int, cap_from_real
+
+    x = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    y = [2.0_wp, 2.5_wp, 3.0_wp, 3.5_wp, 4.0_wp]
+    yerr = [0.2_wp, 0.3_wp, 0.25_wp, 0.35_wp, 0.15_wp]
+
+    ! Integer capsize (the matplotlib idiom the user reported).
+    call figure()
+    call errorbar(x, y, yerr=yerr, capsize=4)
+    f => get_global_figure()
+    plots => f%get_plots()
+    cap_from_int = plots(1)%capsize
+
+    ! Real capsize for the same value, as a reference.
+    call figure()
+    call errorbar(x, y, yerr=yerr, capsize=4.0_wp)
+    f => get_global_figure()
+    plots => f%get_plots()
+    cap_from_real = plots(1)%capsize
+
+    if (abs(cap_from_int - 4.0_wp) > 1.0e-12_wp) then
+        print *, 'FAIL: integer capsize=4 stored as', cap_from_int
+        stop 1
+    end if
+
+    if (abs(cap_from_int - cap_from_real) > 1.0e-12_wp) then
+        print *, 'FAIL: integer capsize differs from real capsize:', &
+            cap_from_int, cap_from_real
+        stop 1
+    end if
+
+    print *, 'PASS: integer capsize accepted and matches real capsize'
+
+end program test_errorbar_capsize_integer


### PR DESCRIPTION
Closes #2020.

## Problem

matplotlib's idiomatic `errorbar(..., capsize=4)` (integer) failed to
compile in fortplot:

```
call errorbar(x, y, yerr=yerr, capsize=4)
                                        1
Error: There is no specific subroutine for the generic 'errorbar' at (1)
```

`capsize` was declared `real(wp)` only, so an integer literal matched no
specific procedure of the `errorbar` / `add_errorbar` generics. The reporter
read this as "errorbar does not support caps". (Caps render correctly when
`capsize` is passed as a real, e.g. `capsize=4.0_wp`.)

## Fix

Add integer-`capsize` overloads for `errorbar` and `add_errorbar` (both the
RGB-triple and string color forms) as thin shims that convert to real and
forward to the existing specifics. The integer `capsize` argument is
required (not optional) in each new variant, which keeps it distinguishable
from its real-capsize counterpart and from the no-capsize call, so generic
resolution stays unambiguous.

## Verification

Build (serial to avoid the unrelated fpm parallel-build SIGABRT):

```
OMP_NUM_THREADS=1 fpm build
```

Failing before the fix:

```
$ fpm build   # program calling errorbar(x, y, yerr=yerr, capsize=4)
Error: There is no specific subroutine for the generic 'errorbar'
```

Passing after the fix:

```
$ fpm test --target test_errorbar_capsize_integer
 PASS: integer capsize accepted and matches real capsize
```

The new test (`test/plot_types/errorbar/test_errorbar_capsize_integer.f90`)
asserts `capsize=4` compiles and stores the same cap length (4.0) as
`capsize=4.0_wp`, read back via `figure_t%get_plots()`.

Existing errorbar tests pass unchanged: `test_errorbar_defaults`,
`test_errorbar_ascii_rendering`, `test_errorbar_pdf_rendering`,
`test_errorbar_legend_entry`, `test_errorbar_barsabove_warning`,
`test_stateful_api_fast`. Rendering gate (`make verify-artifacts`) passes.
A manual render with `capsize=4` shows the horizontal caps drawn at the
error-bar ends.