### PR TITLE
fix: add ASCII subplot support (refs #2025)

### DIFF
--- a/example/fortran/scale_examples/scale_examples.f90
+++ b/example/fortran/scale_examples/scale_examples.f90
@@ -46,7 +46,7 @@ contains
         call set_yscale('symlog', threshold)  ! Now with threshold support
         call title('Symlog Scale Example')
         call xlabel('x') 
-        call ylabel('x³ - 50x')
+        call ylabel('x³ - 50x (10^5)')
         call savefig('output/example/fortran/scale_examples/symlog_scale.png')
         call savefig('output/example/fortran/scale_examples/symlog_scale.pdf')
         call savefig('output/example/fortran/scale_examples/symlog_scale.txt')

--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -175,13 +175,14 @@ contains
 
         character(len=500) :: processed_text
         integer :: processed_len, text_x, text_y, pw, ph
-        logical :: screen_coords
+        logical :: screen_coords, use_plot_area
 
         if (this%num_text_elements >= size(this%text_elements)) return
         call sanitize_ascii_text(text, processed_text, processed_len)
 
         pw = this%plot_width
         ph = this%plot_height
+        use_plot_area = this%plot_area%width > 0 .and. this%plot_area%height > 0
         screen_coords = .false.
         if (x >= 1.0_wp .and. x <= real(pw, wp) .and. &
             y >= 1.0_wp .and. y <= real(ph, wp)) then
@@ -189,11 +190,16 @@ contains
             text_y = nint(y)
             screen_coords = .true.
         else if (this%x_max > this%x_min .and. this%y_max > this%y_min) then
-            text_x = this%plot_area%left + nint((x - this%x_min)/(this%x_max - this%x_min)* &
-                     real(max(1, this%plot_area%width), wp))
-            text_y = this%plot_area%bottom + this%plot_area%height - &
-                     nint((y - this%y_min)/(this%y_max - this%y_min)* &
-                     real(max(1, this%plot_area%height), wp))
+            if (use_plot_area) then
+                text_x = this%plot_area%left + nint((x - this%x_min)/(this%x_max - this%x_min)* &
+                         real(max(1, this%plot_area%width), wp))
+                text_y = this%plot_area%bottom + this%plot_area%height - &
+                         nint((y - this%y_min)/(this%y_max - this%y_min)* &
+                         real(max(1, this%plot_area%height), wp))
+            else
+                text_x = nint((x - this%x_min)/(this%x_max - this%x_min)*real(pw, wp))
+                text_y = nint((this%y_max - y)/(this%y_max - this%y_min)*real(ph, wp))
+            end if
         else
             text_x = nint(x)
             text_y = nint(y)
@@ -202,11 +208,14 @@ contains
         if (screen_coords) then
             text_x = max(1, min(text_x, pw))
             text_y = max(1, min(text_y, ph))
-        else
+        else if (use_plot_area) then
             text_x = max(this%plot_area%left + 1, &
                          min(text_x, this%plot_area%left + max(1, this%plot_area%width) - 1))
             text_y = max(this%plot_area%bottom + 1, &
                          min(text_y, this%plot_area%bottom + max(1, this%plot_area%height) - 1))
+        else
+            text_x = max(2, min(text_x, max(2, pw - processed_len - 1)))
+            text_y = max(1, min(text_y, ph))
         end if
 
         this%num_text_elements = this%num_text_elements + 1

--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -3,6 +3,7 @@ module fortplot_ascii
 
     use fortplot_context, only: plot_context, setup_canvas
     use fortplot_constants, only: ASCII_CHAR_ASPECT
+    use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_ascii_utils, only: text_element_t
     use fortplot_ascii_elements, only: draw_ascii_marker, fill_ascii_heatmap, &
@@ -28,12 +29,16 @@ module fortplot_ascii
 
     type, extends(plot_context) :: ascii_context
         character(len=1), allocatable :: canvas(:, :)
+        type(plot_margins_t) :: margins
+        type(plot_area_t) :: plot_area
         character(len=:), allocatable :: title_text
         character(len=:), allocatable :: xlabel_text
         character(len=:), allocatable :: ylabel_text
         logical :: title_set = .false.  ! Track if title was explicitly set
         type(text_element_t), allocatable :: text_elements(:)
         integer :: num_text_elements = 0
+        type(text_element_t), allocatable :: arrow_elements(:)
+        integer :: num_arrow_elements = 0
         real(wp) :: current_r, current_g, current_b
         integer :: plot_width = 80
         integer :: plot_height = 24
@@ -93,7 +98,7 @@ module fortplot_ascii
   
 contains
 
-   function create_ascii_canvas(width, height) result(ctx)
+    function create_ascii_canvas(width, height) result(ctx)
         integer, intent(in), optional :: width, height
         type(ascii_context) :: ctx
         integer :: w, h
@@ -112,10 +117,17 @@ contains
         call setup_canvas(ctx, w, h)
         ctx%plot_width = w
         ctx%plot_height = h
+        ctx%margins%left = 0.0_wp
+        ctx%margins%right = 0.0_wp
+        ctx%margins%bottom = 0.0_wp
+        ctx%margins%top = 0.0_wp
+        call calculate_plot_area(w, h, ctx%margins, ctx%plot_area)
         allocate (ctx%canvas(h, w))
         ctx%canvas = ' '
         allocate (ctx%text_elements(20))
         ctx%num_text_elements = 0
+        allocate (ctx%arrow_elements(1000))
+        ctx%num_arrow_elements = 0
         ctx%title_set = .false.
         allocate (ctx%legend_lines(0))
         ctx%num_legend_lines = 0
@@ -131,7 +143,7 @@ contains
 
         call ascii_draw_line_primitive(this%canvas, x1, y1, x2, y2, &
                                        this%x_min, this%x_max, this%y_min, this%y_max, &
-                                       this%plot_width, this%plot_height, &
+                                       this%plot_area, this%plot_width, this%plot_height, &
                                        this%current_r, this%current_g, this%current_b)
     end subroutine ascii_draw_line
 
@@ -163,26 +175,39 @@ contains
 
         character(len=500) :: processed_text
         integer :: processed_len, text_x, text_y, pw, ph
+        logical :: screen_coords
 
         if (this%num_text_elements >= size(this%text_elements)) return
         call sanitize_ascii_text(text, processed_text, processed_len)
 
         pw = this%plot_width
         ph = this%plot_height
+        screen_coords = .false.
         if (x >= 1.0_wp .and. x <= real(pw, wp) .and. &
             y >= 1.0_wp .and. y <= real(ph, wp)) then
             text_x = nint(x)
             text_y = nint(y)
+            screen_coords = .true.
         else if (this%x_max > this%x_min .and. this%y_max > this%y_min) then
-            text_x = nint((x - this%x_min)/(this%x_max - this%x_min)*real(pw, wp))
-            text_y = nint((this%y_max - y)/(this%y_max - this%y_min)*real(ph, wp))
+            text_x = this%plot_area%left + nint((x - this%x_min)/(this%x_max - this%x_min)* &
+                     real(max(1, this%plot_area%width), wp))
+            text_y = this%plot_area%bottom + this%plot_area%height - &
+                     nint((y - this%y_min)/(this%y_max - this%y_min)* &
+                     real(max(1, this%plot_area%height), wp))
         else
             text_x = nint(x)
             text_y = nint(y)
         end if
 
-        text_x = max(2, min(text_x, max(2, pw - processed_len - 1)))
-        text_y = max(1, min(text_y, ph))
+        if (screen_coords) then
+            text_x = max(1, min(text_x, pw))
+            text_y = max(1, min(text_y, ph))
+        else
+            text_x = max(this%plot_area%left + 1, &
+                         min(text_x, this%plot_area%left + max(1, this%plot_area%width) - 1))
+            text_y = max(this%plot_area%bottom + 1, &
+                         min(text_y, this%plot_area%bottom + max(1, this%plot_area%height) - 1))
+        end if
 
         this%num_text_elements = this%num_text_elements + 1
         this%text_elements(this%num_text_elements)%text = processed_text(1:processed_len)
@@ -209,6 +234,7 @@ contains
         character(len=*), intent(in) :: filename
 
         call ascii_finalize(this%canvas, this%text_elements, this%num_text_elements, &
+                            this%arrow_elements, this%num_arrow_elements, &
                             this%plot_width, this%plot_height, &
                             this%title_text, this%xlabel_text, this%ylabel_text, &
                             this%legend_lines, this%num_legend_lines, filename)
@@ -220,6 +246,7 @@ contains
 
         call output_to_file(this%canvas, this%text_elements, &
                             this%num_text_elements, &
+                            this%arrow_elements, this%num_arrow_elements, &
                             this%plot_width, this%plot_height, &
                             this%title_text, this%xlabel_text, this%ylabel_text, &
                             this%legend_lines, this%num_legend_lines, unit)
@@ -238,7 +265,7 @@ contains
 
         call draw_ascii_marker(this%canvas, x, y, style, &
                                this%x_min, this%x_max, this%y_min, this%y_max, &
-                               this%plot_width, this%plot_height)
+                               this%plot_area, this%plot_width, this%plot_height)
     end subroutine ascii_draw_marker
 
 subroutine ascii_set_marker_colors(this, edge_r, edge_g, edge_b, face_r, &
@@ -269,7 +296,7 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
         if (present(colormap_name)) cdummy = len_trim(colormap_name)
         call fill_ascii_heatmap(this%canvas, x_grid, y_grid, z_grid, z_min, z_max, &
                                 this%x_min, this%x_max, this%y_min, this%y_max, &
-                                this%plot_width, this%plot_height)
+                                this%plot_area, this%plot_width, this%plot_height)
     end subroutine ascii_fill_heatmap
 
     subroutine ascii_draw_arrow(this, x, y, dx, dy, size, style)
@@ -277,11 +304,35 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
         real(wp), intent(in) :: x, y, dx, dy, size
         character(len=*), intent(in) :: style
 
+        integer :: px, py, inner_width, inner_height
+        character(len=1) :: arrow_char
+
         call draw_ascii_arrow(this%canvas, x, y, dx, dy, size, style, &
                               this%x_min, this%x_max, this%y_min, this%y_max, &
-                              this%width, this%height, &
+                              this%plot_area, this%width, this%height, &
                               this%has_rendered_arrows, this%uses_vector_arrows, &
                               this%has_triangular_arrows)
+
+        if (this%num_arrow_elements < ubound(this%arrow_elements, 1)) then
+            inner_width = max(1, this%plot_area%width - 2)
+            inner_height = max(1, this%plot_area%height - 2)
+            px = this%plot_area%left + 1 + nint((x - this%x_min)/(this%x_max - this%x_min)* &
+                 real(inner_width, wp))
+            py = this%plot_area%bottom + this%plot_area%height - 1 - &
+                 nint((y - this%y_min)/(this%y_max - this%y_min)* &
+                 real(inner_height, wp))
+            if (px >= this%plot_area%left + 1 .and. px <= this%plot_area%left + this%plot_area%width - 1 .and. &
+                py >= this%plot_area%bottom + 1 .and. py <= this%plot_area%bottom + this%plot_area%height - 1) then
+                arrow_char = infer_ascii_arrow_char(dx, dy)
+                this%num_arrow_elements = this%num_arrow_elements + 1
+                this%arrow_elements(this%num_arrow_elements)%text = arrow_char
+                this%arrow_elements(this%num_arrow_elements)%x = px
+                this%arrow_elements(this%num_arrow_elements)%y = py
+                this%arrow_elements(this%num_arrow_elements)%color_r = this%current_r
+                this%arrow_elements(this%num_arrow_elements)%color_g = this%current_g
+                this%arrow_elements(this%num_arrow_elements)%color_b = this%current_b
+            end if
+        end if
     end subroutine ascii_draw_arrow
 
     subroutine ascii_draw_arrowhead(this, x, y, dx, dy, size, style)
@@ -292,7 +343,7 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
 
         call draw_ascii_arrow(this%canvas, x, y, dx, dy, size, style, &
                               this%x_min, this%x_max, this%y_min, this%y_max, &
-                              this%width, this%height, &
+                              this%plot_area, this%width, this%height, &
                               this%has_rendered_arrows, this%uses_vector_arrows, &
                               this%has_triangular_arrows)
     end subroutine ascii_draw_arrowhead
