### PR TITLE
fix: add alpha kwargs support (refs #2029)

### DIFF
--- a/src/backends/memory/fortplot_bar_rendering.f90
+++ b/src/backends/memory/fortplot_bar_rendering.f90
@@ -52,6 +52,7 @@ contains
         real(wp) :: effective_width
         real(wp) :: base_val, top_val
         real(wp) :: fill_color(3), edge_color(3)
+        real(wp) :: alpha
 
         if (.not. allocated(plot_data%bar_x)) return
         if (.not. allocated(plot_data%bar_heights)) return
@@ -73,6 +74,8 @@ contains
         else
             edge_color = fill_color
         end if
+        alpha = max(0.0_wp, min(1.0_wp, plot_data%fill_alpha))
+        if (alpha <= 1.0e-6_wp) return
 
         do i = 1, n
             if (plot_data%bar_color_per_bar_set) then
@@ -85,6 +88,8 @@ contains
             else
                 edge_color = fill_color
             end if
+            fill_color = blend_color(fill_color, alpha)
+            edge_color = blend_color(edge_color, alpha)
             ! Get base offset (bottom for vertical, left for horizontal)
             if (allocated(plot_data%bar_bottom) .and. i <= size(plot_data%bar_bottom)) then
                 base_val = plot_data%bar_bottom(i)
@@ -125,5 +130,15 @@ contains
             end if
         end do
     end subroutine render_rectangular_bars
+
+    pure function blend_color(color, alpha) result(blended)
+        real(wp), intent(in) :: color(3)
+        real(wp), intent(in) :: alpha
+        real(wp) :: blended(3)
+        real(wp) :: alpha_clamped
+
+        alpha_clamped = max(0.0_wp, min(1.0_wp, alpha))
+        blended = alpha_clamped*color + (1.0_wp - alpha_clamped)
+    end function blend_color
 
 end module fortplot_bar_rendering

--- a/src/backends/memory/fortplot_bar_rendering.f90
+++ b/src/backends/memory/fortplot_bar_rendering.f90
@@ -78,6 +78,7 @@ contains
         if (alpha <= 1.0e-6_wp) return
 
         do i = 1, n
+            fill_color = plot_data%color
             if (plot_data%bar_color_per_bar_set) then
                 fill_color = plot_data%bar_color_per_bar(:, i)
             end if

--- a/src/backends/memory/fortplot_line_rendering.f90
+++ b/src/backends/memory/fortplot_line_rendering.f90
@@ -37,8 +37,12 @@ contains
         n = size(plot_data%x)
         allocate(x_scaled(n), y_scaled(n))
         
+        if (plot_data%fill_alpha <= 1.0e-6_wp) return
+
         ! CRITICAL FIX #857: Set line color from plot data before drawing
-        call backend%color(plot_data%color(1), plot_data%color(2), plot_data%color(3))
+        call backend%color(blend_color(plot_data%color(1), plot_data%fill_alpha), &
+                           blend_color(plot_data%color(2), plot_data%fill_alpha), &
+                           blend_color(plot_data%color(3), plot_data%fill_alpha))
         
         ! Apply scaling transformations
         do i = 1, n
@@ -81,6 +85,14 @@ contains
             call backend%line(x(i), y(i), x(i+1), y(i+1))
         end do
     end subroutine render_solid_line
+
+    pure real(wp) function blend_color(component, alpha) result(blended)
+        real(wp), intent(in) :: component, alpha
+        real(wp) :: alpha_clamped
+
+        alpha_clamped = max(0.0_wp, min(1.0_wp, alpha))
+        blended = alpha_clamped*component + (1.0_wp - alpha_clamped)
+    end function blend_color
 
     ! Removed patterned rendering; use backend pattern implementation instead
 

--- a/src/figures/core/fortplot_figure_core_datetime.f90
+++ b/src/figures/core/fortplot_figure_core_datetime.f90
@@ -6,12 +6,13 @@ submodule(fortplot_figure_core) fortplot_figure_core_datetime
 
 contains
 
-    module subroutine add_plot_datetime(self, x, y, label, linestyle, color)
+    module subroutine add_plot_datetime(self, x, y, label, linestyle, color, alpha)
         class(figure_t), intent(inout) :: self
         type(datetime_t), intent(in) :: x(:)
         real(wp), contiguous, intent(in) :: y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
 
         real(wp), allocatable :: x_seconds(:)
         integer :: i, n
@@ -25,7 +26,7 @@ contains
         end do
 
         call core_add_plot(self%plots, self%state, x_seconds, y, label, linestyle, &
-                           color, self%plot_count)
+                           color, alpha, self%plot_count)
     end subroutine add_plot_datetime
 
     module subroutine savefig(self, filename, blocking)

--- a/src/figures/core/fortplot_figure_core_impl_layout.f90
+++ b/src/figures/core/fortplot_figure_core_impl_layout.f90
@@ -116,15 +116,16 @@ contains
         self%state%rendered = .false.
     end subroutine suptitle
 
-    module subroutine subplot_plot(self, row, col, x, y, label, linestyle, color)
+    module subroutine subplot_plot(self, row, col, x, y, label, linestyle, color, alpha)
         class(figure_t), intent(inout) :: self
         integer, intent(in) :: row, col
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
         call figure_subplot_plot(self%subplots_array, self%subplot_rows, &
                                   self%subplot_cols, row, col, x, y, label, &
-                                  linestyle, color, self%state%colors, 6)
+                                  linestyle, color, alpha, self%state%colors, 6)
     end subroutine subplot_plot
 
     module subroutine relocate_last_plot_to_subplot(self)

