### PR TITLE
fix: validate histtype for hist() (refs #2031)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
@@ -8,6 +8,7 @@ module fortplot_matplotlib_hist_wrappers
     use fortplot_logging, only: log_error
     use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb
     use fortplot_matplotlib_session, only: ensure_fig_init
+    use fortplot_string_utils, only: to_lowercase
 
     implicit none
     private
@@ -136,6 +137,13 @@ contains
         real(wp), intent(in), optional :: color_rgb(3)
         real(wp), intent(in), optional :: alpha
 
+        if (present(histtype)) then
+            if (.not. histtype_is_supported(histtype)) then
+                call log_error('hist: unsupported histtype')
+                return
+            end if
+        end if
+
         call ensure_fig_init()
 
         if (size(data) == 0) return
@@ -224,6 +232,20 @@ contains
                      trim(orientation) == 'Horizontal' .or. &
                      trim(orientation) == 'HORIZONTAL'
     end function orientation_is_horizontal
+
+    function histtype_is_supported(histtype) result(supported)
+        character(len=*), intent(in) :: histtype
+        logical :: supported
+        character(len=:), allocatable :: normalized
+
+        normalized = to_lowercase(trim(histtype))
+        select case (normalized)
+        case ('bar', 'barstacked', 'step', 'stepfilled')
+            supported = .true.
+        case default
+            supported = .false.
+        end select
+    end function histtype_is_supported
 
     subroutine finalise_histogram(alpha, histtype, stacked, log)
         !! Attach optional metadata to the last histogram plot. These kwargs

--- a/test/plot_types/2d/test_histogram_rendering.f90
+++ b/test/plot_types/2d/test_histogram_rendering.f90
@@ -15,6 +15,8 @@ program test_histogram_rendering
     call clear_color_cache()
     call test_hist_renders_filled_quads(failed)
     call test_horizontal_hist_renders_filled_quads(failed)
+    call test_histtype_rejects_garbage(failed)
+    call test_histtype_accepts_step(failed)
 
     if (failed) stop 1
     print *, "histogram rendering tests passed"
@@ -100,5 +102,35 @@ contains
         call assert_true("horizontal hist render uses requested fill color", &
                          backend%fill_color_ok, failed)
     end subroutine test_horizontal_hist_renders_filled_quads
+
+    subroutine test_histtype_rejects_garbage(failed)
+        logical, intent(inout) :: failed
+        type(figure_t), pointer :: fig
+        real(wp) :: data(4)
+
+        data = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+
+        call figure()
+        call hist(data, bins=2, histtype='akjsnsdijdknjb', color='steelblue')
+        fig => get_global_figure()
+
+        call assert_true("invalid histtype must not create a plot", &
+                         fig%plot_count == 0, failed)
+    end subroutine test_histtype_rejects_garbage
+
+    subroutine test_histtype_accepts_step(failed)
+        logical, intent(inout) :: failed
+        type(figure_t), pointer :: fig
+        real(wp) :: data(4)
+
+        data = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+
+        call figure()
+        call hist(data, bins=2, histtype='step', color='steelblue')
+        fig => get_global_figure()
+
+        call assert_true("valid histtype must still create a plot", &
+                         fig%plot_count == 1, failed)
+    end subroutine test_histtype_accepts_step
 
 end program test_histogram_rendering

--- a/test/plot_types/2d/test_histogram_rendering.f90
+++ b/test/plot_types/2d/test_histogram_rendering.f90
@@ -17,6 +17,7 @@ program test_histogram_rendering
     call test_horizontal_hist_renders_filled_quads(failed)
     call test_histtype_rejects_garbage(failed)
     call test_histtype_accepts_step(failed)
+    call test_histtype_accepts_bar(failed)
 
     if (failed) stop 1
     print *, "histogram rendering tests passed"
@@ -132,5 +133,20 @@ contains
         call assert_true("valid histtype must still create a plot", &
                          fig%plot_count == 1, failed)
     end subroutine test_histtype_accepts_step
+
+    subroutine test_histtype_accepts_bar(failed)
+        logical, intent(inout) :: failed
+        type(figure_t), pointer :: fig
+        real(wp) :: data(4)
+
+        data = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+
+        call figure()
+        call hist(data, bins=2, histtype='bar', color='steelblue')
+        fig => get_global_figure()
+
+        call assert_true("bar histtype must still create a plot", &
+                         fig%plot_count == 1, failed)
+    end subroutine test_histtype_accepts_bar
 
 end program test_histogram_rendering


### PR DESCRIPTION
## Requirements
- REQ-001: Unsupported `histtype` values are rejected before plot creation. satisfied.
- REQ-002: Supported `histtype` values still plot through the pyplot `hist()` path. satisfied.
- REQ-003: Add regression coverage for both cases. satisfied. Introduced in `e9ac923`, fixed in `675866c`.

## File Set
Edited:
- `src/interfaces/fortplot_matplotlib_hist_wrappers.f90` - validate `histtype` before creating histogram plot state.
- `test/plot_types/2d/test_histogram_rendering.f90` - regression tests for invalid and valid `histtype` values on `hist()`.

Left alone:
- `src/figures/plot_types/fortplot_figure_histogram.f90` - stateful `fig%add_hist` has no `histtype` kwarg.
- `src/plotting/fortplot_plot_statistics.f90` - same stateful histogram path, already covered by existing tests.
- `src/figures/core/fortplot_figure_core_advanced.f90` - forwards the stateful histogram API only.
- `src/interfaces/fortplot_matplotlib_advanced.f90` - re-export only, no signature change needed.

## Verification
- `fpm test --target test_histogram_rendering`
  - failing before: `FAIL: invalid histtype must not create a plot`
  - passing after: `[ERROR] hist: unsupported histtype` / `histogram rendering tests passed`
- `make test-ci`
  - `Artifact verification passed.`
  - `CI essential test suite completed successfully`

(ref #2031)
<!-- orchestrate: fully-resolved -->