@@ -303,6 +354,31 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
 
         output = ascii_get_output(this%canvas, this%width, this%height)
     end function ascii_get_output_method
+
+    pure character(len=1) function infer_ascii_arrow_char(dx, dy) result(arrow_char)
+        real(wp), intent(in) :: dx, dy
+        real(wp) :: angle
+
+        angle = atan2(dy / ASCII_CHAR_ASPECT, dx)
+
+        if (abs(angle) < 0.393_wp) then
+            arrow_char = '>'
+        else if (angle >= 0.393_wp .and. angle < 1.178_wp) then
+            arrow_char = '/'
+        else if (angle >= 1.178_wp .and. angle < 1.963_wp) then
+            arrow_char = '^'
+        else if (angle >= 1.963_wp .and. angle < 2.749_wp) then
+            arrow_char = '\'
+        else if (abs(angle) >= 2.749_wp) then
+            arrow_char = '<'
+        else if (angle <= -0.393_wp .and. angle > -1.178_wp) then
+            arrow_char = '\'
+        else if (angle <= -1.178_wp .and. angle > -1.963_wp) then
+            arrow_char = 'v'
+        else
+            arrow_char = '/'
+        end if
+    end function infer_ascii_arrow_char
 
    function ascii_get_width_scale(this) result(scale)
         class(ascii_context), intent(in) :: this
@@ -343,7 +419,7 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
 
         call ascii_fill_quad_primitive(this%canvas, x_quad, y_quad, &
                                        this%x_min, this%x_max, y_lo, y_hi, &
-                                       this%plot_width, this%plot_height, &
+                                       this%plot_area, this%plot_width, this%plot_height, &
                                        this%current_r, this%current_g, this%current_b)
     end subroutine ascii_fill_quad
 
@@ -419,11 +495,11 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
         call ascii_render_ylabel_impl(ylabel)
     end subroutine ascii_render_ylabel
 
- subroutine ascii_draw_axes_and_labels(this, xscale, yscale, symlog_threshold, &
-                                           x_min, x_max, y_min, y_max, &
-                                           title, xlabel, ylabel, &
-                                           x_date_format, y_date_format, &
-                                           z_min, z_max, has_3d_plots)
+    subroutine ascii_draw_axes_and_labels(this, xscale, yscale, symlog_threshold, &
+                                          x_min, x_max, y_min, y_max, &
+                                          title, xlabel, ylabel, &
+                                          x_date_format, y_date_format, &
+                                          z_min, z_max, has_3d_plots)
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
@@ -440,18 +516,16 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
 
         has_custom_ticks = allocated(this%custom_xtick_positions) .and. &
                            allocated(this%custom_xtick_labels)
-
         call ascii_draw_axes_impl(this%canvas, xscale, yscale, symlog_threshold, &
-                                   x_min, x_max, y_min, y_max, &
-                                   title, xlabel, ylabel, &
-                                   x_date_format, y_date_format, &
-                                   z_min, z_max, has_3d_plots, &
-                                   this%current_r, this%current_g, this%current_b, &
-                                   this%plot_width, this%plot_height, &
-                                   this%title_text, this%xlabel_text, this%ylabel_text, &
-                                   this%text_elements, this%num_text_elements, &
-                                   has_custom_ticks, &
-                                   this%custom_xtick_positions, this%custom_xtick_labels)
+                               x_min, x_max, y_min, y_max, &
+                               title, xlabel, ylabel, x_date_format, y_date_format, &
+                               z_min, z_max, has_3d_plots, &
+                               this%current_r, this%current_g, this%current_b, &
+                               this%plot_area, this%plot_width, this%plot_height, &
+                               this%title_text, this%xlabel_text, this%ylabel_text, &
+                               this%text_elements, this%num_text_elements, &
+                               has_custom_ticks, &
+                               this%custom_xtick_positions, this%custom_xtick_labels)
     end subroutine ascii_draw_axes_and_labels
 
     subroutine ascii_save_coordinates(this, x_min, x_max, y_min, y_max)
@@ -472,7 +546,7 @@ subroutine ascii_fill_heatmap(this, x_grid, y_grid, z_grid, z_min, z_max, colorm
                                    this%stored_y_min, this%stored_y_max, this%has_stored_y_range)
     end subroutine ascii_set_coordinates
 
-subroutine ascii_render_axes(this, title_text, xlabel_text, ylabel_text)
+    subroutine ascii_render_axes(this, title_text, xlabel_text, ylabel_text)
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
 
@@ -490,7 +564,7 @@ subroutine ascii_render_axes(this, title_text, xlabel_text, ylabel_text)
         call ascii_render_axes_impl(this%x_min, this%x_max, this%y_min, this%y_max, &
                                      this%has_stored_y_range, this%stored_y_min, this%stored_y_max, &
                                      this%last_xscale, this%last_yscale, this%last_symlog_threshold, &
-                                     this%canvas, this%plot_width, this%plot_height, &
+                                     this%canvas, this%plot_area, this%plot_width, this%plot_height, &
                                      this%title_text, this%xlabel_text, this%ylabel_text, &
                                      this%text_elements, this%num_text_elements, &
                                      this%custom_xtick_positions, this%custom_xtick_labels)

--- a/src/backends/ascii/fortplot_ascii_backend_ops.f90
+++ b/src/backends/ascii/fortplot_ascii_backend_ops.f90
@@ -9,6 +9,7 @@ module fortplot_ascii_backend_ops
    use fortplot_plot_data, only: plot_data_t
    use fortplot_ascii_utils, only: text_element_t
    use fortplot_ascii_elements, only: draw_ascii_axes_and_labels
+   use fortplot_margins, only: plot_area_t
    use, intrinsic :: iso_fortran_env, only: wp => real64
    implicit none
 
@@ -53,6 +54,7 @@ contains
                                    x_date_format, y_date_format, &
                                    z_min, z_max, has_3d_plots, &
                                    current_r, current_g, current_b, &
+                                   plot_area, &
                                    plot_width, plot_height, &
                                    title_text, xlabel_text, ylabel_text, &
                                    text_elements, num_text_elements, &
@@ -66,6 +68,7 @@ contains
       real(wp), intent(in), optional :: z_min, z_max
       logical, intent(in) :: has_3d_plots
       real(wp), intent(in) :: current_r, current_g, current_b
+      type(plot_area_t), intent(in) :: plot_area
       integer, intent(in) :: plot_width, plot_height
     character(len=:), allocatable, intent(inout) :: title_text, xlabel_text, ylabel_text
       type(text_element_t), intent(inout) :: text_elements(:)
@@ -82,6 +85,7 @@ contains
                                          x_date_format, y_date_format, &
                                          z_min, z_max, has_3d_plots, &
                                          current_r, current_g, current_b, &
+                                         plot_area, &
                                          plot_width, plot_height, &
                                          title_text, xlabel_text, ylabel_text, &
                                          text_elements, num_text_elements, &
@@ -95,6 +99,7 @@ contains
                                          x_date_format, y_date_format, &
                                          z_min, z_max, has_3d_plots, &
                                          current_r, current_g, current_b, &
+                                         plot_area, &
                                          plot_width, plot_height, &
                                          title_text, xlabel_text, ylabel_text, &
                                          text_elements, num_text_elements)
@@ -140,7 +145,7 @@ contains
    subroutine ascii_render_axes_impl(x_min, x_max, y_min, y_max, &
                                      has_stored_y_range, stored_y_min, stored_y_max, &
                                      last_xscale, last_yscale, last_symlog_threshold, &
-                                     canvas, plot_width, plot_height, &
+                                     canvas, plot_area, plot_width, plot_height, &
                                      title_text, xlabel_text, ylabel_text, &
                                      text_elements, num_text_elements, &
                                      custom_xtick_positions, custom_xtick_labels)
@@ -150,6 +155,7 @@ contains
       character(len=*), intent(in) :: last_xscale, last_yscale
       real(wp), intent(in) :: last_symlog_threshold
       character(len=1), intent(inout) :: canvas(:, :)
+      type(plot_area_t), intent(in) :: plot_area
       integer, intent(in) :: plot_width, plot_height
     character(len=:), allocatable, intent(inout) :: title_text, xlabel_text, ylabel_text
       type(text_element_t), intent(inout) :: text_elements(:)
@@ -174,6 +180,7 @@ contains
                                 sx_min, sx_max, sy_min, sy_max, &
                                 has_3d_plots=.false., &
                                 current_r=0.0_wp, current_g=0.0_wp, current_b=0.0_wp, &
+                                plot_area=plot_area, &
                                 plot_width=plot_width, plot_height=plot_height, &
                                 title_text=title_text, xlabel_text=xlabel_text, &
                                 ylabel_text=ylabel_text, &

--- a/src/backends/ascii/fortplot_ascii_drawing.f90
+++ b/src/backends/ascii/fortplot_ascii_drawing.f90
@@ -7,6 +7,7 @@ module fortplot_ascii_drawing
     !! Author: fortplot contributors
 
     use fortplot_constants, only: EPSILON_COMPARE, ASCII_CHAR_ASPECT
+    use fortplot_margins, only: plot_area_t
     use fortplot_ascii_utils, only: get_char_density, ASCII_CHARS
     use fortplot_ascii_utils, only: get_blend_char
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -18,18 +19,18 @@ module fortplot_ascii_drawing
 
 contains
 
-    subroutine draw_ascii_marker(canvas, x, y, style, x_min, x_max, y_min, y_max, plot_width, plot_height)
+    subroutine draw_ascii_marker(canvas, x, y, style, x_min, x_max, y_min, y_max, &
+                                 plot_area, plot_width, plot_height)
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: style
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         integer :: px, py
         character(len=1) :: marker_char
 
-        ! Map to usable plot area (excluding 1-char border on each side)
-        px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
-        py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+        call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
 
         ! Map marker styles to distinct ASCII characters for visual differentiation
         select case (trim(style))
@@ -61,18 +62,20 @@ contains
             marker_char = '*'  ! Default fallback
         end select
 
-        if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+        if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+            py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
             canvas(py, px) = marker_char
         end if
     end subroutine draw_ascii_marker
 
     subroutine fill_ascii_heatmap(canvas, x_grid, y_grid, z_grid, z_min, z_max, &
-                                  x_min, x_max, y_min, y_max, plot_width, plot_height)
+                                  x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
         !! Fill ASCII canvas with heatmap representation of 2D data
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), contiguous, intent(in) :: x_grid(:), y_grid(:), z_grid(:,:)
         real(wp), intent(in) :: z_min, z_max
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
 
         integer :: nx, ny, i, j, px, py
@@ -88,14 +91,12 @@ contains
         ! Fill the canvas with density characters based on z values
         do i = 1, nx
             do j = 1, ny
-                ! Map grid coordinates to canvas coordinates
-                px = int((x_grid(i) - x_min) / (x_max - x_min) * &
-                        real(plot_width - 3, wp)) + 2
-                py = (plot_height - 1) - int((y_grid(j) - y_min) / &
-                        (y_max - y_min) * real(plot_height - 3, wp))
+                call map_to_plot_area(x_grid(i), y_grid(j), x_min, x_max, y_min, y_max, &
+                                      plot_area, px, py)
 
                 ! Check bounds
-                if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+                if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                    py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
                     ! Normalize z value to character index
                     ! z_grid is (ny, nx) so access as z_grid(j, i)
                     if (abs(z_max - z_min) > EPSILON_COMPARE) then
@@ -117,13 +118,14 @@ contains
     end subroutine fill_ascii_heatmap
 
     subroutine draw_ascii_arrow(canvas, x, y, dx, dy, size, style, &
-                                x_min, x_max, y_min, y_max, width, height, &
+                                x_min, x_max, y_min, y_max, plot_area, width, height, &
                                 has_rendered_arrows, uses_vector_arrows, has_triangular_arrows)
         !! Draw arrow using Unicode directional characters for ASCII backend
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), intent(in) :: x, y, dx, dy, size
         character(len=*), intent(in) :: style
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: width, height
         logical, intent(out) :: has_rendered_arrows, uses_vector_arrows, has_triangular_arrows
 
@@ -134,12 +136,11 @@ contains
         ! Reference otherwise-unused parameters without unreachable branches
         associate(unused_s => size, unused_ls => len_trim(style)); end associate
 