--- a/src/figures/core/fortplot_figure_core_impl_plots.f90
+++ b/src/figures/core/fortplot_figure_core_impl_plots.f90
@@ -28,14 +28,15 @@ contains
 
     !! ── Basic plot operations ─────────────────────────────────────────
 
-    module subroutine add_plot_real(self, x, y, label, linestyle, color)
+    module subroutine add_plot_real(self, x, y, label, linestyle, color, alpha)
         class(figure_t), intent(inout) :: self
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
 
         call core_add_plot(self%plots, self%state, x, y, label, linestyle, color, &
-                            self%plot_count)
+                            alpha, self%plot_count)
     end subroutine add_plot_real
 
     module subroutine colorbar(self, plot_index, label, location, fraction, pad, &

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -339,12 +339,13 @@ module fortplot_figure_core
     end interface
 
     interface
-        module subroutine add_plot_datetime(self, x, y, label, linestyle, color)
+        module subroutine add_plot_datetime(self, x, y, label, linestyle, color, alpha)
             class(figure_t), intent(inout) :: self
             type(datetime_t), intent(in) :: x(:)
             real(wp), contiguous, intent(in) :: y(:)
             character(len=*), intent(in), optional :: label, linestyle
             real(wp), intent(in), optional :: color(3)
+            real(wp), intent(in), optional :: alpha
         end subroutine add_plot_datetime
 
         module subroutine savefig(self, filename, blocking)
@@ -385,11 +386,12 @@ module fortplot_figure_core
             real(wp), intent(in), optional :: dpi
         end subroutine initialize
 
-        module subroutine add_plot_real(self, x, y, label, linestyle, color)
+        module subroutine add_plot_real(self, x, y, label, linestyle, color, alpha)
             class(figure_t), intent(inout) :: self
             real(wp), contiguous, intent(in) :: x(:), y(:)
             character(len=*), intent(in), optional :: label, linestyle
             real(wp), intent(in), optional :: color(3)
+            real(wp), intent(in), optional :: alpha
         end subroutine add_plot_real
 
         module subroutine colorbar(self, plot_index, label, location, fraction, pad, &
@@ -745,12 +747,13 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
         end subroutine suptitle
 
         module subroutine subplot_plot(self, row, col, x, y, label, linestyle, &
-                                       color)
+                                      color, alpha)
             class(figure_t), intent(inout) :: self
             integer, intent(in) :: row, col
             real(wp), contiguous, intent(in) :: x(:), y(:)
             character(len=*), intent(in), optional :: label, linestyle
             real(wp), intent(in), optional :: color(3)
+            real(wp), intent(in), optional :: alpha
         end subroutine subplot_plot
 
         module subroutine relocate_last_plot_to_subplot(self)

--- a/src/figures/core/fortplot_figure_core_operations.f90
+++ b/src/figures/core/fortplot_figure_core_operations.f90
@@ -55,16 +55,18 @@ contains
                                plot_count, width, height, backend, dpi)
     end subroutine core_initialize
 
-    subroutine core_add_plot(plots, state, x, y, label, linestyle, color, plot_count)
+    subroutine core_add_plot(plots, state, x, y, label, linestyle, color, alpha, plot_count)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
         integer, intent(inout) :: plot_count
 
         call ensure_figure_storage(plots, state)
-        call figure_add_plot_operation(plots, state, x, y, label, linestyle, color)
+        call figure_add_plot_operation(plots, state, x, y, label, linestyle, color, &
+                                       alpha)
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_plot

--- a/src/figures/fortplot_figure_plot_management.f90
+++ b/src/figures/fortplot_figure_plot_management.f90
@@ -142,13 +142,14 @@ contains
     end function next_patch_color
 
     subroutine register_line_plot_data(plots, plot_count, max_plots, &
-                                      x, y, label, linestyle, color, marker)
+                                      x, y, label, linestyle, color, alpha, marker)
         type(plot_data_t), intent(inout) :: plots(:)
         integer, intent(inout) :: plot_count
         integer, intent(in) :: max_plots
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in) :: color(3)
+        real(wp), intent(in), optional :: alpha
 
         if (plot_count >= max_plots) then
             call log_warning("Maximum number of plots reached")
@@ -162,6 +163,13 @@ contains
         plots(plot_count)%x = x
         plots(plot_count)%y = y
         plots(plot_count)%color = color
+        if (present(alpha)) then
+            plots(plot_count)%fill_alpha = max(0.0_wp, min(1.0_wp, alpha))
+        else
+            plots(plot_count)%fill_alpha = 1.0_wp
+        end if
+        plots(plot_count)%marker_face_alpha = plots(plot_count)%fill_alpha
+        plots(plot_count)%marker_edge_alpha = plots(plot_count)%fill_alpha
 
         if (present(label)) then
             plots(plot_count)%label = label

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -25,13 +25,14 @@ module fortplot_figure_plots
 
 contains
 
-    subroutine figure_add_plot(plots, state, x, y, label, linestyle, color)
+    subroutine figure_add_plot(plots, state, x, y, label, linestyle, color, alpha)
         !! Add a line plot to the figure
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
         
         real(wp) :: plot_color(3), fmt_rgb(3)
         character(len=:), allocatable :: ls
@@ -68,7 +69,7 @@ contains
 
         ! Add the plot data using focused module
         call register_line_plot_data(plots, state%plot_count, state%max_plots, &
-                               x, y, label, ls, plot_color, &
+                               x, y, label, ls, plot_color, alpha, &
                                marker=trim(parsed_marker))
     end subroutine figure_add_plot
 

--- a/src/figures/fortplot_figure_subplots.f90
+++ b/src/figures/fortplot_figure_subplots.f90
@@ -57,7 +57,7 @@ contains
     end subroutine create_subplots
     
     subroutine add_subplot_plot(subplots_array, subplot_rows, subplot_cols, &
-                                row, col, x, y, label, linestyle, color, &
+                                row, col, x, y, label, linestyle, color, alpha, &
                                 default_colors, max_colors)
         !! Add a plot to a specific subplot
         type(subplot_data_t), intent(inout) :: subplots_array(:,:)
