### PR TITLE
fix: legend with subplots (refs #2030)

### DIFF
--- a/src/figures/core/fortplot_figure_core_impl_state.f90
+++ b/src/figures/core/fortplot_figure_core_impl_state.f90
@@ -89,7 +89,8 @@ contains
         class(figure_t), intent(inout) :: self
         character(len=*), intent(in), optional :: location
         call core_figure_legend(self%state, self%plots, self%state%plot_count, &
-                                location)
+                                location, self%subplots_array, self%subplot_rows, &
+                                self%subplot_cols)
     end subroutine figure_legend
 
     module subroutine clear(self)

--- a/src/figures/core/fortplot_figure_core_utils.f90
+++ b/src/figures/core/fortplot_figure_core_utils.f90
@@ -5,7 +5,7 @@ module fortplot_figure_core_utils
     !! to maintain architectural compliance with size limits.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_plot_data, only: plot_data_t
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_figure_operations
     implicit none
@@ -22,13 +22,17 @@ contains
         call figure_set_ydata_operation(plots, plot_count, plot_index, y_new)
     end subroutine core_set_ydata
 
-    subroutine core_figure_legend(state, plots, plot_count, location)
+    subroutine core_figure_legend(state, plots, plot_count, location, &
+                                  subplots_array, subplot_rows, subplot_cols)
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
         integer, intent(in) :: plot_count
         character(len=*), intent(in), optional :: location
+        type(subplot_data_t), allocatable, intent(in), optional :: subplots_array(:,:)
+        integer, intent(in), optional :: subplot_rows, subplot_cols
         call figure_legend_operation(state%legend_data, state%show_legend, &
-                                     plots, plot_count, location, state%backend_name)
+                                     plots, plot_count, location, state%backend_name, &
+                                     subplots_array, subplot_rows, subplot_cols)
     end subroutine core_figure_legend
 
 end module fortplot_figure_core_utils

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -14,7 +14,7 @@ module fortplot_figure_operations
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
-    use fortplot_plot_data, only: plot_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_legend, only: legend_t
     use fortplot_figure_plots, only: figure_add_plot, figure_add_contour, &
@@ -380,7 +380,8 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
     end subroutine figure_set_ydata_operation
 
     subroutine figure_legend_operation(legend_data, show_legend, plots, plot_count, &
-                                       location, backend_name)
+                                       location, backend_name, subplots_array, &
+                                       subplot_rows, subplot_cols)
         !! Add legend to figure
         type(legend_t), intent(inout) :: legend_data
         logical, intent(inout) :: show_legend