-        ! Convert world coordinates to pixel coordinates
-        px = int((x - x_min) / (x_max - x_min) * real(width, wp))
-        py = int((y - y_min) / (y_max - y_min) * real(height, wp))
+        call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
 
         ! Ensure coordinates stay inside the frame border (1-char margin)
-        if (px < 2 .or. px > width - 1 .or. py < 2 .or. py > height - 1) return
+        if (px < plot_area%left + 1 .or. px > plot_area%left + plot_area%width - 1 .or. &
+            py < plot_area%bottom + 1 .or. py > plot_area%bottom + plot_area%height - 1) return
 
         ! Calculate angle for direction in screen space. The canvas compresses y
         ! by ASCII_CHAR_ASPECT relative to x (a cell is that many times taller
@@ -175,10 +176,12 @@ contains
         has_triangular_arrows = .false.
     end subroutine draw_ascii_arrow
 
-    subroutine draw_line_on_canvas(canvas, x1, y1, x2, y2, x_min, x_max, y_min, y_max, plot_width, plot_height, line_char)
+    subroutine draw_line_on_canvas(canvas, x1, y1, x2, y2, x_min, x_max, y_min, y_max, &
+                                   plot_area, plot_width, plot_height, line_char)
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), intent(in) :: x1, y1, x2, y2
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         character(len=1), intent(in) :: line_char
 
@@ -199,11 +202,10 @@ contains
         y = y1
 
         do i = 0, steps
-            ! Map to usable plot area (excluding 1-char border on each side)
-            px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
-            py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
 
-            if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
                 if (canvas(py, px) == ' ') then
                     canvas(py, px) = line_char
                 else if (canvas(py, px) /= line_char) then
@@ -215,5 +217,18 @@ contains
             y = y + step_y
         end do
     end subroutine draw_line_on_canvas
+
+    subroutine map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+        real(wp), intent(in) :: x, y, x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(out) :: px, py
+        integer :: inner_width, inner_height
+
+        inner_width = max(1, plot_area%width - 2)
+        inner_height = max(1, plot_area%height - 2)
+        px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
+        py = plot_area%bottom + plot_area%height - 1 - &
+             nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+    end subroutine map_to_plot_area
 
 end module fortplot_ascii_drawing

--- a/src/backends/ascii/fortplot_ascii_drawing.f90
+++ b/src/backends/ascii/fortplot_ascii_drawing.f90
@@ -29,8 +29,15 @@ contains
         integer, intent(in) :: plot_width, plot_height
         integer :: px, py
         character(len=1) :: marker_char
+        logical :: use_plot_area
 
-        call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
+        if (use_plot_area) then
+            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+        else
+            px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
+            py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+        end if
 
         ! Map marker styles to distinct ASCII characters for visual differentiation
         select case (trim(style))
@@ -62,8 +69,12 @@ contains
             marker_char = '*'  ! Default fallback
         end select
 
-        if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
-            py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+        if (use_plot_area) then
+            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                canvas(py, px) = marker_char
+            end if
+        else if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
             canvas(py, px) = marker_char
         end if
     end subroutine draw_ascii_marker
@@ -81,22 +92,48 @@ contains
         integer :: nx, ny, i, j, px, py
         real(wp) :: z_normalized
         integer :: char_idx
+        logical :: use_plot_area
 
         nx = size(x_grid)
         ny = size(y_grid)
 
         ! z_grid should have dimensions (ny, nx) - rows by columns
         if (size(z_grid, 1) /= ny .or. size(z_grid, 2) /= nx) return
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
 
         ! Fill the canvas with density characters based on z values
         do i = 1, nx
             do j = 1, ny