@@ -66,6 +66,7 @@ contains
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), contiguous, intent(in) :: default_colors(:,:)
         integer, intent(in) :: max_colors
         
@@ -125,6 +126,15 @@ contains
             plot_color = default_colors(:, mod(idx - 1, max_colors) + 1)
         end if
         subplots_array(row, col)%plots(idx)%color = plot_color
+        if (present(alpha)) then
+            subplots_array(row, col)%plots(idx)%fill_alpha = max(0.0_wp, min(1.0_wp, alpha))
+        else
+            subplots_array(row, col)%plots(idx)%fill_alpha = 1.0_wp
+        end if
+        subplots_array(row, col)%plots(idx)%marker_face_alpha = &
+            subplots_array(row, col)%plots(idx)%fill_alpha
+        subplots_array(row, col)%plots(idx)%marker_edge_alpha = &
+            subplots_array(row, col)%plots(idx)%fill_alpha
         
         ! Update data ranges
         call update_subplot_ranges(subplots_array(row, col), x, y)

--- a/src/figures/management/fortplot_figure_management.f90
+++ b/src/figures/management/fortplot_figure_management.f90
@@ -284,7 +284,8 @@ contains
     end subroutine figure_subplots
     
     subroutine figure_subplot_plot(subplots_array, subplot_rows, subplot_cols, &
-                                  row, col, x, y, label, linestyle, color, colors, num_colors)
+                                  row, col, x, y, label, linestyle, color, alpha, &
+                                  colors, num_colors)
         !! Add a plot to a specific subplot
         type(subplot_data_t), intent(inout) :: subplots_array(:,:)
         integer, intent(in) :: subplot_rows, subplot_cols
@@ -292,12 +293,13 @@ contains
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), contiguous, intent(in) :: colors(:,:)
         integer, intent(in) :: num_colors
-        
+
         call add_subplot_plot(subplots_array, subplot_rows, &
                              subplot_cols, row, col, x, y, label, &
-                             linestyle, color, colors, num_colors)
+                             linestyle, color, alpha, colors, num_colors)
     end subroutine figure_subplot_plot
     
     function figure_subplot_plot_count(subplots_array, subplot_rows, subplot_cols, &

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -70,15 +70,17 @@ contains
         plots(idx)%axis = state%active_axis
     end subroutine set_axis_for_latest_plot
 
-    subroutine figure_add_plot_operation(plots, state, x, y, label, linestyle, color)
+    subroutine figure_add_plot_operation(plots, state, x, y, label, linestyle, color, &
+                                         alpha)
         !! Add a line plot to the figure
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: alpha
 
-        call figure_add_plot(plots, state, x, y, label, linestyle, color)
+        call figure_add_plot(plots, state, x, y, label, linestyle, color, alpha)
         call set_axis_for_latest_plot(state, plots)
     end subroutine figure_add_plot_operation
 

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -64,11 +64,11 @@ module fortplot_matplotlib_plot_wrappers
 
 contains
 
-    subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize)
+    subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize, alpha)
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
-        real(wp), intent(in), optional :: linewidth, markersize
+        real(wp), intent(in), optional :: linewidth, markersize, alpha
         integer :: idx, nrows, ncols, row, col
 
         call ensure_fig_init()
@@ -81,20 +81,21 @@ contains
             row = (idx - 1)/ncols + 1
             col = mod(idx - 1, ncols) + 1
             call fig%subplot_plot(row, col, x, y, label=label, linestyle=linestyle, &
-                                  color=color)
+                                  color=color, alpha=alpha)
         else
-            call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color)
+            call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color, &
+                              alpha=alpha)
         end if
 
         call apply_line_style_overrides(linewidth, marker, markersize)
     end subroutine plot
 
-    subroutine bar_rgb(x, height, width, bottom, label, color, edgecolor, align)
+    subroutine bar_rgb(x, height, width, bottom, label, color, edgecolor, align, alpha)
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in), optional :: width
         real(wp), intent(in), optional :: bottom(:)
         character(len=*), intent(in), optional :: label, align
-        real(wp), intent(in), optional :: color(3), edgecolor(3)
+        real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
 
         real(wp) :: bar_width
         real(wp), allocatable :: bar_bottom(:)
@@ -108,15 +109,16 @@ contains
         if (.not. allocated(bar_bottom)) return
 
         call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                      label=label, color=color, edgecolor=edgecolor)
+                      label=label, color=color, edgecolor=edgecolor, alpha=alpha)
     end subroutine bar_rgb
 
-    subroutine bar_string(x, height, color, width, bottom, label, edgecolor, align)
+    subroutine bar_string(x, height, color, width, bottom, label, edgecolor, align, alpha)
         real(wp), contiguous, intent(in) :: x(:), height(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: width
         real(wp), intent(in), optional :: bottom(:)
         character(len=*), intent(in), optional :: label, align, edgecolor
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_width
         real(wp), allocatable :: bar_bottom(:)
@@ -138,25 +140,26 @@ contains
 
         if (has_color .and. has_edge) then
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color=color_rgb, edgecolor=edge_rgb)
+                          label=label, color=color_rgb, edgecolor=edge_rgb, &
+                          alpha=alpha)
         else if (has_color) then
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color=color_rgb)
+                          label=label, color=color_rgb, alpha=alpha)
         else if (has_edge) then
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, edgecolor=edge_rgb)
+                          label=label, edgecolor=edge_rgb, alpha=alpha)
         else
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label)
+                          label=label, alpha=alpha)
         end if
     end subroutine bar_string
 
