### PR TITLE
fix: export tight_layout from fortplot (refs #2028)

### DIFF
--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -130,6 +130,7 @@ module fortplot
                                     xlim, ylim, view_init, &
                                     set_line_width, set_ydata, use_axis, &
                                     get_active_axis, minorticks_on, &
+                                    tight_layout, &
                                     axhline, axvline, hlines, vlines, &
                                     set_xticks, set_yticks, &
                                     show, show_viewer, &
@@ -171,6 +172,7 @@ module fortplot
     public :: xlabel, ylabel, title, suptitle, legend, grid
     public :: xlim, ylim, view_init, set_xscale, set_yscale, xscale, yscale
     public :: set_line_width, set_ydata, use_axis, get_active_axis, minorticks_on
+    public :: tight_layout
     public :: set_xticks, set_yticks
     public :: savefig, savefig_with_status
 

--- a/test/layout/test_tight_layout_public_api.f90
+++ b/test/layout/test_tight_layout_public_api.f90
@@ -1,0 +1,47 @@
+program test_tight_layout_public_api
+    use iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, subplot, plot, title, xlabel, ylabel, suptitle, &
+                        tight_layout, savefig
+    use fortplot_test_output_helpers, only: ensure_test_output_dir
+    implicit none
+
+    real(wp), dimension(5) :: x, y1, y2, y3, y4
+    character(len=:), allocatable :: output_dir
+
+    call ensure_test_output_dir('tight_layout_public_api', output_dir)
+
+    x = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    y1 = [1.0_wp, 4.0_wp, 9.0_wp, 16.0_wp, 25.0_wp]
+    y2 = [25.0_wp, 16.0_wp, 9.0_wp, 4.0_wp, 1.0_wp]
+    y3 = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    y4 = [5.0_wp, 4.0_wp, 3.0_wp, 2.0_wp, 1.0_wp]
+
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call subplot(2, 2, 1)
+    call plot(x, y1, label='Plot 1')
+    call title('Subplot (1,1)')
+    call xlabel('X axis')
+    call ylabel('Y axis')
+
+    call subplot(2, 2, 2)
+    call plot(x, y2, label='Plot 2')
+    call title('Subplot (1,2)')
+    call xlabel('X axis')
+    call ylabel('Y axis')
+
+    call subplot(2, 2, 3)
+    call plot(x, y3, label='Plot 3')
+    call title('Subplot (2,1)')
+    call xlabel('X axis')
+    call ylabel('Y axis')
+
+    call subplot(2, 2, 4)
+    call plot(x, y4, label='Plot 4')
+    call title('Subplot (2,2)')
+    call xlabel('X axis')
+    call ylabel('Y axis')
+
+    call suptitle('2x2 Subplot Grid')
+    call tight_layout()
+    call savefig(trim(output_dir)//'test_tight_layout_public_api.png')
+end program test_tight_layout_public_api


### PR DESCRIPTION
## Requirements
- REQ-001 satisfied: `tight_layout()` is available through `use fortplot`.
- REQ-002 satisfied: the existing OO and `fortplot_matplotlib` layout paths remain unchanged.
- REQ-003 satisfied: a regression test covers the public `fortplot` import path.

Prior branch commits satisfied none of these requirements.

## File Set
- Edited `src/core/fortplot.f90`: re-exported `tight_layout` from `fortplot`.
- Edited `test/layout/test_tight_layout_public_api.f90`: added a regression test for `use fortplot, only: tight_layout`.
- Left alone `src/interfaces/fortplot_matplotlib.f90`, `src/interfaces/fortplot_matplotlib_advanced.f90`, `src/interfaces/fortplot_matplotlib_axes.f90`: they already export and implement `tight_layout`.
- Left alone `src/figures/core/fortplot_figure_core_impl_layout.f90` and `src/figures/core/fortplot_figure_core_main.f90`: the OO layout implementation already exists.
- Left alone `test/layout/test_tight_layout.f90`: it already covers the matplotlib facade and OO API.
- Left alone `app/mpl_parity.f90` and examples: no code path there needs the new export.

## Verification
- `gh pr checks 2038`
  - `CMake FetchContent pass`
  - `Container build and test pass`
  - `FPM Dependency pass`
  - `flang (macOS) pass`
  - `test pass`
  - `test (windows) pass`
- `make test-ci`
  - `Project compiled successfully.`
  - `PASS: public API test - PNG written (       28062  bytes)`
  - `CI essential test suite completed successfully`

(ref #2028)

<!-- orchestrate: fully-resolved -->