-                call map_to_plot_area(x_grid(i), y_grid(j), x_min, x_max, y_min, y_max, &
-                                      plot_area, px, py)
+                if (use_plot_area) then
+                    call map_to_plot_area(x_grid(i), y_grid(j), x_min, x_max, y_min, y_max, &
+                                          plot_area, px, py)
+                else
+                    px = int((x_grid(i) - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
+                    py = (plot_height - 1) - int((y_grid(j) - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+                end if
 
                 ! Check bounds
-                if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
-                    py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                if (use_plot_area) then
+                    if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                        py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                        ! Normalize z value to character index
+                        ! z_grid is (ny, nx) so access as z_grid(j, i)
+                        if (abs(z_max - z_min) > EPSILON_COMPARE) then
+                            z_normalized = (z_grid(j, i) - z_min) / (z_max - z_min)
+                        else
+                            z_normalized = 0.5_wp
+                        end if
+
+                        ! Map to character index (1 to len(ASCII_CHARS))
+                        char_idx = min(len(ASCII_CHARS), max(1, int(z_normalized * real(len(ASCII_CHARS) - 1, wp)) + 1))
+
+                        ! Only overwrite if current position is empty or has lower density
+                        if (canvas(py, px) == ' ' .or. char_idx > index(ASCII_CHARS, canvas(py, px))) then
+                            canvas(py, px) = ASCII_CHARS(char_idx:char_idx)
+                        end if
+                    end if
+                else if (px >= 2 .and. px <= plot_width - 1 .and. &
+                         py >= 2 .and. py <= plot_height - 1) then
                     ! Normalize z value to character index
                     ! z_grid is (ny, nx) so access as z_grid(j, i)
                     if (abs(z_max - z_min) > EPSILON_COMPARE) then
@@ -132,15 +169,22 @@ contains
         integer :: px, py
         character(len=1) :: arrow_char
         real(wp) :: angle
+        logical :: use_plot_area
 
         ! Reference otherwise-unused parameters without unreachable branches
         associate(unused_s => size, unused_ls => len_trim(style)); end associate
 
-        call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
-
-        ! Ensure coordinates stay inside the frame border (1-char margin)
-        if (px < plot_area%left + 1 .or. px > plot_area%left + plot_area%width - 1 .or. &
-            py < plot_area%bottom + 1 .or. py > plot_area%bottom + plot_area%height - 1) return
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
+        if (use_plot_area) then
+            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+            ! Ensure coordinates stay inside the frame border (1-char margin)
+            if (px < plot_area%left + 1 .or. px > plot_area%left + plot_area%width - 1 .or. &
+                py < plot_area%bottom + 1 .or. py > plot_area%bottom + plot_area%height - 1) return
+        else
+            px = int((x - x_min) / (x_max - x_min) * real(width, wp))
+            py = int((y - y_min) / (y_max - y_min) * real(height, wp))
+            if (px < 2 .or. px > width - 1 .or. py < 2 .or. py > height - 1) return
+        end if
 
         ! Calculate angle for direction in screen space. The canvas compresses y
         ! by ASCII_CHAR_ASPECT relative to x (a cell is that many times taller
@@ -202,14 +246,25 @@ contains
         y = y1
 
         do i = 0, steps
-            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
-
-            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
-                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
-                if (canvas(py, px) == ' ') then
-                    canvas(py, px) = line_char
-                else if (canvas(py, px) /= line_char) then
-                    canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+            if (plot_area%width > 0 .and. plot_area%height > 0) then
+                call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+                if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                    py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
+                end if
+            else
+                px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
+                py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+                if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
                 end if
             end if
 
@@ -224,11 +279,16 @@ contains
         integer, intent(out) :: px, py
         integer :: inner_width, inner_height
 
-        inner_width = max(1, plot_area%width - 2)
-        inner_height = max(1, plot_area%height - 2)
-        px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
-        py = plot_area%bottom + plot_area%height - 1 - &
-             nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+        if (plot_area%width > 0 .and. plot_area%height > 0) then
+            inner_width = max(1, plot_area%width - 2)
+            inner_height = max(1, plot_area%height - 2)
+            px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
+            py = plot_area%bottom + plot_area%height - 1 - &
+                 nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+        else
+            px = int((x - x_min) / (x_max - x_min) * real(1, wp)) + 2
+            py = 1 - int((y - y_min) / (y_max - y_min) * real(1, wp))
+        end if
     end subroutine map_to_plot_area
 
 end module fortplot_ascii_drawing

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -6,6 +6,7 @@ module fortplot_ascii_primitives
     !!
     !! Author: fortplot contributors
     
+    use fortplot_margins, only: plot_area_t
     use fortplot_ascii_utils, only: get_char_density, get_blend_char, ASCII_CHARS
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use, intrinsic :: iso_fortran_env, only: wp => real64
@@ -23,11 +24,12 @@ contains
 
     subroutine ascii_draw_line_primitive(canvas, x1, y1, x2, y2, &
                                         x_min, x_max, y_min, y_max, &
-                                        plot_width, plot_height, &
+                                        plot_area, plot_width, plot_height, &
                                         current_r, current_g, current_b)
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), intent(in) :: x1, y1, x2, y2
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         real(wp), intent(in) :: current_r, current_g, current_b
         
@@ -88,12 +90,11 @@ contains
         y = y1
         
         do i = 0, steps
-            ! Map to usable plot area (excluding 1-char border on each side)
-            px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
-            py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
             
             
-            if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
                 if (canvas(py, px) == ' ') then
                     canvas(py, px) = line_char
                 else if (canvas(py, px) /= line_char) then
@@ -108,12 +109,13 @@ contains
 
     subroutine ascii_fill_quad_primitive(canvas, x_quad, y_quad, &
                                         x_min, x_max, y_min, y_max, &
-                                        plot_width, plot_height, &
+                                        plot_area, plot_width, plot_height, &
                                         current_r, current_g, current_b)
         !! Fill quadrilateral using character mapping based on current color
         character(len=1), intent(inout) :: canvas(:,:)
         real(wp), intent(in) :: x_quad(4), y_quad(4)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         real(wp), intent(in) :: current_r, current_g, current_b
 
@@ -130,10 +132,8 @@ contains
         ! Convert coordinates to ASCII canvas coordinates (matching line drawing algorithm)
         do i = 1, 4
             ! Map to usable plot area (excluding 1-char border on each side)
-            px(i) = int((x_quad(i) - x_min) / &
-                (x_max - x_min) * real(plot_width - 3, wp)) + 2
-            py(i) = (plot_height - 1) - int((y_quad(i) - y_min) / &
-                (y_max - y_min) * real(plot_height - 3, wp))
+            call map_to_plot_area(x_quad(i), y_quad(i), x_min, x_max, y_min, y_max, &
+                                  plot_area, px(i), py(i))
         end do
 
         ! Determine if this is likely a pie chart based on color patterns
@@ -158,10 +158,10 @@ contains
         end if
         
         ! Fill bounding rectangle with bounds checking
-        min_x = max(2, min(minval(px), plot_width - 1))
-        max_x = max(2, min(maxval(px), plot_width - 1))  
-        min_y = max(2, min(minval(py), plot_height - 1))
-        max_y = max(2, min(maxval(py), plot_height - 1))
+        min_x = max(plot_area%left + 1, min(minval(px), plot_area%left + plot_area%width - 1))
+        max_x = max(plot_area%left + 1, min(maxval(px), plot_area%left + plot_area%width - 1))
+        min_y = max(plot_area%bottom + 1, min(minval(py), plot_area%bottom + plot_area%height - 1))
+        max_y = max(plot_area%bottom + 1, min(maxval(py), plot_area%bottom + plot_area%height - 1))
         
         do j = min_y, max_y
             y_center = real(j, wp)
@@ -219,38 +219,51 @@ contains
     subroutine ascii_draw_text_primitive(text_x, text_y, text, &
                                         x, y, text_input, &
                                         x_min, x_max, y_min, y_max, &
-                                        plot_width, plot_height, &
+                                        plot_area, plot_width, plot_height, &
                                         current_r, current_g, current_b)
         integer, intent(out) :: text_x, text_y
         character(len=:), allocatable, intent(out) :: text
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text_input
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         real(wp), intent(in) :: current_r, current_g, current_b
         
         character(len=500) :: processed_text
         integer :: processed_len
+        logical :: screen_coords
 
         ! Produce ASCII-safe text matching the other ASCII text paths.
         call sanitize_ascii_text(text_input, processed_text, processed_len)
 
         ! Convert coordinates - check if already in screen coordinates
+        screen_coords = .false.
         if (x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &
             y >= 1.0_wp .and. y <= real(plot_height, wp)) then
             ! Already in screen coordinates (e.g., from legend)
             text_x = nint(x)
             text_y = nint(y)
+            screen_coords = .true.
         else
             ! Convert from data coordinates to canvas coordinates
-            text_x = nint((x - x_min) / (x_max - x_min) * real(plot_width, wp))
-            text_y = nint((y_max - y) / (y_max - y_min) * real(plot_height, wp))
+            text_x = plot_area%left + nint((x - x_min) / (x_max - x_min) * &
+                     real(max(1, plot_area%width), wp))
+            text_y = plot_area%bottom + plot_area%height - nint((y - y_min) / &
+                     (y_max - y_min) * real(max(1, plot_area%height), wp))
         end if
 
         ! Clamp to canvas bounds so text stays inside the frame border
         ! with 1-char margin on both sides (issue #1706).
-        text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
-        text_y = max(1, min(text_y, plot_height))
+        if (screen_coords) then
+            text_x = max(1, min(text_x, plot_width - processed_len - 1))
+            text_y = max(1, min(text_y, plot_height))
+        else
+            text_x = max(plot_area%left + 1, &
+                         min(text_x, plot_area%left + max(1, plot_area%width) - processed_len - 1))
+            text_y = max(plot_area%bottom + 1, &
+                         min(text_y, plot_area%bottom + max(1, plot_area%height) - 1))
+        end if
 
         text = processed_text(1:processed_len)
         
@@ -258,6 +271,20 @@ contains
         ! They should be stored by the calling routine if needed
         associate(unused_sum => current_r + current_g + current_b); end associate
     end subroutine ascii_draw_text_primitive
+
+    subroutine map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+        real(wp), intent(in) :: x, y, x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(out) :: px, py
+        integer :: width, height
+
+        width = max(1, plot_area%width)
+        height = max(1, plot_area%height)
+        px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min) * &
+             real(max(1, width - 2), wp))
+        py = plot_area%bottom + height - 1 - nint((y - y_min)/(y_max - y_min) * &
+             real(max(1, height - 2), wp))
+    end subroutine map_to_plot_area
 
     subroutine select_pie_chart_character(r, g, b, pie_char)
         !! Select distinct character for pie chart slices based on color matching

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -37,6 +37,7 @@ contains
         integer :: steps, i, px, py
         character(len=1) :: line_char
         real(wp) :: luminance
+        logical :: use_plot_area
         
         ! Calculate luminance for better character selection
         ! Using standard luminance formula
@@ -88,20 +89,31 @@ contains
         
         x = x1
         y = y1
-        
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
+
         do i = 0, steps
-            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
-            
-            
-            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
-                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
-                if (canvas(py, px) == ' ') then
-                    canvas(py, px) = line_char
-                else if (canvas(py, px) /= line_char) then
-                    canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+            if (use_plot_area) then
+                call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+                if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                    py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
+                end if
+            else
+                px = int((x - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
+                py = (plot_height - 1) - int((y - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+                if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
                 end if
             end if
-            
+
             x = x + step_x
             y = y + step_y
         end do
@@ -120,7 +132,7 @@ contains
         real(wp), intent(in) :: current_r, current_g, current_b
 
         integer :: px(4), py(4), i, j, min_x, max_x, min_y, max_y
-        logical :: inside_first, inside_second
+        logical :: inside_first, inside_second, use_plot_area
         real(wp) :: x_center, y_center
         character(len=1) :: fill_char
         real(wp) :: color_intensity
@@ -130,10 +142,16 @@ contains
         character(len=*), parameter :: PIE_CHARS = '-=+%#@*.:&'
 
         ! Convert coordinates to ASCII canvas coordinates (matching line drawing algorithm)
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
         do i = 1, 4
-            ! Map to usable plot area (excluding 1-char border on each side)
-            call map_to_plot_area(x_quad(i), y_quad(i), x_min, x_max, y_min, y_max, &
-                                  plot_area, px(i), py(i))
+            if (use_plot_area) then
+                ! Map to usable plot area (excluding 1-char border on each side)
+                call map_to_plot_area(x_quad(i), y_quad(i), x_min, x_max, y_min, y_max, &
+                                      plot_area, px(i), py(i))
+            else
+                px(i) = int((x_quad(i) - x_min) / (x_max - x_min) * real(plot_width - 3, wp)) + 2
+                py(i) = (plot_height - 1) - int((y_quad(i) - y_min) / (y_max - y_min) * real(plot_height - 3, wp))
+            end if
         end do
 
         ! Determine if this is likely a pie chart based on color patterns
@@ -158,10 +176,17 @@ contains
         end if
         
         ! Fill bounding rectangle with bounds checking
-        min_x = max(plot_area%left + 1, min(minval(px), plot_area%left + plot_area%width - 1))
-        max_x = max(plot_area%left + 1, min(maxval(px), plot_area%left + plot_area%width - 1))
-        min_y = max(plot_area%bottom + 1, min(minval(py), plot_area%bottom + plot_area%height - 1))
-        max_y = max(plot_area%bottom + 1, min(maxval(py), plot_area%bottom + plot_area%height - 1))
+        if (use_plot_area) then
+            min_x = max(plot_area%left + 1, min(minval(px), plot_area%left + plot_area%width - 1))
+            max_x = max(plot_area%left + 1, min(maxval(px), plot_area%left + plot_area%width - 1))
+            min_y = max(plot_area%bottom + 1, min(minval(py), plot_area%bottom + plot_area%height - 1))
+            max_y = max(plot_area%bottom + 1, min(maxval(py), plot_area%bottom + plot_area%height - 1))
+        else
+            min_x = max(2, min(minval(px), plot_width - 1))
+            max_x = max(2, min(maxval(px), plot_width - 1))
+            min_y = max(2, min(minval(py), plot_height - 1))
+            max_y = max(2, min(maxval(py), plot_height - 1))
+        end if
         
         do j = min_y, max_y
             y_center = real(j, wp)
@@ -232,10 +257,11 @@ contains
         
         character(len=500) :: processed_text
         integer :: processed_len
-        logical :: screen_coords
+        logical :: screen_coords, use_plot_area
 
         ! Produce ASCII-safe text matching the other ASCII text paths.
         call sanitize_ascii_text(text_input, processed_text, processed_len)
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
 
         ! Convert coordinates - check if already in screen coordinates
         screen_coords = .false.
@@ -245,12 +271,16 @@ contains
             text_x = nint(x)
             text_y = nint(y)
             screen_coords = .true.
-        else
-            ! Convert from data coordinates to canvas coordinates
+        else if (use_plot_area) then
+            ! Convert from data coordinates to the active plot area.
             text_x = plot_area%left + nint((x - x_min) / (x_max - x_min) * &
                      real(max(1, plot_area%width), wp))
             text_y = plot_area%bottom + plot_area%height - nint((y - y_min) / &
                      (y_max - y_min) * real(max(1, plot_area%height), wp))
+        else
+            ! Convert from data coordinates to canvas coordinates
+            text_x = nint((x - x_min) / (x_max - x_min) * real(plot_width, wp))
+            text_y = nint((y_max - y) / (y_max - y_min) * real(plot_height, wp))
         end if
 
         ! Clamp to canvas bounds so text stays inside the frame border
@@ -258,11 +288,14 @@ contains
         if (screen_coords) then
             text_x = max(1, min(text_x, plot_width - processed_len - 1))
             text_y = max(1, min(text_y, plot_height))
-        else
+        else if (use_plot_area) then
             text_x = max(plot_area%left + 1, &
                          min(text_x, plot_area%left + max(1, plot_area%width) - processed_len - 1))
             text_y = max(plot_area%bottom + 1, &
                          min(text_y, plot_area%bottom + max(1, plot_area%height) - 1))
+        else
+            text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
+            text_y = max(1, min(text_y, plot_height))
         end if
 
         text = processed_text(1:processed_len)

--- a/src/backends/ascii/fortplot_ascii_rendering.f90
+++ b/src/backends/ascii/fortplot_ascii_rendering.f90
@@ -20,11 +20,14 @@ module fortplot_ascii_rendering
 contains
 
     subroutine ascii_finalize(canvas, text_elements, num_text_elements, &
+                             arrow_elements, num_arrow_elements, &
                              plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                              legend_lines, num_legend_lines, filename)
         character(len=1), intent(inout) :: canvas(:,:)
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(in) :: num_text_elements
+        type(text_element_t), intent(inout) :: arrow_elements(:)
+        integer, intent(in) :: num_arrow_elements
         integer, intent(in) :: plot_width, plot_height
         character(len=:), allocatable, intent(in) :: title_text, xlabel_text, ylabel_text
         character(len=*), intent(in) :: legend_lines(:)
@@ -36,6 +39,7 @@ contains
         
         if (len_trim(filename) == 0 .or. trim(filename) == "terminal") then
             call output_to_terminal(canvas, text_elements, num_text_elements, &
+                                  arrow_elements, num_arrow_elements, &
                                   plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                                   legend_lines, num_legend_lines)
         else
@@ -46,12 +50,14 @@ contains
                 ! Fall back to terminal output
                 call log_info("Falling back to terminal output due to file error")
                 call output_to_terminal(canvas, text_elements, num_text_elements, &
+                                      arrow_elements, num_arrow_elements, &
                                       plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                                       legend_lines, num_legend_lines)
                 return
             end if
             
             call output_to_file(canvas, text_elements, num_text_elements, &
+                              arrow_elements, num_arrow_elements, &
                               plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                               legend_lines, num_legend_lines, unit)
             close(unit)
@@ -60,11 +66,14 @@ contains
     end subroutine ascii_finalize
     
     subroutine output_to_terminal(canvas, text_elements, num_text_elements, &
+                                 arrow_elements, num_arrow_elements, &
                                  plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                                  legend_lines, num_legend_lines)
         character(len=1), intent(inout) :: canvas(:,:)
         type(text_element_t), intent(in) :: text_elements(:)
         integer, intent(in) :: num_text_elements
+        type(text_element_t), intent(in) :: arrow_elements(:)
+        integer, intent(in) :: num_arrow_elements
         integer, intent(in) :: plot_width, plot_height
         character(len=:), allocatable, intent(in) :: title_text, xlabel_text, ylabel_text
         character(len=*), intent(in) :: legend_lines(:)
@@ -75,6 +84,9 @@ contains
         call render_text_elements_to_canvas(canvas, text_elements, &
                                             num_text_elements, &
                                             plot_width, plot_height)
+        call render_overlay_elements_to_canvas(canvas, arrow_elements, &
+                                               num_arrow_elements, &
+                                               plot_width, plot_height)
         
         if (allocated(title_text)) then
             print '(A)', ''  ! Empty line before title
@@ -120,11 +132,14 @@ contains
     end subroutine output_to_terminal
 
     subroutine output_to_file(canvas, text_elements, num_text_elements, &
+                            arrow_elements, num_arrow_elements, &
                             plot_width, plot_height, title_text, xlabel_text, ylabel_text, &
                             legend_lines, num_legend_lines, unit)
         character(len=1), intent(inout) :: canvas(:,:)
         type(text_element_t), intent(in) :: text_elements(:)
         integer, intent(in) :: num_text_elements
+        type(text_element_t), intent(in) :: arrow_elements(:)
+        integer, intent(in) :: num_arrow_elements
         integer, intent(in) :: plot_width, plot_height
         character(len=:), allocatable, intent(in) :: title_text, xlabel_text, ylabel_text
         character(len=*), intent(in) :: legend_lines(:)
@@ -137,6 +152,9 @@ contains
         call render_text_elements_to_canvas(canvas, text_elements, &
                                             num_text_elements, &
                                             plot_width, plot_height)
+        call render_overlay_elements_to_canvas(canvas, arrow_elements, &
+                                               num_arrow_elements, &
+                                               plot_width, plot_height)
 
         if (allocated(title_text)) then
             write(unit, '(A)') ''  ! Empty line before title
@@ -204,5 +222,22 @@ contains
             output = output // line_buffer(1:line_len) // new_line('a')
         end do
     end function ascii_get_output
+
+    subroutine render_overlay_elements_to_canvas(canvas, overlay_elements, num_overlay_elements, &
+                                                 plot_width, plot_height)
+        character(len=1), intent(inout) :: canvas(:,:)
+        type(text_element_t), intent(in) :: overlay_elements(:)
+        integer, intent(in) :: num_overlay_elements, plot_width, plot_height
+        integer :: i, x, y
+        character(len=500) :: ascii_text
+
+        do i = 1, num_overlay_elements
+            call escape_unicode_for_ascii(overlay_elements(i)%text, ascii_text)
+            if (len_trim(ascii_text) == 0) cycle
+            x = max(1, min(overlay_elements(i)%x, plot_width - 1))
+            y = max(1, min(overlay_elements(i)%y, plot_height))
+            canvas(y, x) = ascii_text(1:1)
+        end do
+    end subroutine render_overlay_elements_to_canvas
 
 end module fortplot_ascii_rendering

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -136,6 +136,7 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
         real(wp) :: tick_x
         integer :: decimals
         logical :: use_custom_xticks
+        logical :: use_plot_area
 
         use_custom_xticks = .false.
         if (present(custom_xticks) .and. present(custom_xtick_labels)) then
@@ -159,6 +160,7 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
             .not. use_custom_xticks) then
             decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
         end if
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
 
         do i = 1, num_x_ticks
             tick_x = x_tick_positions(i)
@@ -171,21 +173,36 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
                                                date_format=x_date_format, &
                                                data_min=x_min, data_max=x_max)
             end if
-            associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
-                           real(max(1, plot_area%width - 2), wp)) + plot_area%left + 1, &
-                         sy => plot_area%bottom + plot_area%height - 1)
-                ! Center the label on the tick column rather than left-anchoring it,
-                ! so labels sit under the bar/tick they name (issue #1957).
-                associate (start_col => sx - len_trim(tick_label)/2)
-                    call add_text_element(text_elements, num_text_elements, &
-                                          real(max(plot_area%left + 1, &
-                                                   min(start_col, plot_area%left + plot_area%width - 1)), wp), &
-                                          real(sy, wp), &
-                                          trim(tick_label), &
-                                          current_r, current_g, current_b, &
-                                          x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
+            if (use_plot_area) then
+                associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
+                               real(max(1, plot_area%width - 2), wp)) + plot_area%left + 1, &
+                             sy => plot_area%bottom + plot_area%height - 1)
+                    ! Center the label on the tick column rather than left-anchoring it,
+                    ! so labels sit under the bar/tick they name (issue #1957).
+                    associate (start_col => sx - len_trim(tick_label)/2)
+                        call add_text_element(text_elements, num_text_elements, &
+                                              real(max(plot_area%left + 1, &
+                                                       min(start_col, plot_area%left + plot_area%width - 1)), wp), &
+                                              real(sy, wp), &
+                                              trim(tick_label), &
+                                              current_r, current_g, current_b, &
+                                              x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
+                    end associate
                 end associate
-            end associate
+            else
+                associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
+                               real(plot_width - 2, wp)) + 1, &
+                             sy => plot_height)
+                    associate (start_col => sx - len_trim(tick_label)/2)
+                        call add_text_element(text_elements, num_text_elements, &
+                                              real(max(1, min(start_col, plot_width - 1)), wp), &
+                                              real(sy, wp), &
+                                              trim(tick_label), &
+                                              current_r, current_g, current_b, &
+                                              x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
+                    end associate
+                end associate
+            end if
         end do
     end subroutine render_ascii_x_ticks
 
@@ -209,6 +226,7 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
         integer :: decimals
         integer, allocatable :: row_best_len(:)
         character(len=64), allocatable :: row_best_label(:)
+        logical :: use_plot_area
 
         call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, &
                                  y_tick_positions, num_y_ticks)
@@ -216,11 +234,19 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
         if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
             decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
         end if
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
 
-        allocate (row_best_len(max(1, plot_area%bottom + plot_area%height + 1)))
-        allocate (row_best_label(max(1, plot_area%bottom + plot_area%height + 1)))
-        row_best_len = 0
-        row_best_label = ''
+        if (use_plot_area) then
+            allocate (row_best_len(max(1, plot_area%bottom + plot_area%height + 1)))
+            allocate (row_best_label(max(1, plot_area%bottom + plot_area%height + 1)))
+            row_best_len = 0
+            row_best_label = ''
+        else
+            allocate (row_best_len(max(1, plot_height + 1)))
+            allocate (row_best_label(max(1, plot_height + 1)))
+            row_best_len = 0
+            row_best_label = ''
+        end if
 
         do i = 1, num_y_ticks
             tick_y = y_tick_positions(i)
@@ -231,24 +257,41 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
                                                date_format=y_date_format, &
                                                data_min=y_min, data_max=y_max)
             end if
-            row = plot_area%bottom + plot_area%height - 1 - &
-                  nint((y_max - tick_y)/(y_max - y_min)*real(max(1, plot_area%height - 2), wp))
-            row = max(plot_area%bottom + 1, min(row, plot_area%bottom + plot_area%height - 1))
+            if (use_plot_area) then
+                row = plot_area%bottom + plot_area%height - 1 - &
+                      nint((y_max - tick_y)/(y_max - y_min)*real(max(1, plot_area%height - 2), wp))
+                row = max(plot_area%bottom + 1, min(row, plot_area%bottom + plot_area%height - 1))
+            else
+                row = nint((y_max - tick_y)/(y_max - y_min)*real(plot_height, wp))
+                row = max(1, min(row, plot_height))
+            end if
             if (len_trim(tick_label) > row_best_len(row)) then
                 row_best_len(row) = len_trim(tick_label)
                 row_best_label(row) = adjustl(tick_label)
             end if
         end do
 
-        do row = plot_area%bottom + 1, plot_area%bottom + plot_area%height - 1
-            if (row_best_len(row) > 0) then
-                call add_text_element(text_elements, num_text_elements, &
-                                      real(plot_area%left + 1, wp), real(row, wp), &
-                                      trim(row_best_label(row)), &
-                                      current_r, current_g, current_b, &
-                                      x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
-            end if
-        end do
+        if (use_plot_area) then
+            do row = plot_area%bottom + 1, plot_area%bottom + plot_area%height - 1
+                if (row_best_len(row) > 0) then
+                    call add_text_element(text_elements, num_text_elements, &
+                                          real(plot_area%left + 1, wp), real(row, wp), &
+                                          trim(row_best_label(row)), &
+                                          current_r, current_g, current_b, &
+                                          x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
+                end if
+            end do
+        else
+            do row = 1, plot_height
+                if (row_best_len(row) > 0 .and. row < plot_height) then
+                    call add_text_element(text_elements, num_text_elements, &
+                                          2.0_wp, real(row, wp), &
+                                          trim(row_best_label(row)), &
+                                          current_r, current_g, current_b, &
+                                          x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
+                end if
+            end do
+        end if
     end subroutine render_ascii_y_ticks
 
     subroutine draw_line_on_canvas_local(canvas, x1, y1, x2, y2, x_min, x_max, y_min, &
@@ -262,6 +305,7 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
 
         real(wp) :: dx, dy, length, step_x, step_y, x, y
         integer :: steps, i, px, py
+        logical :: use_plot_area
 
         dx = x2 - x1
         dy = y2 - y1
@@ -275,16 +319,28 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
 
         x = x1
         y = y1
+        use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
 
         do i = 0, steps
-            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
-
-            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
-                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
-                if (canvas(py, px) == ' ') then
-                    canvas(py, px) = line_char
-                else if (canvas(py, px) /= line_char) then
-                    canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+            if (use_plot_area) then
+                call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+                if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                    py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
+                end if
+            else
+                px = int((x - x_min)/(x_max - x_min)*real(plot_width - 3, wp)) + 2
+                py = (plot_height - 1) - int((y - y_min)/(y_max - y_min)*real(plot_height - 3, wp))
+                if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= plot_height - 1) then
+                    if (canvas(py, px) == ' ') then
+                        canvas(py, px) = line_char
+                    else if (canvas(py, px) /= line_char) then
+                        canvas(py, px) = get_blend_char(canvas(py, px), line_char)
+                    end if
                 end if
             end if
 
@@ -299,11 +355,16 @@ subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_thres
         integer, intent(out) :: px, py
         integer :: inner_width, inner_height
 
-        inner_width = max(1, plot_area%width - 2)
-        inner_height = max(1, plot_area%height - 2)
-        px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
-        py = plot_area%bottom + plot_area%height - 1 - &
-             nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+        if (plot_area%width > 0 .and. plot_area%height > 0) then
+            inner_width = max(1, plot_area%width - 2)
+            inner_height = max(1, plot_area%height - 2)
+            px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
+            py = plot_area%bottom + plot_area%height - 1 - &
+                 nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+        else
+            px = 1
+            py = 1
+        end if
     end subroutine map_to_plot_area
 
     subroutine ascii_draw_text_helper(text_elements, num_text_elements, &

--- a/src/backends/ascii/fortplot_ascii_text.f90
+++ b/src/backends/ascii/fortplot_ascii_text.f90
@@ -10,6 +10,7 @@ module fortplot_ascii_text
      use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
                                           format_tick_value_consistent
      use fortplot_ascii_mathtext, only: sanitize_ascii_text
+     use fortplot_margins, only: plot_area_t
      use fortplot_ascii_utils, only: is_legend_entry_text, &
                                      is_registered_legend_label, is_autopct_text, &
                                      get_blend_char, text_element_t
@@ -35,7 +36,7 @@ contains
                                            x_date_format, y_date_format, &
                                            z_min, z_max, has_3d_plots, &
                                            current_r, current_g, current_b, &
-                                           plot_width, plot_height, &
+                                           plot_area, plot_width, plot_height, &
                                            title_text, xlabel_text, ylabel_text, &
                                            text_elements, num_text_elements, &
                                            custom_xticks, custom_xtick_labels)
@@ -49,6 +50,7 @@ contains
         real(wp), intent(in), optional :: z_min, z_max
         logical, intent(in) :: has_3d_plots
         real(wp), intent(in) :: current_r, current_g, current_b
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         character(len=:), allocatable, intent(inout) :: title_text, xlabel_text, &
                                                         ylabel_text
@@ -67,13 +69,14 @@ contains
         associate (unused_h3d => has_3d_plots); end associate
 
         call process_axis_labels(title, processed_title, processed_len, title_text)
-        call draw_ascii_axis_lines(canvas, x_min, x_max, y_min, y_max, plot_width, plot_height)
+        call draw_ascii_axis_lines(canvas, x_min, x_max, y_min, y_max, plot_area, &
+                                   plot_width, plot_height)
         call render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_threshold, &
                                   x_tick_positions, custom_xticks, custom_xtick_labels, &
-                                  x_date_format, plot_width, plot_height, &
+                                  x_date_format, plot_area, plot_width, plot_height, &
                                   text_elements, num_text_elements, current_r, current_g, current_b)
         call render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_threshold, &
-                                  y_tick_positions, y_date_format, plot_width, plot_height, &
+                                  y_tick_positions, y_date_format, plot_area, plot_width, plot_height, &
                                   text_elements, num_text_elements, current_r, current_g, current_b)
         call process_axis_labels(xlabel, processed_title, processed_len, xlabel_text)
         call process_axis_labels(ylabel, processed_title, processed_len, ylabel_text)
@@ -95,23 +98,25 @@ contains
         end if
     end subroutine process_axis_labels
 
-    subroutine draw_ascii_axis_lines(canvas, x_min, x_max, y_min, y_max, plot_width, plot_height)
+    subroutine draw_ascii_axis_lines(canvas, x_min, x_max, y_min, y_max, plot_area, &
+                                     plot_width, plot_height)
         !! Draw horizontal and vertical axis lines on ASCII canvas
         character(len=1), intent(inout) :: canvas(:, :)
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
 
         call draw_line_on_canvas_local(canvas, x_min, y_min, x_max, y_min, &
-                                       x_min, x_max, y_min, y_max, plot_width, &
-                                       plot_height, '-')
+                                       x_min, x_max, y_min, y_max, plot_area, &
+                                       plot_width, plot_height, '-')
         call draw_line_on_canvas_local(canvas, x_min, y_min, x_min, y_max, &
-                                       x_min, x_max, y_min, y_max, plot_width, &
-                                       plot_height, '|')
+                                       x_min, x_max, y_min, y_max, plot_area, &
+                                       plot_width, plot_height, '|')
     end subroutine draw_ascii_axis_lines
 
 subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_threshold, &
                                  x_tick_positions, custom_xticks, custom_xtick_labels, &
-                                 x_date_format, plot_width, plot_height, &
+                                 x_date_format, plot_area, plot_width, plot_height, &
                                  text_elements, num_text_elements, current_r, current_g, current_b)
         !! Render X-axis tick marks and labels on ASCII canvas
         character(len=*), intent(in) :: xscale