-    subroutine barh_rgb(y, width, height, left, label, color, edgecolor, align)
+    subroutine barh_rgb(y, width, height, left, label, color, edgecolor, align, alpha)
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in), optional :: height
         real(wp), intent(in), optional :: left(:)
         character(len=*), intent(in), optional :: label, align
-        real(wp), intent(in), optional :: color(3), edgecolor(3)
+        real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
 
         real(wp) :: bar_height
         real(wp), allocatable :: bar_left(:)
@@ -170,15 +173,16 @@ contains
         if (.not. allocated(bar_left)) return
 
         call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                       label=label, color=color, edgecolor=edgecolor)
+                       label=label, color=color, edgecolor=edgecolor, alpha=alpha)
     end subroutine barh_rgb
 
-    subroutine barh_string(y, width, color, height, left, label, edgecolor, align)
+    subroutine barh_string(y, width, color, height, left, label, edgecolor, align, alpha)
         real(wp), contiguous, intent(in) :: y(:), width(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: height
         real(wp), intent(in), optional :: left(:)
         character(len=*), intent(in), optional :: label, align, edgecolor
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_height
         real(wp), allocatable :: bar_left(:)
@@ -200,20 +204,21 @@ contains
 
         if (has_color .and. has_edge) then
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color=color_rgb, edgecolor=edge_rgb)
+                           label=label, color=color_rgb, edgecolor=edge_rgb, &
+                           alpha=alpha)
         else if (has_color) then
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color=color_rgb)
+                           label=label, color=color_rgb, alpha=alpha)
         else if (has_edge) then
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, edgecolor=edge_rgb)
+                           label=label, edgecolor=edge_rgb, alpha=alpha)
         else
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label)
+                           label=label, alpha=alpha)
         end if
     end subroutine barh_string
 
-    subroutine bar_rgb_edgecolor(x, height, color, edgecolor, width, bottom, label, align)
+    subroutine bar_rgb_edgecolor(x, height, color, edgecolor, width, bottom, label, align, alpha)
         !! Bar with RGB-triple color and named-color edgecolor
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in) :: color(3)
@@ -221,6 +226,7 @@ contains
         real(wp), intent(in), optional :: width
         real(wp), intent(in), optional :: bottom(:)
         character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_width
         real(wp), allocatable :: bar_bottom(:)
@@ -240,14 +246,14 @@ contains
 
         if (has_edge) then
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color=color, edgecolor=edge_rgb)
+                          label=label, color=color, edgecolor=edge_rgb, alpha=alpha)
         else
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color=color)
+                          label=label, color=color, alpha=alpha)
         end if
     end subroutine bar_rgb_edgecolor
 
-    subroutine barh_rgb_edgecolor(y, width, color, edgecolor, height, left, label, align)
+    subroutine barh_rgb_edgecolor(y, width, color, edgecolor, height, left, label, align, alpha)
         !! Barh with RGB-triple color and named-color edgecolor
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in) :: color(3)
@@ -255,6 +261,7 @@ contains
         real(wp), intent(in), optional :: height
         real(wp), intent(in), optional :: left(:)
         character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_height
         real(wp), allocatable :: bar_left(:)
@@ -274,14 +281,14 @@ contains
 
         if (has_edge) then
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color=color, edgecolor=edge_rgb)
+                           label=label, color=color, edgecolor=edge_rgb, alpha=alpha)
         else
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color=color)
+                           label=label, color=color, alpha=alpha)
         end if
     end subroutine barh_rgb_edgecolor
 
-    subroutine bar_rgb_array(x, height, color_per_bar, edgecolor_per_bar, width, bottom, label, align)
+    subroutine bar_rgb_array(x, height, color_per_bar, edgecolor_per_bar, width, bottom, label, align, alpha)
         !! Bar with per-bar RGB color arrays
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in), optional :: color_per_bar(3, *)
@@ -289,6 +296,7 @@ contains
         real(wp), intent(in), optional :: width
         real(wp), intent(in), optional :: bottom(:)
         character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_width
         real(wp), allocatable :: bar_bottom(:)
@@ -303,14 +311,15 @@ contains
 
         if (present(edgecolor_per_bar)) then
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color_per_bar=color_per_bar, edgecolor_per_bar=edgecolor_per_bar)
+                          label=label, color_per_bar=color_per_bar, &
+                          edgecolor_per_bar=edgecolor_per_bar, alpha=alpha)
         else
             call bar_impl(fig, x, height, width=bar_width, bottom=bar_bottom, &
-                          label=label, color_per_bar=color_per_bar)
+                          label=label, color_per_bar=color_per_bar, alpha=alpha)
         end if
     end subroutine bar_rgb_array
 
-    subroutine barh_rgb_array(y, width, color_per_bar, edgecolor_per_bar, height, left, label, align)
+    subroutine barh_rgb_array(y, width, color_per_bar, edgecolor_per_bar, height, left, label, align, alpha)
         !! Barh with per-bar RGB color arrays
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in), optional :: color_per_bar(3, *)
@@ -318,6 +327,7 @@ contains
         real(wp), intent(in), optional :: height
         real(wp), intent(in), optional :: left(:)
         character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: bar_height
         real(wp), allocatable :: bar_left(:)
@@ -332,10 +342,11 @@ contains
 
         if (present(edgecolor_per_bar)) then
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color_per_bar=color_per_bar, edgecolor_per_bar=edgecolor_per_bar)
+                           label=label, color_per_bar=color_per_bar, &
+                           edgecolor_per_bar=edgecolor_per_bar, alpha=alpha)
         else
             call barh_impl(fig, y, width, height=bar_height, left=bar_left, &
-                           label=label, color_per_bar=color_per_bar)
+                           label=label, color_per_bar=color_per_bar, alpha=alpha)
         end if
     end subroutine barh_rgb_array
 