@@ -388,10 +389,61 @@ subroutine figure_add_surface_operation(plots, state, x_grid, y_grid, &
         integer, intent(in) :: plot_count
         character(len=*), intent(in), optional :: location
         character(len=*), intent(in) :: backend_name
+        type(subplot_data_t), intent(in), optional :: subplots_array(:,:)
+        integer, intent(in), optional :: subplot_rows, subplot_cols
+
+        if (present(subplots_array) .and. present(subplot_rows) .and. &
+            present(subplot_cols)) then
+            if (subplot_rows > 0 .and. subplot_cols > 0) then
+                if (size(subplots_array, 1) == subplot_rows .and. &
+                    size(subplots_array, 2) == subplot_cols) then
+                    call setup_subplot_figure_legend(legend_data, show_legend, &
+                                                     subplots_array, subplot_rows, &
+                                                     subplot_cols, location, &
+                                                     backend_name)
+                    return
+                end if
+            end if
+        end if
 
         call setup_figure_legend(legend_data, show_legend, plots, plot_count, &
                                  location, backend_name)
     end subroutine figure_legend_operation
+
+    subroutine setup_subplot_figure_legend(legend_data, show_legend, subplots_array, &
+                                           subplot_rows, subplot_cols, location, &
+                                           backend_name)
+        type(legend_t), intent(inout) :: legend_data
+        logical, intent(inout) :: show_legend
+        type(subplot_data_t), intent(in) :: subplots_array(:,:)
+        integer, intent(in) :: subplot_rows, subplot_cols
+        character(len=*), intent(in), optional :: location
+        character(len=*), intent(in) :: backend_name
+
+        type(plot_data_t), allocatable :: legend_plots(:)
+        integer :: i, j, k, total_plots, cursor
+
+        total_plots = 0
+        do i = 1, subplot_rows
+            do j = 1, subplot_cols
+                total_plots = total_plots + subplots_array(i, j)%plot_count
+            end do
+        end do
+
+        allocate(legend_plots(max(0, total_plots)))
+        cursor = 0
+        do i = 1, subplot_rows
+            do j = 1, subplot_cols
+                do k = 1, subplots_array(i, j)%plot_count
+                    cursor = cursor + 1
+                    legend_plots(cursor) = subplots_array(i, j)%plots(k)
+                end do
+            end do
+        end do
+
+        call setup_figure_legend(legend_data, show_legend, legend_plots, cursor, &
+                                 location, backend_name)
+    end subroutine setup_subplot_figure_legend
 
     subroutine figure_grid_operation(state, enabled, which, axis, alpha, linestyle)
         !! Enable/disable and configure grid lines

--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -19,6 +19,7 @@ module fortplot_subplot_rendering
     use fortplot_raster_labels, only: render_title_centered_with_size
     use fortplot_pdf_text, only: estimate_pdf_text_width
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
+    use fortplot_legend, only: legend_render
     use fortplot_context, only: plot_context
     implicit none
 
@@ -116,6 +117,13 @@ contains
         end select
 
         call render_suptitle(state, suptitle_height_frac)
+        if (state%show_legend .and. state%legend_data%num_entries > 0) then
+            call restore_figure_legend_frame(state%backend, state%margin_left, &
+                                             state%margin_right, state%margin_bottom, &
+                                             state%margin_top)
+            call apply_subplot_legend_bounds(state%backend, subplots_array, nr, nc)
+            call legend_render(state%legend_data, state%backend)
+        end if
     end subroutine render_subplots
 
     subroutine render_subplot_cell(state, sp, i, j, have_tight, &
@@ -318,6 +326,77 @@ contains
         class default
         end select
     end subroutine render_suptitle
+
+    subroutine restore_figure_legend_frame(backend, left_f, right_f, bottom_f, top_f)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: left_f, right_f, bottom_f, top_f
+
+        select type (bk => backend)
+        class is (raster_context)
+            bk%margins%left = left_f
+            bk%margins%right = right_f
+            bk%margins%bottom = bottom_f
+            bk%margins%top = top_f
+            call calculate_plot_area(bk%width, bk%height, bk%margins, bk%plot_area)
+        class is (pdf_context)
+            bk%margins%left = left_f
+            bk%margins%right = right_f
+            bk%margins%bottom = bottom_f
+            bk%margins%top = top_f
+            call calculate_pdf_plot_area(bk%width, bk%height, bk%margins, bk%plot_area)
+        class is (ascii_context)
+            bk%margins%left = left_f
+            bk%margins%right = right_f
+            bk%margins%bottom = bottom_f
+            bk%margins%top = top_f
+            call calculate_plot_area(bk%plot_width, bk%plot_height, bk%margins, &
+                                     bk%plot_area)
+        class default
+        end select
+    end subroutine restore_figure_legend_frame
+
+    subroutine apply_subplot_legend_bounds(backend, subplots_array, nr, nc)
+        class(plot_context), intent(inout) :: backend
+        type(subplot_data_t), intent(in) :: subplots_array(:, :)
+        integer, intent(in) :: nr, nc
+
+        integer :: i, j, k
+        logical :: have_bounds
+        real(wp) :: x_min, x_max, y_min, y_max
+        real(wp) :: x_min_local, x_max_local, y_min_local, y_max_local
+
+        have_bounds = .false.
+        do i = 1, nr
+            do j = 1, nc
+                do k = 1, subplots_array(i, j)%plot_count
+                    if (.not. allocated(subplots_array(i, j)%plots(k)%x)) cycle
+                    if (.not. allocated(subplots_array(i, j)%plots(k)%y)) cycle
+                    x_min_local = minval(subplots_array(i, j)%plots(k)%x)
+                    x_max_local = maxval(subplots_array(i, j)%plots(k)%x)
+                    y_min_local = minval(subplots_array(i, j)%plots(k)%y)
+                    y_max_local = maxval(subplots_array(i, j)%plots(k)%y)
+                    if (.not. have_bounds) then
+                        x_min = x_min_local
+                        x_max = x_max_local
+                        y_min = y_min_local
+                        y_max = y_max_local
+                        have_bounds = .true.
+                    else
+                        x_min = min(x_min, x_min_local)
+                        x_max = max(x_max, x_max_local)
+                        y_min = min(y_min, y_min_local)
+                        y_max = max(y_max, y_max_local)
+                    end if
+                end do
+            end do
+        end do
+
+        if (.not. have_bounds) return
+        backend%x_min = x_min
+        backend%x_max = x_max
+        backend%y_min = y_min
+        backend%y_max = y_max
+    end subroutine apply_subplot_legend_bounds
 
     function compute_suptitle_height_frac(state, fig_w, fig_h) result(h_frac)
         !! Compute the fractional height that the suptitle occupies in the figure.

--- a/test/legend/test_legend_comprehensive.f90
+++ b/test/legend/test_legend_comprehensive.f90
@@ -24,6 +24,7 @@ program test_legend_comprehensive
     call test_ascii_legend(num_failures)
     call test_empty_label_handling(num_failures)
     call test_legend_optimizations(num_failures)
+    call test_subplot_legend(num_failures)
     
     print *, ""
     print *, "========================================="
@@ -466,5 +467,62 @@ contains
             failures = failures + 1
         end if
     end subroutine test_legend_optimizations
+
+    subroutine test_subplot_legend(failures)
+        !! Regression for issue #2030: legends must render when subplots are active.
+        integer, intent(inout) :: failures
+        real(wp), dimension(8) :: x, y1, y2
+        integer :: i
+        type(validation_result_t) :: val
+        character(len=:), allocatable :: stream_text
+        character(len=:), allocatable :: plain_text
+        integer :: status_stream
+        logical :: has_left, has_right
+
+        print *, ""
+        print *, "Test 8: Subplot legend rendering"
+        print *, "--------------------------------"
+
+        do i = 1, 8
+            x(i) = real(i, wp)
+            y1(i) = real(i, wp)
+            y2(i) = 9.0_wp - real(i, wp)
+        end do
+
+        call figure(figsize=[6.4_wp, 4.8_wp])
+        call subplots(1, 2)
+        call subplot(1, 2, 1)
+        call plot(x, y1, label="left series")
+        call subplot(1, 2, 2)
+        call plot(x, y2, label="right series")
+        call legend()
+        call savefig("build/test/output/test_subplot_legend.pdf")
+
+        val = validate_file_exists('build/test/output/test_subplot_legend.pdf')
+        if (.not. val%passed) then
+            print *, "  FAIL: subplot legend PDF not created"
+            failures = failures + 1
+            return
+        end if
+
+        call extract_pdf_stream_text('build/test/output/test_subplot_legend.pdf', &
+                                     stream_text, status_stream)
+        if (status_stream /= 0) then
+            print *, "  FAIL: unable to extract subplot legend PDF text"
+            failures = failures + 1
+            return
+        end if
+
+        call pdf_stream_to_plain(stream_text, plain_text)
+        has_left = index(plain_text, 'left series') > 0
+        has_right = index(plain_text, 'right series') > 0
+
+        if (has_left .and. has_right) then
+            print *, "  PASS: subplot legend labels present in PDF stream"
+        else
+            print *, "  FAIL: subplot legend labels missing from PDF stream"
+            failures = failures + 1
+        end if
+    end subroutine test_subplot_legend
 
 end program test_legend_comprehensive


### PR DESCRIPTION
## Requirements
- REQ-001 satisfied: `legend()` collects labels from plots inside active subplots.
- REQ-002 satisfied: subplot legends are rendered into saved output.
- REQ-003 satisfied: single-axis legend behavior stays unchanged.

## File Set
Edited:
- `test/legend/test_legend_comprehensive.f90`: added a regression that fails if subplot legend labels do not reach the PDF stream.
- `src/figures/core/fortplot_figure_core_utils.f90`: pass subplot storage into the legend setup path.
- `src/figures/core/fortplot_figure_core_impl_state.f90`: forward subplot storage from the figure object.
- `src/figures/management/fortplot_figure_operations.f90`: flatten subplot plots into legend entries when a subplot grid is active.
- `src/figures/management/fortplot_subplot_rendering.f90`: render the figure legend after subplot layout and restore figure-level geometry.

Left alone:
- `src/ui/fortplot_legend_drawing.f90`: drawing already worked; the bug was routing and render timing.
- `src/figures/fortplot_figure_subplots.f90`: subplot storage already existed and needed no shape change.
- `src/figures/management/fortplot_figure_render_steps.f90`: single-axis legend rendering already worked.

## Verification
- `make test ARGS="--target test_legend_comprehensive"`
  - `PASS: PDF legend entries present in stream`
  - `PASS: subplot legend labels present in PDF stream`
  - `ALL TESTS PASSED (fpm test)`
- `make verify-artifacts`
  - `Artifact verification passed.`
- Artifact: `build/test/output/test_subplot_legend.pdf`

(ref #2030)
<!-- orchestrate: fully-resolved -->