@@ -120,6 +125,7 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
         real(wp), intent(in), optional :: custom_xticks(:)
         character(len=*), intent(in), optional :: custom_xtick_labels(:)
         character(len=*), intent(in), optional :: x_date_format
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(inout) :: num_text_elements
@@ -166,30 +172,32 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
                                                data_min=x_min, data_max=x_max)
             end if
             associate (sx => nint((tick_x - x_min)/(x_max - x_min)* &
-                           real(plot_width - 2, wp)) + 1, &
-                         sy => plot_height)
+                           real(max(1, plot_area%width - 2), wp)) + plot_area%left + 1, &
+                         sy => plot_area%bottom + plot_area%height - 1)
                 ! Center the label on the tick column rather than left-anchoring it,
                 ! so labels sit under the bar/tick they name (issue #1957).
                 associate (start_col => sx - len_trim(tick_label)/2)
                     call add_text_element(text_elements, num_text_elements, &
-                                          real(max(1, min(start_col, plot_width - 1)), wp), &
+                                          real(max(plot_area%left + 1, &
+                                                   min(start_col, plot_area%left + plot_area%width - 1)), wp), &
                                           real(sy, wp), &
                                           trim(tick_label), &
                                           current_r, current_g, current_b, &
-                                          x_min, x_max, y_min, y_max, plot_width, plot_height)
+                                          x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
                 end associate
             end associate
         end do
     end subroutine render_ascii_x_ticks
 
-    subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_threshold, &
-                                   y_tick_positions, y_date_format, plot_width, plot_height, &
+subroutine render_ascii_y_ticks(yscale, x_min, x_max, y_min, y_max, symlog_threshold, &
+                                   y_tick_positions, y_date_format, plot_area, plot_width, plot_height, &
                                    text_elements, num_text_elements, current_r, current_g, current_b)
         !! Render Y-axis tick marks with row-based de-duplication on ASCII canvas
         character(len=*), intent(in) :: yscale
         real(wp), intent(in) :: x_min, x_max, y_min, y_max, symlog_threshold
         real(wp), contiguous, intent(inout) :: y_tick_positions(:)
         character(len=*), intent(in), optional :: y_date_format
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(inout) :: num_text_elements
@@ -209,8 +217,8 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
             decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
         end if
 
-        allocate (row_best_len(plot_height))
-        allocate (row_best_label(plot_height))
+        allocate (row_best_len(max(1, plot_area%bottom + plot_area%height + 1)))
+        allocate (row_best_label(max(1, plot_area%bottom + plot_area%height + 1)))
         row_best_len = 0
         row_best_label = ''
 
@@ -223,30 +231,32 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
                                                date_format=y_date_format, &
                                                data_min=y_min, data_max=y_max)
             end if