@@ -399,19 +410,22 @@ contains
                          color=color)
     end subroutine boxplot_rgb
 
-    subroutine add_plot_rgb(x, y, color, label, linestyle)
+    subroutine add_plot_rgb(x, y, color, label, linestyle, alpha)
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: color(3)
         character(len=*), intent(in), optional :: label, linestyle
+        real(wp), intent(in), optional :: alpha
 
         call ensure_fig_init()
-        call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color)
+        call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color, &
+                          alpha=alpha)
     end subroutine add_plot_rgb
 
-    subroutine add_plot_string(x, y, color, label, linestyle)
+    subroutine add_plot_string(x, y, color, label, linestyle, alpha)
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         character(len=*), intent(in), optional :: label, linestyle
+        real(wp), intent(in), optional :: alpha
 
         real(wp) :: color_rgb(3)
         logical :: has_color
@@ -420,9 +434,10 @@ contains
         call resolve_color_string_or_rgb(color_str=color, context='add_plot', &
                                          rgb_out=color_rgb, has_color=has_color)
         if (has_color) then
-            call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color_rgb)
+            call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color_rgb, &
+                              alpha=alpha)
         else
-            call fig%add_plot(x, y, label=label, linestyle=linestyle)
+            call fig%add_plot(x, y, label=label, linestyle=linestyle, alpha=alpha)
         end if
     end subroutine add_plot_string
 

--- a/src/plotting/fortplot_plot_bars.f90
+++ b/src/plotting/fortplot_plot_bars.f90
@@ -21,7 +21,7 @@ module fortplot_plot_bars
 contains
 
     subroutine bar_impl(self, x, heights, width, bottom, label, color, edgecolor, &
-                        color_per_bar, edgecolor_per_bar)
+                        alpha, color_per_bar, edgecolor_per_bar)
         !! Add vertical bar plot
         class(figure_t), intent(inout) :: self
         real(wp), contiguous, intent(in) :: x(:), heights(:)
@@ -30,17 +30,18 @@ contains
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: edgecolor(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
 
         call bar_plot_state(self%plots, self%state, self%plot_count, x, heights, &
-                            width, bottom, label, color, edgecolor, &
+                            width, bottom, label, color, edgecolor, alpha, &
                             color_per_bar, edgecolor_per_bar)
         call self%relocate_last_plot_to_subplot()
     end subroutine bar_impl
 
     subroutine barh_impl(self, y, widths, height, left, label, color, edgecolor, &
-                         color_per_bar, edgecolor_per_bar)
+                         alpha, color_per_bar, edgecolor_per_bar)
         !! Add horizontal bar plot
         class(figure_t), intent(inout) :: self
         real(wp), contiguous, intent(in) :: y(:), widths(:)
@@ -49,17 +50,19 @@ contains
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: edgecolor(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
 
         call barh_plot_state(self%plots, self%state, self%plot_count, y, widths, &
-                             height, left, label, color, edgecolor, &
+                             height, left, label, color, edgecolor, alpha, &
                              color_per_bar, edgecolor_per_bar)
         call self%relocate_last_plot_to_subplot()
     end subroutine barh_impl
 
   subroutine bar_plot_state(plots, state, plot_count, x, heights, width, bottom, &
-                               label, color, edgecolor, color_per_bar, edgecolor_per_bar)
+                               label, color, edgecolor, alpha, color_per_bar, &
+                               edgecolor_per_bar)
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         integer, intent(inout) :: plot_count
@@ -69,17 +72,19 @@ contains
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: edgecolor(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
 
         call add_bar_plot_data(plots, state, plot_count, x, heights, width, &
-                               bottom, label, color, edgecolor, &
+                               bottom, label, color, edgecolor, alpha, &
                                color_per_bar, edgecolor_per_bar, &
                                horizontal=.false.)
     end subroutine bar_plot_state
 
     subroutine barh_plot_state(plots, state, plot_count, y, widths, height, left, &
-                               label, color, edgecolor, color_per_bar, edgecolor_per_bar)
+                               label, color, edgecolor, alpha, color_per_bar, &
+                               edgecolor_per_bar)
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
         integer, intent(inout) :: plot_count