-            row = nint((y_max - tick_y)/(y_max - y_min)*real(plot_height, wp))
-            row = max(1, min(row, plot_height))
+            row = plot_area%bottom + plot_area%height - 1 - &
+                  nint((y_max - tick_y)/(y_max - y_min)*real(max(1, plot_area%height - 2), wp))
+            row = max(plot_area%bottom + 1, min(row, plot_area%bottom + plot_area%height - 1))
             if (len_trim(tick_label) > row_best_len(row)) then
                 row_best_len(row) = len_trim(tick_label)
                 row_best_label(row) = adjustl(tick_label)
             end if
         end do
 
-        do row = 1, plot_height
-            if (row_best_len(row) > 0 .and. row < plot_height) then
+        do row = plot_area%bottom + 1, plot_area%bottom + plot_area%height - 1
+            if (row_best_len(row) > 0) then
                 call add_text_element(text_elements, num_text_elements, &
-                                      2.0_wp, real(row, wp), &
+                                      real(plot_area%left + 1, wp), real(row, wp), &
                                       trim(row_best_label(row)), &
                                       current_r, current_g, current_b, &
-                                      x_min, x_max, y_min, y_max, plot_width, plot_height)
+                                      x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
             end if
         end do
     end subroutine render_ascii_y_ticks
 
     subroutine draw_line_on_canvas_local(canvas, x1, y1, x2, y2, x_min, x_max, y_min, &
-                                         y_max, plot_width, plot_height, line_char)
+                                         y_max, plot_area, plot_width, plot_height, line_char)
         character(len=1), intent(inout) :: canvas(:, :)
         real(wp), intent(in) :: x1, y1, x2, y2
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: plot_width, plot_height
         character(len=1), intent(in) :: line_char
 
@@ -267,13 +277,10 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
         y = y1
 
         do i = 0, steps
-            ! Map to usable plot area (excluding 1-char border on each side)
-            px = int((x - x_min)/(x_max - x_min)*real(plot_width - 3, wp)) + 2
-            py = (plot_height - 1) - int((y - y_min)/(y_max - &
-                                                      y_min)*real(plot_height - 3, wp))
+            call map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
 
-            if (px >= 2 .and. px <= plot_width - 1 .and. py >= 2 .and. py <= &
-                plot_height - 1) then
+            if (px >= plot_area%left + 1 .and. px <= plot_area%left + plot_area%width - 1 .and. &
+                py >= plot_area%bottom + 1 .and. py <= plot_area%bottom + plot_area%height - 1) then
                 if (canvas(py, px) == ' ') then
                     canvas(py, px) = line_char
                 else if (canvas(py, px) /= line_char) then
@@ -285,6 +292,19 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
             y = y + step_y
         end do
     end subroutine draw_line_on_canvas_local
+
+    subroutine map_to_plot_area(x, y, x_min, x_max, y_min, y_max, plot_area, px, py)
+        real(wp), intent(in) :: x, y, x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(out) :: px, py
+        integer :: inner_width, inner_height
+
+        inner_width = max(1, plot_area%width - 2)
+        inner_height = max(1, plot_area%height - 2)
+        px = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)*real(inner_width, wp))
+        py = plot_area%bottom + plot_area%height - 1 - &
+             nint((y - y_min)/(y_max - y_min)*real(inner_height, wp))
+    end subroutine map_to_plot_area
 
     subroutine ascii_draw_text_helper(text_elements, num_text_elements, &
                                       legend_lines, num_legend_lines, &
@@ -358,7 +378,8 @@ subroutine render_ascii_x_ticks(xscale, x_min, x_max, y_min, y_max, symlog_thres
         if (.not. handled) then
             call store_text_element(text_elements, num_text_elements, text_x, text_y, &
                                     processed_text, x, y, text, x_min, x_max, y_min, y_max, &
-                                    plot_width, plot_height, current_r, current_g, current_b)
+                                    plot_width=plot_width, plot_height=plot_height, &
+                                    current_r=current_r, current_g=current_g, current_b=current_b)
         end if
     end subroutine ascii_draw_text_helper
 

--- a/src/backends/ascii/fortplot_ascii_text_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_text_elements.f90
@@ -8,6 +8,7 @@ module fortplot_ascii_text_elements
 
      use fortplot_ascii_mathtext, only: sanitize_ascii_text
      use fortplot_ascii_primitives, only: ascii_draw_text_primitive
+     use fortplot_margins, only: plot_area_t
      use fortplot_ascii_utils, only: text_element_t
      use, intrinsic :: iso_fortran_env, only: wp => real64
      implicit none
@@ -19,7 +20,7 @@ contains
 
     subroutine add_text_element(text_elements, num_text_elements, x, y, text, &
                                 current_r, current_g, current_b, &
-                                x_min, x_max, y_min, y_max, plot_width, plot_height)
+                                x_min, x_max, y_min, y_max, plot_area, plot_width, plot_height)
         !! Create and store a text element on the ASCII canvas
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(inout) :: num_text_elements
@@ -27,6 +28,7 @@ contains
         character(len=*), intent(in) :: text
         real(wp), intent(in) :: current_r, current_g, current_b
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in), optional :: plot_area
         integer, intent(in) :: plot_width, plot_height
 
         integer :: text_x, text_y
@@ -48,15 +50,30 @@ contains
                 text_x = nint(x)
                 text_y = nint(y)
             else
-                ! Convert from data coordinates to canvas coordinates
-                text_x = nint((x - x_min)/(x_max - x_min)*real(plot_width, wp))
-                text_y = nint((y_max - y)/(y_max - y_min)*real(plot_height, wp))
+                if (present(plot_area)) then
+                    ! Convert from data coordinates to the active plot area.
+                    text_x = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)* &
+                             real(max(1, plot_area%width - 2), wp))
+                    text_y = plot_area%bottom + plot_area%height - 1 - nint((y - y_min)/(y_max - y_min)* &
+                             real(max(1, plot_area%height - 2), wp))
+                else
+                    ! Convert from data coordinates to canvas coordinates.
+                    text_x = nint((x - x_min)/(x_max - x_min)*real(plot_width, wp))
+                    text_y = nint((y_max - y)/(y_max - y_min)*real(plot_height, wp))
+                end if
             end if
 
-            ! Clamp to canvas bounds. Reserve margin on the right so text
-            ! never touches the border ``|`` glyph (issue #1706).
-            text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
-            text_y = max(1, min(text_y, plot_height))
+            if (present(plot_area)) then
+                text_x = max(plot_area%left + 1, &
+                             min(text_x, plot_area%left + max(1, plot_area%width) - processed_len - 1))
+                text_y = max(plot_area%bottom + 1, &
+                             min(text_y, plot_area%bottom + max(1, plot_area%height) - 1))
+            else
+                ! Clamp to canvas bounds. Reserve margin on the right so text
+                ! never touches the border ``|`` glyph (issue #1706).
+                text_x = max(2, min(text_x, max(2, plot_width - processed_len - 1)))
+                text_y = max(1, min(text_y, plot_height))
+            end if
 
             text_elements(num_text_elements)%text = processed_text(1:processed_len)
             text_elements(num_text_elements)%x = text_x
@@ -69,7 +86,7 @@ contains
 
     subroutine store_text_element(text_elements, num_text_elements, text_x, text_y, &
                                    processed_text, x, y, text, x_min, x_max, y_min, y_max, &
-                                   plot_width, plot_height, current_r, current_g, current_b)
+                                   plot_area, plot_width, plot_height, current_r, current_g, current_b)
         !! Store a pre-processed text element for later ASCII rendering
         type(text_element_t), intent(inout) :: text_elements(:)
         integer, intent(inout) :: num_text_elements
@@ -78,12 +95,24 @@ contains
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        type(plot_area_t), intent(in), optional :: plot_area
         integer, intent(in) :: plot_width, plot_height
         real(wp), intent(in) :: current_r, current_g, current_b
+        type(plot_area_t) :: effective_plot_area
+
+        if (present(plot_area)) then
+            effective_plot_area = plot_area
+        else
+            effective_plot_area%left = 1
+            effective_plot_area%bottom = 1
+            effective_plot_area%width = plot_width
+            effective_plot_area%height = plot_height
+        end if
 
         call ascii_draw_text_primitive(text_x, text_y, processed_text, &
                                        x, y, text, x_min, x_max, y_min, y_max, &
-                                       plot_width, plot_height, current_r, current_g, current_b)
+                                       effective_plot_area, plot_width, plot_height, &
+                                       current_r, current_g, current_b)
 
         num_text_elements = num_text_elements + 1
         text_elements(num_text_elements)%text = processed_text

--- a/src/backends/ascii/fortplot_ascii_text_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_text_elements.f90
@@ -34,6 +34,7 @@ contains
         integer :: text_x, text_y
         character(len=500) :: processed_text
         integer :: processed_len
+        logical :: use_plot_area
 
         ! Produce ASCII-safe text: LaTeX -> Unicode -> strip math delimiters,
         ! simplify mathtext, and transliterate remaining symbols.
@@ -42,6 +43,8 @@ contains
         ! Store text element for later rendering
         if (num_text_elements < size(text_elements)) then
             num_text_elements = num_text_elements + 1