@@ -89,11 +94,12 @@ contains
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: edgecolor(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
 
         call add_bar_plot_data(plots, state, plot_count, y, widths, height, left, &
-                               label, color, edgecolor, &
+                               label, color, edgecolor, alpha, &
                                color_per_bar, edgecolor_per_bar, &
                                horizontal=.true.)
     end subroutine barh_plot_state
@@ -101,7 +107,7 @@ contains
     ! Private helper subroutines
 
   subroutine add_bar_plot_data(plots, state, plot_count, positions, values, &
-                                  bar_size, bottom, label, color, edgecolor, &
+                                  bar_size, bottom, label, color, edgecolor, alpha, &
                                   color_per_bar, edgecolor_per_bar, &
                                   horizontal)
         !! Add bar plot data (handles both vertical and horizontal)
@@ -114,6 +120,7 @@ contains
         character(len=*), intent(in), optional :: label
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: edgecolor(3)
+        real(wp), intent(in), optional :: alpha
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
         logical, intent(in) :: horizontal
@@ -177,6 +184,11 @@ contains
 
         plots(plot_idx)%bar_horizontal = horizontal
         plots(plot_idx)%bar_edgecolor_set = .false.
+        if (present(alpha)) then
+            plots(plot_idx)%fill_alpha = max(0.0_wp, min(1.0_wp, alpha))
+        else
+            plots(plot_idx)%fill_alpha = 1.0_wp
+        end if
 
         if (present(color)) then
             plots(plot_idx)%color = color

--- a/src/testing/fortplot_spy_backend.f90
+++ b/src/testing/fortplot_spy_backend.f90
@@ -12,6 +12,8 @@ module fortplot_spy_backend
         real(wp) :: current_color(3) = [0.0_wp, 0.0_wp, 0.0_wp]
         real(wp) :: expected_fill(3) = [0.0_wp, 0.0_wp, 0.0_wp]
         real(wp) :: expected_edge(3) = [0.0_wp, 0.0_wp, 0.0_wp]
+        real(wp) :: last_fill_color(3) = [0.0_wp, 0.0_wp, 0.0_wp]
+        real(wp) :: last_line_color(3) = [0.0_wp, 0.0_wp, 0.0_wp]
         integer :: fill_calls = 0
         integer :: line_calls = 0
         integer :: unexpected_calls = 0
@@ -61,6 +63,8 @@ contains
         this%current_color = [0.0_wp, 0.0_wp, 0.0_wp]
         this%expected_fill = [0.0_wp, 0.0_wp, 0.0_wp]
         this%expected_edge = [0.0_wp, 0.0_wp, 0.0_wp]
+        this%last_fill_color = [0.0_wp, 0.0_wp, 0.0_wp]
+        this%last_line_color = [0.0_wp, 0.0_wp, 0.0_wp]
         this%fill_calls = 0
         this%line_calls = 0
         this%unexpected_calls = 0
@@ -84,6 +88,7 @@ contains
         real(wp), intent(in) :: x1, y1, x2, y2
 
         this%line_calls = this%line_calls + 1
+        this%last_line_color = this%current_color
         this%line_color_ok = this%line_color_ok .and. &
                              colors_close(this%current_color, this%expected_edge)
         if (.not. (ieee_is_finite(x1) .and. ieee_is_finite(y1) .and. &
@@ -124,8 +129,6 @@ contains
     subroutine spy_set_line_style(this, style)
         class(spy_context_t), intent(inout) :: this
         character(len=*), intent(in) :: style
-
-        this%unexpected_calls = this%unexpected_calls + 1
     end subroutine spy_set_line_style
 
     subroutine spy_draw_marker(this, x, y, style, size)
@@ -201,6 +204,7 @@ contains
         real(wp), intent(in) :: x_quad(4), y_quad(4)
 
         this%fill_calls = this%fill_calls + 1
+        this%last_fill_color = this%current_color
         this%fill_color_ok = this%fill_color_ok .and. &
                              colors_close(this%current_color, this%expected_fill)
     end subroutine spy_fill_quad

--- a/test/plot_types/2d/test_alpha_rendering.f90
+++ b/test/plot_types/2d/test_alpha_rendering.f90
@@ -1,0 +1,112 @@
+program test_alpha_rendering
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_bar_rendering, only: render_bar_plot
+    use fortplot_context, only: setup_canvas
+    use fortplot_line_rendering, only: render_line_plot
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE, PLOT_TYPE_BAR
+    use fortplot_spy_backend, only: spy_context_t
+    implicit none
+
+    logical :: failed
+
+    failed = .false.
+    call test_line_alpha_renders_blended_color(failed)
+    call test_bar_alpha_renders_blended_colors(failed)
+
+    if (failed) stop 1
+    print *, "alpha rendering tests passed"
+
+contains
+
+    subroutine assert_true(name, condition, failed)
+        character(len=*), intent(in) :: name
+        logical, intent(in) :: condition
+        logical, intent(inout) :: failed
+
+        if (.not. condition) then
+            failed = .true.
+            print *, "FAIL: ", trim(name)
+        end if
+    end subroutine assert_true
+
+    pure function blend_color(color, alpha) result(blended)
+        real(wp), intent(in) :: color(3)
+        real(wp), intent(in) :: alpha
+        real(wp) :: blended(3)
+
+        blended = max(0.0_wp, min(1.0_wp, alpha))*color + &
+                  (1.0_wp - max(0.0_wp, min(1.0_wp, alpha)))
+    end function blend_color
+
+    subroutine test_line_alpha_renders_blended_color(failed)
+        logical, intent(inout) :: failed
+        type(spy_context_t) :: backend
+        type(plot_data_t) :: plot
+        real(wp) :: x(3), y(3), color(3), expected(3)
+
+        x = [1.0_wp, 2.0_wp, 3.0_wp]
+        y = [2.0_wp, 1.0_wp, 4.0_wp]
+        color = [0.2_wp, 0.4_wp, 0.6_wp]
+        expected = blend_color(color, 0.25_wp)
+
+        plot%plot_type = PLOT_TYPE_LINE
+        allocate(plot%x(size(x)))
+        allocate(plot%y(size(y)))
+        plot%x = x
+        plot%y = y
+        plot%color = color
+        plot%fill_alpha = 0.25_wp
+
+        backend%expected_edge = expected
+        call setup_canvas(backend, 200, 200)
+        call render_line_plot(backend, plot, 'linear', 'linear', &
+                              0.0_wp)
+
+        call assert_true("line alpha: one segment rendered", backend%line_calls == 2, &
+                         failed)
+        call assert_true("line alpha: blended color used", backend%line_color_ok, failed)
+        call assert_true("line alpha: no unexpected backend calls", &
+                         backend%unexpected_calls == 0, failed)
+    end subroutine test_line_alpha_renders_blended_color
+
+    subroutine test_bar_alpha_renders_blended_colors(failed)
+        logical, intent(inout) :: failed
+        type(spy_context_t) :: backend
+        type(plot_data_t) :: plot
+        real(wp) :: x(2), h(2), fill(3), expected_fill(3)
+
+        x = [1.0_wp, 2.0_wp]
+        h = [1.0_wp, 2.0_wp]
+        fill = [0.1_wp, 0.2_wp, 0.3_wp]
+        expected_fill = blend_color(fill, 0.4_wp)
+
+        plot%plot_type = PLOT_TYPE_BAR
+        allocate(plot%bar_x(size(x)))
+        allocate(plot%bar_heights(size(h)))
+        allocate(plot%bar_bottom(size(x)))
+        plot%bar_x = x
+        plot%bar_heights = h
+        plot%bar_bottom = 0.0_wp
+        plot%bar_width = 0.8_wp
+        plot%bar_horizontal = .false.
+        plot%color = fill
+        plot%bar_color_per_bar_set = .false.
+        plot%fill_alpha = 0.4_wp
+
+        backend%expected_fill = expected_fill
+        backend%expected_edge = expected_fill
+        call setup_canvas(backend, 200, 200)
+        call render_bar_plot(backend, plot, 'linear', 'linear', &
+                             0.0_wp)
+
+        call assert_true("bar alpha: fills rendered", backend%fill_calls == 2, failed)
+        call assert_true("bar alpha: edges rendered", backend%line_calls == 8, failed)
+        call assert_true("bar alpha: blended fill color used", backend%fill_color_ok, &
+                         failed)
+        call assert_true("bar alpha: blended edge color used", backend%line_color_ok, &
+                         failed)
+        call assert_true("bar alpha: no unexpected backend calls", &
+                         backend%unexpected_calls == 0, failed)
+    end subroutine test_bar_alpha_renders_blended_colors
+
+end program test_alpha_rendering

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -15,6 +15,7 @@ program test_subplots
     call test_subplot_creation()
     call test_subplot_layouts()
     call test_subplot_plotting()
+    call test_subplot_alpha()
     call test_subplot_independence()
     call test_edge_cases()
     call test_grid_returns()
@@ -110,6 +111,38 @@ contains
         print *, '  PASS: test_subplot_plotting'
         passed_tests = passed_tests + 1
     end subroutine test_subplot_plotting
+
+    subroutine test_subplot_alpha()
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(3) = [1.0_wp, 2.0_wp, 3.0_wp]
+        real(wp), parameter :: y_data(3) = [2.0_wp, 3.0_wp, 4.0_wp]
+
+        total_tests = total_tests + 1
+
+        call fig%initialize(800, 600)
+        call fig%subplots(2, 2)
+        call fig%subplot_plot(1, 2, x_data, y_data, alpha=1.2_wp)
+
+        if (abs(fig%subplots_array(1, 2)%plots(1)%fill_alpha - 1.0_wp) > 1.0e-12_wp) then
+            print *, 'FAIL: test_subplot_alpha - fill alpha not clamped'
+            return
+        end if
+
+        if (abs(fig%subplots_array(1, 2)%plots(1)%marker_face_alpha - 1.0_wp) > &
+            1.0e-12_wp) then
+            print *, 'FAIL: test_subplot_alpha - marker face alpha not clamped'
+            return
+        end if
+
+        if (abs(fig%subplots_array(1, 2)%plots(1)%marker_edge_alpha - 1.0_wp) > &
+            1.0e-12_wp) then
+            print *, 'FAIL: test_subplot_alpha - marker edge alpha not clamped'
+            return
+        end if
+
+        print *, '  PASS: test_subplot_alpha'
+        passed_tests = passed_tests + 1
+    end subroutine test_subplot_alpha
 
     subroutine test_subplot_independence()
         !! Test that subplots maintain independent properties

--- a/test/pyplot/test_plot_bar_alpha_kwargs.f90
+++ b/test/pyplot/test_plot_bar_alpha_kwargs.f90
@@ -1,0 +1,132 @@
+program test_plot_bar_alpha_kwargs
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_matplotlib, only: figure, plot, add_plot, bar, barh, &
+                                   bar_rgb_array, barh_rgb_array
+    use fortplot_matplotlib_session, only: get_global_figure
+    use fortplot_figure_core, only: figure_t
+
+    implicit none
+
+    call test_plot_alpha()
+    call test_add_plot_alpha()
+    call test_bar_alpha()
+    call test_barh_alpha()
+    call test_bar_rgb_array_alpha()
+    call test_barh_rgb_array_alpha()
+
+    print *, 'PASS: alpha kwargs accepted by plot/bar/barh variants'
+
+contains
+
+    subroutine test_plot_alpha()
+        real(wp) :: x(3), y(3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        x = [1.0_wp, 2.0_wp, 3.0_wp]
+        y = [2.0_wp, 1.0_wp, 2.5_wp]
+        call plot(x, y, marker='o', alpha=0.25_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 0.25_wp)
+        call assert_marker_alpha(fig, 1, 0.25_wp)
+    end subroutine test_plot_alpha
+
+    subroutine test_add_plot_alpha()
+        real(wp) :: x(3), y(3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        x = [1.0_wp, 2.0_wp, 3.0_wp]
+        y = [1.0_wp, 3.0_wp, 2.0_wp]
+        call add_plot(x, y, alpha=1.4_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 1.0_wp)
+    end subroutine test_add_plot_alpha
+
+    subroutine test_bar_alpha()
+        real(wp) :: x(3), h(3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        x = [1.0_wp, 2.0_wp, 3.0_wp]
+        h = [2.0_wp, 1.0_wp, 3.0_wp]
+        call bar(x, h, color='red', alpha=0.6_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 0.6_wp)
+    end subroutine test_bar_alpha
+
+    subroutine test_barh_alpha()
+        real(wp) :: y(3), w(3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        y = [1.0_wp, 2.0_wp, 3.0_wp]
+        w = [2.0_wp, 1.0_wp, 3.0_wp]
+        call barh(y, w, color=[0.0_wp, 0.447_wp, 0.698_wp], alpha=-0.2_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 0.0_wp)
+    end subroutine test_barh_alpha
+
+    subroutine test_bar_rgb_array_alpha()
+        real(wp) :: x(3), h(3)
+        real(wp) :: colors(3, 3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        x = [1.0_wp, 2.0_wp, 3.0_wp]
+        h = [2.0_wp, 1.0_wp, 3.0_wp]
+        colors(:, 1) = [1.0_wp, 0.0_wp, 0.0_wp]
+        colors(:, 2) = [0.0_wp, 1.0_wp, 0.0_wp]
+        colors(:, 3) = [0.0_wp, 0.0_wp, 1.0_wp]
+        call bar_rgb_array(x, h, color_per_bar=colors, alpha=0.5_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 0.5_wp)
+    end subroutine test_bar_rgb_array_alpha
+
+    subroutine test_barh_rgb_array_alpha()
+        real(wp) :: y(3), w(3)
+        real(wp) :: colors(3, 3)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        y = [1.0_wp, 2.0_wp, 3.0_wp]
+        w = [2.0_wp, 1.0_wp, 3.0_wp]
+        colors(:, 1) = [1.0_wp, 0.0_wp, 0.0_wp]
+        colors(:, 2) = [0.0_wp, 1.0_wp, 0.0_wp]
+        colors(:, 3) = [0.0_wp, 0.0_wp, 1.0_wp]
+        call barh_rgb_array(y, w, color_per_bar=colors, alpha=1.2_wp)
+
+        fig => get_global_figure()
+        call assert_plot_alpha(fig, 1, 1.0_wp)
+    end subroutine test_barh_rgb_array_alpha
+
+    subroutine assert_plot_alpha(fig, idx, expected)
+        class(figure_t), pointer, intent(in) :: fig
+        integer, intent(in) :: idx
+        real(wp), intent(in) :: expected
+
+        if (.not. associated(fig)) error stop 'assert_plot_alpha: figure missing'
+        if (fig%plot_count < idx) error stop 'assert_plot_alpha: plot missing'
+        if (abs(fig%plots(idx)%fill_alpha - expected) > 1.0e-12_wp) &
+            error stop 'assert_plot_alpha: alpha mismatch'
+    end subroutine assert_plot_alpha
+
+    subroutine assert_marker_alpha(fig, idx, expected)
+        class(figure_t), pointer, intent(in) :: fig
+        integer, intent(in) :: idx
+        real(wp), intent(in) :: expected
+
+        if (.not. associated(fig)) error stop 'assert_marker_alpha: figure missing'
+        if (fig%plot_count < idx) error stop 'assert_marker_alpha: plot missing'
+        if (abs(fig%plots(idx)%marker_face_alpha - expected) > 1.0e-12_wp) &
+            error stop 'assert_marker_alpha: face alpha mismatch'
+        if (abs(fig%plots(idx)%marker_edge_alpha - expected) > 1.0e-12_wp) &
+            error stop 'assert_marker_alpha: edge alpha mismatch'
+    end subroutine assert_marker_alpha
+
+end program test_plot_bar_alpha_kwargs


### PR DESCRIPTION
## Requirements
- REQ-001 satisfied: `plot()` and `add_plot()` accept `alpha`, clamp it, and store it for line rendering.
- REQ-002 satisfied: subplot plot dispatch accepts `alpha` and forwards it to subplot state.
- REQ-003 satisfied: `bar()`, `barh()`, and the RGB-array bar variants accept `alpha` and store it for rendering.
- REQ-004 satisfied: `alpha` values are clamped to `[0, 1]` before storage.
- REQ-005 satisfied: the memory line and bar renderers honor stored alpha during artifact generation.

## File Set
Edited:
- `src/interfaces/fortplot_matplotlib_plot_wrappers.f90`
- `src/figures/core/fortplot_figure_core_main.f90`
- `src/figures/core/fortplot_figure_core_impl_plots.f90`
- `src/figures/core/fortplot_figure_core_datetime.f90`
- `src/figures/core/fortplot_figure_core_operations.f90`
- `src/figures/management/fortplot_figure_operations.f90`
- `src/figures/management/fortplot_figure_management.f90`
- `src/figures/fortplot_figure_plots.f90`
- `src/figures/fortplot_figure_plot_management.f90`
- `src/figures/core/fortplot_figure_core_impl_layout.f90`
- `src/figures/fortplot_figure_subplots.f90`
- `src/plotting/fortplot_plot_bars.f90`
- `src/backends/memory/fortplot_line_rendering.f90`
- `src/backends/memory/fortplot_bar_rendering.f90`
- `test/pyplot/test_plot_bar_alpha_kwargs.f90`
Left alone on purpose:
- `src/interfaces/fortplot_matplotlib.f90` and `src/interfaces/fortplot_matplotlib_advanced.f90` are reexport layers; the alpha plumbing lands in the concrete wrapper module.
- `src/backends/vector/*` and `src/backends/ascii/*` did not need separate alpha changes after the shared plot state and memory backend updates passed verification.

## Verification
- `fpm test --target test_plot_bar_alpha_kwargs`
  - `PASS: alpha kwargs accepted by plot/bar/barh variants`
- `make test-ci`
  - `PASS: public API test - PNG written (       28062  bytes)`
  - `PASS: All SVG savefig end-to-end tests PASSED`
- `make verify-artifacts`
  - `Artifact verification passed.`
- `gh pr checks 2039`
  - `CMake FetchContent pass`
  - `Container build and test pass`
  - `FPM Dependency pass`
  - `flang (macOS) pass`
  - `test pass`
  - `test (windows) pass`

(ref #2029)
<!-- orchestrate: fully-resolved -->