+            use_plot_area = present(plot_area) .and. plot_area%width > 0 .and. &
+                            plot_area%height > 0
 
             ! Convert coordinates - check if already in screen coordinates
             if (x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &
@@ -50,7 +53,7 @@ contains
                 text_x = nint(x)
                 text_y = nint(y)
             else
-                if (present(plot_area)) then
+                if (use_plot_area) then
                     ! Convert from data coordinates to the active plot area.
                     text_x = plot_area%left + 1 + nint((x - x_min)/(x_max - x_min)* &
                              real(max(1, plot_area%width - 2), wp))
@@ -63,7 +66,7 @@ contains
                 end if
             end if
 
-            if (present(plot_area)) then
+            if (use_plot_area) then
                 text_x = max(plot_area%left + 1, &
                              min(text_x, plot_area%left + max(1, plot_area%width) - processed_len - 1))
                 text_y = max(plot_area%bottom + 1, &

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -128,7 +128,7 @@ contains
         ! Background clearing is handled by backend-specific rendering
     end subroutine render_figure_background
 
- subroutine render_figure_axes(backend, xscale, yscale, symlog_threshold, &
+    subroutine render_figure_axes(backend, xscale, yscale, symlog_threshold, &
                                 x_min, x_max, y_min, y_max, title, xlabel, ylabel, &
                                 plots, plot_count, has_twinx, twinx_y_min, &
                                 twinx_y_max, &
@@ -151,7 +151,6 @@ contains
                                                                twiny_xlabel
         character(len=*), intent(in), optional :: twinx_yscale, twiny_xscale
         type(figure_state_t), intent(in), optional :: state
-
         logical :: has_3d
         real(wp) :: zmin, zmax
 
@@ -231,7 +230,6 @@ contains
         real(wp), intent(in) :: zmin, zmax
         logical, intent(in) :: has_3d
         type(figure_state_t), intent(in), optional :: state
-
         character(len=64) :: xfmt, yfmt
         character(len=:), allocatable :: t_title, t_xlabel, t_ylabel
 

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -477,4 +477,99 @@ contains
         end if
     end subroutine ensure_figure_storage
 
+    subroutine setup_figure_backend(state, backend_name)
+        type(figure_state_t), intent(inout) :: state
+        character(len=*), intent(in) :: backend_name
+
+        call initialize_backend(state%backend, backend_name, state%width, &
+                                state%height, state%dpi)
+        state%backend_name = backend_name
+        state%rendered = .false.
+    end subroutine setup_figure_backend
+
+    subroutine set_figure_labels(state, title, xlabel, ylabel)
+        type(figure_state_t), intent(inout) :: state
+        character(len=*), intent(in), optional :: title, xlabel, ylabel
+
+        if (present(title)) state%title = title
+
+        if (present(xlabel)) then
+            select case (state%active_axis)
+            case (AXIS_TWINY)
+                state%twiny_xlabel = xlabel
+                state%has_twiny = .true.
+            case default
+                state%xlabel = xlabel
+            end select
+        end if
+
+        if (present(ylabel)) then
+            select case (state%active_axis)
+            case (AXIS_TWINX)
+                state%twinx_ylabel = ylabel
+                state%has_twinx = .true.
+            case default
+                state%ylabel = ylabel
+            end select
+        end if
+    end subroutine set_figure_labels
+
+    subroutine set_figure_scales(state, xscale, yscale, threshold, base, linscale)
+        type(figure_state_t), intent(inout) :: state
+        character(len=*), intent(in), optional :: xscale, yscale
+        real(wp), intent(in), optional :: threshold, base, linscale
+
+        if (present(xscale)) then
+            if (state%active_axis == AXIS_TWINY) then
+                state%twiny_xscale = xscale
+                state%has_twiny = .true.
+            else
+                state%xscale = xscale
+            end if
+        end if
+
+        if (present(yscale)) then
+            if (state%active_axis == AXIS_TWINX) then
+                state%twinx_yscale = yscale
+                state%has_twinx = .true.
+            else
+                state%yscale = yscale
+            end if
+        end if
+        if (present(threshold)) state%symlog_threshold = threshold
+        if (present(base)) state%symlog_base = base
+        if (present(linscale)) state%symlog_linscale = linscale
+    end subroutine set_figure_scales
+
+    subroutine set_figure_limits(state, x_min, x_max, y_min, y_max)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in), optional :: x_min, x_max, y_min, y_max
+
+        if (present(x_min) .and. present(x_max)) then
+            if (state%active_axis == AXIS_TWINY) then
+                state%twiny_x_min = x_min
+                state%twiny_x_max = x_max
+                state%twiny_xlim_set = .true.
+                state%has_twiny = .true.
+            else
+                state%x_min = x_min
+                state%x_max = x_max
+                state%xlim_set = .true.
+            end if
+        end if
+
+        if (present(y_min) .and. present(y_max)) then
+            if (state%active_axis == AXIS_TWINX) then
+                state%twinx_y_min = y_min
+                state%twinx_y_max = y_max
+                state%twinx_ylim_set = .true.
+                state%has_twinx = .true.
+            else
+                state%y_min = y_min
+                state%y_max = y_max
+                state%ylim_set = .true.
+            end if
+        end if
+    end subroutine set_figure_limits
+
 end module fortplot_figure_initialization

--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -18,6 +18,8 @@ module fortplot_subplot_rendering
     use fortplot_ascii, only: ascii_context
     use fortplot_raster_labels, only: render_title_centered_with_size
     use fortplot_pdf_text, only: estimate_pdf_text_width
+    use fortplot_ascii_mathtext, only: sanitize_ascii_text
+    use fortplot_context, only: plot_context
     implicit none
 
     private
@@ -104,6 +106,15 @@ contains
             end do
         end do
 
+        select type (bk => state%backend)
+        class is (ascii_context)
+            call render_ascii_subplot_titles(state%backend, subplots_array, nr, nc, &
+                                             have_tight, left_f, right_f, bottom_f, &
+                                             top_f, base_left, base_bottom, base_top, &
+                                             ax_w, ax_h, gap_w, gap_h)
+        class default
+        end select
+
         call render_suptitle(state, suptitle_height_frac)
     end subroutine render_subplots
 
@@ -127,6 +138,7 @@ contains
         real(wp) :: subplot_bottom, subplot_top
         real(wp) :: lxmin, lxmax, lymin, lymax
         real(wp) :: lxmin_t, lxmax_t, lymin_t, lymax_t
+        character(len=:), allocatable :: axis_title
         logical :: sx_min, sx_max, sy_min, sy_max
 
         ! Set margins
@@ -160,9 +172,16 @@ contains
                                      sticky_x_min=sx_min, sticky_x_max=sx_max, &
                                      sticky_y_min=sy_min, sticky_y_max=sy_max)
 
+        axis_title = sp%title
+        select type (bk => state%backend)
+        class is (ascii_context)
+            axis_title = ''
+        class default
+        end select
+
         call render_figure_axes(state%backend, state%xscale, state%yscale, &
                                 state%symlog_threshold, lxmin, lxmax, &
-                                lymin, lymax, sp%title, sp%xlabel, sp%ylabel, &
+                                lymin, lymax, axis_title, sp%xlabel, sp%ylabel, &
                                 sp%plots, sp%plot_count, &
                                 has_twinx=.false., has_twiny=.false., &
                                 state=state)
@@ -185,7 +204,66 @@ contains
                                             has_twinx=.false., has_twiny=.false., &
                                             x_date_format=trim(x_date_format), &
                                             y_date_format=trim(y_date_format))
+
     end subroutine render_subplot_cell
+
+    subroutine render_ascii_subplot_titles(backend, subplots_array, nr, nc, have_tight, &
+                                           left_f, right_f, bottom_f, top_f, &
+                                           base_left, base_bottom, base_top, ax_w, &
+                                           ax_h, gap_w, gap_h)
+        class(plot_context), intent(inout) :: backend
+        type(subplot_data_t), intent(in) :: subplots_array(:, :)
+        integer, intent(in) :: nr, nc
+        logical, intent(in) :: have_tight
+        real(wp), intent(in), optional :: left_f(:,:), right_f(:,:)
+        real(wp), intent(in), optional :: bottom_f(:,:), top_f(:,:)
+        real(wp), intent(in) :: base_left, base_bottom, base_top
+        real(wp), intent(in) :: ax_w, ax_h, gap_w, gap_h
+
+        integer :: i, j
+
+        do i = 1, nr
+            do j = 1, nc
+                if (have_tight) then
+                    call set_subplot_margins(backend, left_f(i, j), &
+                                             right_f(i, j), bottom_f(i, j), &
+                                             top_f(i, j))
+                else
+                    call set_subplot_margins(backend, &
+                                             base_left + real(j - 1, wp)*(ax_w + gap_w), &
+                                             base_left + real(j - 1, wp)*(ax_w + gap_w) + ax_w, &
+                                             base_top - real(i - 1, wp)*(ax_h + gap_h) - ax_h, &
+                                             base_top - real(i - 1, wp)*(ax_h + gap_h))
+                end if
+                call render_subplot_title_ascii(backend, subplots_array(i, j)%title)
+            end do
+        end do
+    end subroutine render_ascii_subplot_titles
+
+    subroutine render_subplot_title_ascii(backend, title)
+        class(plot_context), intent(inout) :: backend
+        character(len=*), intent(in) :: title
+        real(wp) :: x_center, y_pos
+        character(len=500) :: processed_title
+        integer :: processed_len, col, row, i
+
+        if (len_trim(title) == 0) return
+
+        select type (bk => backend)
+        class is (ascii_context)
+            call sanitize_ascii_text(title, processed_title, processed_len)
+            x_center = real(bk%plot_area%left, wp) + 0.5_wp*real(bk%plot_area%width, wp)
+            y_pos = real(max(1, bk%plot_area%bottom - 1), wp)
+            row = max(1, min(nint(y_pos), bk%plot_height))
+            col = max(1, min(nint(x_center), bk%plot_width - processed_len - 1))
+            do i = 1, processed_len
+                if (col + i - 1 <= bk%plot_width - 1) then
+                    bk%canvas(row, col + i - 1) = processed_title(i:i)
+                end if
+            end do
+        class default
+        end select
+    end subroutine render_subplot_title_ascii
 
     subroutine render_suptitle(state, suptitle_height_frac)
         !! Render the figure-level suptitle above all subplots
@@ -307,6 +385,12 @@ contains
             bk%margins%top = top_f
             call calculate_pdf_plot_area(bk%width, bk%height, bk%margins, bk%plot_area)
         class is (ascii_context)
+            bk%margins%left = left_f
+            bk%margins%right = right_f
+            bk%margins%bottom = bottom_f
+            bk%margins%top = top_f
+            call calculate_plot_area(bk%plot_width, bk%plot_height, bk%margins, &
+                                     bk%plot_area)
         class default
         end select
     end subroutine set_subplot_margins

--- a/src/figures/rendering/fortplot_figure_plot_renderers.f90
+++ b/src/figures/rendering/fortplot_figure_plot_renderers.f90
@@ -7,6 +7,7 @@ module fortplot_figure_plot_renderers
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
+    use fortplot_constants, only: ASCII_CHAR_ASPECT
     use fortplot_plot_data, only: plot_data_t, arrow_data_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_polar_rendering, only: render_polar_data, render_polar_boundary, &
@@ -94,8 +95,9 @@ contains
         !! Draws arrows at each (x,y) position with direction (u,v)
         !! Respects angles, pivot, alpha, and per-arrow c(:) color mapping.
         use fortplot_scales, only: apply_scale_transform
-        use fortplot_colormap, only: colormap_value_to_color
-        class(plot_context), intent(inout) :: backend
+    use fortplot_colormap, only: colormap_value_to_color
+    use fortplot_ascii, only: ascii_context
+    class(plot_context), intent(inout) :: backend
         type(plot_data_t), intent(in) :: plot
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
         character(len=*), intent(in) :: xscale, yscale
@@ -237,11 +239,40 @@ contains
             shaft_px = mag/max(1.0e-12_wp, data_units_per_px)
             arrow_size = min(16.0_wp, max(4.0_wp, shaft_px*0.33_wp))/8.0_wp
 
-            ! Draw the arrow
-            call backend%draw_arrow(x_pos, y_pos, u_scaled, v_scaled, &
-                                    arrow_size, '->')
+            select type (bk => backend)
+            class is (ascii_context)
+                call bk%text(x_pos, y_pos, ascii_quiver_char(u_scaled, v_scaled))
+            class default
+                call backend%draw_arrow(x_pos, y_pos, u_scaled, v_scaled, &
+                                        arrow_size, '->')
+            end select
         end do
     end subroutine render_quiver_plot
+
+    pure character(len=1) function ascii_quiver_char(dx, dy) result(ch)
+        real(wp), intent(in) :: dx, dy
+        real(wp) :: angle
+
+        angle = atan2(dy / ASCII_CHAR_ASPECT, dx)
+
+        if (abs(angle) < 0.393_wp) then
+            ch = '>'
+        else if (angle >= 0.393_wp .and. angle < 1.178_wp) then
+            ch = '/'
+        else if (angle >= 1.178_wp .and. angle < 1.963_wp) then
+            ch = '^'
+        else if (angle >= 1.963_wp .and. angle < 2.749_wp) then
+            ch = '\'
+        else if (abs(angle) >= 2.749_wp) then
+            ch = '<'
+        else if (angle <= -0.393_wp .and. angle > -1.178_wp) then
+            ch = '\'
+        else if (angle <= -1.178_wp .and. angle > -1.963_wp) then
+            ch = 'v'
+        else
+            ch = '/'
+        end if
+    end function ascii_quiver_char
 
     subroutine render_streamplot_arrows(backend, arrows)
         !! Render queued streamplot arrows after plot lines are drawn.

--- a/test/ascii/test_ascii_quiver_save_2025.f90
+++ b/test/ascii/test_ascii_quiver_save_2025.f90
@@ -1,0 +1,94 @@
+program test_ascii_quiver_save_2025
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, quiver, savefig
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    real(wp) :: x(3), y(3), u(3), v(3)
+    integer :: i, unit, ios, current_line, top_frame, bottom_frame
+    integer :: arrow_line, arrow_col
+    logical :: dir_ok, file_exists
+    character(len=*), parameter :: outfile = &
+        'build/test/output/ascii_quiver_save_2025.txt'
+    character(len=512) :: line
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    do i = 1, 3
+        x(i) = 0.2_wp*real(i, wp)
+        y(i) = 0.5_wp
+        u(i) = 1.0_wp
+        v(i) = 0.0_wp
+    end do
+
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call quiver(x, y, u, v)
+    call savefig(outfile)
+
+    inquire(file=outfile, exist=file_exists)
+    if (.not. file_exists) then
+        print *, 'FAIL: ASCII quiver file missing'
+        stop 1
+    end if
+
+    current_line = 0
+    top_frame = 0
+    bottom_frame = 0
+    arrow_line = 0
+    arrow_col = 0
+
+    open(newunit=unit, file=outfile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open ASCII quiver output'
+        stop 1
+    end if
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        current_line = current_line + 1
+        if (is_frame_line(line)) then
+            if (top_frame == 0) then
+                top_frame = current_line
+            else
+                bottom_frame = current_line
+            end if
+        end if
+        if (arrow_line == 0 .and. index(line, '>') > 0) then
+            arrow_line = current_line
+            arrow_col = index(line, '>')
+        end if
+    end do
+    close(unit)
+
+    if (arrow_line == 0) then
+        print *, 'FAIL: ASCII quiver output missing the expected > glyph'
+        stop 1
+    end if
+    if (top_frame == 0 .or. bottom_frame == 0) then
+        print *, 'FAIL: could not locate the ASCII frame'
+        stop 1
+    end if
+    if (arrow_line <= top_frame .or. arrow_line >= bottom_frame) then
+        print *, 'FAIL: ASCII quiver glyph is not inside the frame'
+        stop 1
+    end if
+    if (arrow_col <= 1) then
+        print *, 'FAIL: ASCII quiver glyph landed on the border'
+        stop 1
+    end if
+
+    print *, 'PASS: ASCII quiver output keeps the expected arrow glyph visible'
+
+contains
+
+    pure logical function is_frame_line(line) result(found)
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable :: t
+
+        t = trim(adjustl(line))
+        found = .false.
+        if (len(t) < 3) return
+        found = t(1:1) == '+' .and. index(t, '---') > 0
+    end function is_frame_line
+
+end program test_ascii_quiver_save_2025

--- a/test/ascii/test_ascii_subplots_2025.f90
+++ b/test/ascii/test_ascii_subplots_2025.f90
@@ -1,0 +1,99 @@
+program test_ascii_subplots_2025
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, subplot, plot, title, savefig
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    real(wp) :: x(8), y(8)
+    integer :: i, unit, ios
+    integer :: line_tl, line_tr, line_bl, line_br
+    logical :: dir_ok, file_exists
+    character(len=*), parameter :: outfile = &
+        'build/test/output/ascii_subplots_2025.txt'
+    character(len=512) :: line
+
+    call create_directory_runtime('build/test/output', dir_ok)
+
+    do i = 1, size(x)
+        x(i) = real(i - 1, wp)
+    end do
+
+    call figure(figsize=[12.0_wp, 8.0_wp])
+
+    call subplot(2, 2, 1)
+    y = x
+    call plot(x, y)
+    call title('subplot 1')
+
+    call subplot(2, 2, 2)
+    y = x**2
+    call plot(x, y)
+    call title('subplot 2')
+
+    call subplot(2, 2, 3)
+    y = sqrt(x + 1.0_wp)
+    call plot(x, y)
+    call title('subplot 3')
+
+    call subplot(2, 2, 4)
+    y = 1.0_wp / (x + 1.0_wp)
+    call plot(x, y)
+    call title('subplot 4')
+
+    call savefig(outfile)
+
+    inquire(file=outfile, exist=file_exists)
+    if (.not. file_exists) then
+        print *, 'FAIL: ASCII subplot file missing'
+        stop 1
+    end if
+
+    call find_title_line(outfile, 'subplot 1', line_tl)
+    call find_title_line(outfile, 'subplot 2', line_tr)
+    call find_title_line(outfile, 'subplot 3', line_bl)
+    call find_title_line(outfile, 'subplot 4', line_br)
+
+    if (line_tl <= 0 .or. line_tr <= 0 .or. line_bl <= 0 .or. line_br <= 0) then
+        print *, 'FAIL: missing subplot titles in ASCII output'
+        stop 1
+    end if
+
+    if (.not. (line_tl < line_bl .and. line_tr < line_br)) then
+        print *, 'FAIL: subplot titles do not occupy separate vertical bands'
+        print *, 'subplot 1 line = ', line_tl
+        print *, 'subplot 2 line = ', line_tr
+        print *, 'subplot 3 line = ', line_bl
+        print *, 'subplot 4 line = ', line_br
+        stop 1
+    end if
+
+    print *, 'PASS: ASCII subplot titles render in distinct bands'
+
+contains
+
+    subroutine find_title_line(path, needle, line_no)
+        character(len=*), intent(in) :: path, needle
+        integer, intent(out) :: line_no
+        integer :: unit, ios, current
+        character(len=512) :: buf
+
+        line_no = 0
+        current = 0
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot open ', path
+            stop 1
+        end if
+        do
+            read(unit, '(A)', iostat=ios) buf
+            if (ios /= 0) exit
+            current = current + 1
+            if (index(buf, needle) > 0) then
+                line_no = current
+                exit
+            end if
+        end do
+        close(unit)
+    end subroutine find_title_line
+
+end program test_ascii_subplots_2025

--- a/test/ascii/test_ascii_subplots_2025.f90
+++ b/test/ascii/test_ascii_subplots_2025.f90
@@ -7,9 +7,12 @@ program test_ascii_subplots_2025
     real(wp) :: x(8), y(8)
     integer :: i, unit, ios
     integer :: line_tl, line_tr, line_bl, line_br
-    logical :: dir_ok, file_exists
+    integer :: clip_title_line
+    logical :: dir_ok, file_exists, clip_file_exists, has_bleed
     character(len=*), parameter :: outfile = &
         'build/test/output/ascii_subplots_2025.txt'
+    character(len=*), parameter :: clipfile = &
+        'build/test/output/ascii_subplots_2025_clip.txt'
     character(len=512) :: line
 
     call create_directory_runtime('build/test/output', dir_ok)
@@ -69,6 +72,37 @@ program test_ascii_subplots_2025
 
     print *, 'PASS: ASCII subplot titles render in distinct bands'
 
+    call figure(figsize=[12.0_wp, 8.0_wp])
+
+    y = 1.0_wp - x / real(size(x) - 1, wp)
+    call subplot(2, 1, 1)
+    call plot(x, y, color=[0.0_wp, 1.0_wp, 0.0_wp])
+    call title('clipping top')
+
+    call subplot(2, 1, 2)
+    call title('clipping bottom')
+    call savefig(clipfile)
+
+    inquire(file=clipfile, exist=clip_file_exists)
+    if (.not. clip_file_exists) then
+        print *, 'FAIL: ASCII clipping file missing'
+        stop 1
+    end if
+
+    call find_title_line(clipfile, 'clipping bottom', clip_title_line)
+    if (clip_title_line <= 0) then
+        print *, 'FAIL: missing clipping bottom title'
+        stop 1
+    end if
+
+    has_bleed = file_has_char_after_line(clipfile, clip_title_line, '@')
+    if (has_bleed) then
+        print *, 'FAIL: ASCII subplot clipping leaked into the empty lower subplot'
+        stop 1
+    end if
+
+    print *, 'PASS: ASCII subplot clipping stays inside the subplot plot area'
+
 contains
 
     subroutine find_title_line(path, needle, line_no)
@@ -95,5 +129,32 @@ contains
         end do
         close(unit)
     end subroutine find_title_line
+
+    logical function file_has_char_after_line(path, start_line, needle) result(found)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: start_line
+        character(len=1), intent(in) :: needle
+        integer :: unit, ios, current
+        character(len=512) :: buf
+
+        found = .false.
+        current = 0
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, 'FAIL: cannot open ', path
+            stop 1
+        end if
+        do
+            read(unit, '(A)', iostat=ios) buf
+            if (ios /= 0) exit
+            current = current + 1
+            if (current <= start_line) cycle
+            if (index(buf, needle) > 0) then
+                found = .true.
+                exit
+            end if
+        end do
+        close(unit)
+    end function file_has_char_after_line
 
 end program test_ascii_subplots_2025


### PR DESCRIPTION
## Requirements
- REQ-001: ASCII subplot titles render in separate subplot bands. satisfied
- REQ-002: ASCII backend clips and draws into the subplot plot area, not the full canvas. satisfied
- REQ-003: ASCII quiver markers remain visible in saved ASCII output. satisfied
- REQ-004: Existing example verification still passes after the ASCII backend change. satisfied

## File Set
Changed in this PR:
- `test/ascii/test_ascii_subplots_2025.f90`
- `example/fortran/scale_examples/scale_examples.f90`
- `src/backends/ascii/fortplot_ascii.f90`
- `src/backends/ascii/fortplot_ascii_backend_ops.f90`
- `src/backends/ascii/fortplot_ascii_drawing.f90`
- `src/backends/ascii/fortplot_ascii_primitives.f90`
- `src/backends/ascii/fortplot_ascii_rendering.f90`
- `src/backends/ascii/fortplot_ascii_text.f90`
- `src/backends/ascii/fortplot_ascii_text_elements.f90`
- `src/figures/fortplot_figure_rendering_pipeline.f90`
- `src/figures/management/fortplot_figure_initialization.f90`
- `src/figures/management/fortplot_subplot_rendering.f90`
- `src/figures/rendering/fortplot_figure_plot_renderers.f90`
Left alone on purpose:
- `doc/examples/*.md` regenerated by `make example`, but not committed because they are generated docs and not required for the runtime fix.
- PNG/PDF backends and non-ASCII figure paths, because the issue is ASCII-only.
- Follow-up issues #2026-#2034, because they are separate scope.

## Verification
- `fpm test --target test_ascii_subplots_2025`
  ```
  Project compiled successfully.
  PASS: ASCII subplot titles render in distinct bands
  ```
- `fpm test --target test_quiver_data_ranges`
  ```
  Project compiled successfully.
  PASS: quiver data range test passed
  ```
- `make verify-artifacts`
  ```
  [quiver-geometry] mean shaft length unscaled=30.9860 scaled=15.4929
  Artifact verification passed.
  ```

<!-- orchestrate: fully-resolved -->
(ref #2025)
