### PR TITLE
fix: add python-like API docs (refs #2032)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -45,7 +45,11 @@ module fortplot_matplotlib_axes
 contains
 
     subroutine xlabel(label_text)
-        !! Set the x-axis label text. Routes to subplot or figure level.
+        !! Set the x-axis label text.
+        !!
+        !! Parameters
+        !! label_text : character(len=*), intent(in)
+        !!     X-axis label.
         character(len=*), intent(in) :: label_text
         integer :: idx, nrows, ncols, row, col
         call ensure_fig_init()
@@ -62,7 +66,11 @@ contains
     end subroutine xlabel
 
     subroutine ylabel(label_text)
-        !! Set the y-axis label text. Routes to subplot or figure level.
+        !! Set the y-axis label text.
+        !!
+        !! Parameters
+        !! label_text : character(len=*), intent(in)
+        !!     Y-axis label.
         character(len=*), intent(in) :: label_text
         integer :: idx, nrows, ncols, row, col
         call ensure_fig_init()
@@ -79,7 +87,11 @@ contains
     end subroutine ylabel
 
     subroutine title(title_text)
-        !! Set the title for the current axes. Routes to subplot or figure level.
+        !! Set the title for the current axes.
+        !!
+        !! Parameters
+        !! title_text : character(len=*), intent(in)
+        !!     Title text.
         character(len=*), intent(in) :: title_text
         integer :: idx, nrows, ncols, row, col
         call ensure_fig_init()
@@ -96,7 +108,13 @@ contains
     end subroutine title
 
     subroutine suptitle(title_text, fontsize)
-        !! Set a centered figure-level title above all subplots
+        !! Set a centered figure-level title above all subplots.
+        !!
+        !! Parameters
+        !! title_text : character(len=*), intent(in)
+        !!     Figure title.
+        !! fontsize : real(wp), optional
+        !!     Font size for the title.
         character(len=*), intent(in) :: title_text
         real(wp), intent(in), optional :: fontsize
 
@@ -105,13 +123,17 @@ contains
     end subroutine suptitle
 
     subroutine legend(loc, box, fontsize, position)
-        !! Display figure legend (matplotlib-compatible)
+        !! Display the figure legend.
         !!
-        !! Arguments mirror matplotlib.pyplot.legend:
-        !!   loc      - legend location string (e.g. 'upper right', 'best')
-        !!   box      - accepted for compatibility; styling not yet implemented
-        !!   fontsize - accepted for compatibility; styling not yet implemented
-        !!   position - deprecated alias for loc, kept for backward compatibility
+        !! Parameters
+        !! loc : character(len=*), optional
+        !!     Legend location string such as 'upper right' or 'best'.
+        !! box : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! fontsize : integer, optional
+        !!     Accepted for matplotlib parity.
+        !! position : character(len=*), optional
+        !!     Deprecated alias for loc.
         character(len=*), intent(in), optional :: loc
         logical, intent(in), optional :: box
         integer, intent(in), optional :: fontsize
@@ -144,23 +166,21 @@ contains
     end subroutine ignore_unused_legend_kwargs
 
     subroutine grid(visible, which, axis, alpha, linestyle, enabled)
-        !! Toggle or style grid lines (matplotlib-compatible)
+        !! Toggle or style grid lines.
         !!
-        !! Arguments:
-        !!   visible   - show grid when .true.; canonical matplotlib name
-        !!   which     - 'major', 'minor', or 'both'
-        !!   axis      - 'x', 'y', or 'both'
-        !!   alpha     - grid line transparency
-        !!   linestyle - grid line style ('-', '--', ':', '-.')
-        !!   enabled   - deprecated alias for visible, kept for backward compatibility
-        !!
-        !! Default grid state follows the active style: MPL mode disables
-        !! grid by default; Vega-Lite mode enables it.
-        !!
-        !! When neither visible nor enabled is present and no styling kwargs
-        !! are given, grid() is a no-op.  When styling kwargs (which, axis,
-        !! alpha, linestyle) are present without a visibility argument, the
-        !! grid is implicitly enabled with the given styling.
+        !! Parameters
+        !! visible : logical, optional
+        !!     Show the grid when .true.
+        !! which : character(len=*), optional
+        !!     Grid selection: 'major', 'minor', or 'both'.
+        !! axis : character(len=*), optional
+        !!     Axis selection: 'x', 'y', or 'both'.
+        !! alpha : real(wp), optional
+        !!     Grid line transparency.
+        !! linestyle : character(len=*), optional
+        !!     Grid line style.
+        !! enabled : logical, optional
+        !!     Deprecated alias for visible.
         logical, intent(in), optional :: visible
         character(len=*), intent(in), optional :: which, axis, linestyle
         real(wp), intent(in), optional :: alpha
@@ -204,21 +224,34 @@ contains
     end subroutine ylim
 
     subroutine view_init(elev, azim, dist)
-        !! Set the 3D view angles (degrees) like matplotlib's view_init.
+        !! Set the 3D view angles in degrees.
+        !!
+        !! Parameters
+        !! elev : real(wp), optional
+        !!     Elevation angle.
+        !! azim : real(wp), optional
+        !!     Azimuth angle.
+        !! dist : real(wp), optional
+        !!     Camera distance.
         real(wp), intent(in), optional :: elev, azim, dist
         call ensure_fig_init()
         call fig%set_view(elev=elev, azim=azim, dist=dist)
     end subroutine view_init
 
     subroutine set_xscale(scale, linthresh, threshold, base, linscale)
-        !! Set x-axis scale (matplotlib-compatible)
+        !! Set the x-axis scale.
         !!
-        !! Arguments:
-        !!   scale     - 'linear', 'log', 'symlog', 'logit'
-        !!   linthresh - symlog linear range threshold (matplotlib canonical)
-        !!   threshold - deprecated alias for linthresh, kept for compatibility
-        !!   base      - symlog logarithm base (default 10)
-        !!   linscale  - symlog linear region scaling factor (default 1)
+        !! Parameters
+        !! scale : character(len=*), intent(in)
+        !!     'linear', 'log', 'symlog', or 'logit'.
+        !! linthresh : real(wp), optional
+        !!     Symlog linear range threshold.
+        !! threshold : real(wp), optional
+        !!     Deprecated alias for linthresh.
+        !! base : real(wp), optional
+        !!     Symlog logarithm base.
+        !! linscale : real(wp), optional
+        !!     Symlog linear-region scaling factor.
         character(len=*), intent(in) :: scale
         real(wp), intent(in), optional :: linthresh, threshold, base, linscale
         real(wp) :: resolved_threshold
@@ -235,7 +268,19 @@ contains
     end subroutine set_xscale
 
     subroutine set_yscale(scale, linthresh, threshold, base, linscale)
-        !! Set y-axis scale (matplotlib-compatible); see set_xscale for kwargs
+        !! Set the y-axis scale.
+        !!
+        !! Parameters
+        !! scale : character(len=*), intent(in)
+        !!     'linear', 'log', 'symlog', or 'logit'.
+        !! linthresh : real(wp), optional
+        !!     Symlog linear range threshold.
+        !! threshold : real(wp), optional
+        !!     Deprecated alias for linthresh.
+        !! base : real(wp), optional
+        !!     Symlog logarithm base.
+        !! linscale : real(wp), optional
+        !!     Symlog linear-region scaling factor.
         character(len=*), intent(in) :: scale
         real(wp), intent(in), optional :: linthresh, threshold, base, linscale
         real(wp) :: resolved_threshold
@@ -252,7 +297,11 @@ contains
     end subroutine set_yscale
 
     subroutine xscale(scale, linthresh, threshold, base, linscale)
-        !! matplotlib pyplot alias for set_xscale
+        !! Alias for set_xscale.
+        !!
+        !! Parameters
+        !! scale : character(len=*), intent(in)
+        !!     'linear', 'log', 'symlog', or 'logit'.
         character(len=*), intent(in) :: scale
         real(wp), intent(in), optional :: linthresh, threshold, base, linscale
         call set_xscale(scale, linthresh=linthresh, threshold=threshold, &
@@ -260,7 +309,11 @@ contains
     end subroutine xscale
 
     subroutine yscale(scale, linthresh, threshold, base, linscale)
-        !! matplotlib pyplot alias for set_yscale
+        !! Alias for set_yscale.
+        !!
+        !! Parameters
+        !! scale : character(len=*), intent(in)
+        !!     'linear', 'log', 'symlog', or 'logit'.
         character(len=*), intent(in) :: scale
         real(wp), intent(in), optional :: linthresh, threshold, base, linscale
         call set_yscale(scale, linthresh=linthresh, threshold=threshold, &
@@ -314,30 +367,43 @@ contains
     end function get_active_axis
 
     subroutine minorticks_on()
-        !! Enable minor ticks on both axes (matplotlib-compatible)
+        !! Enable minor ticks on both axes.
         call ensure_fig_init()
         call fig%minorticks_on()
     end subroutine minorticks_on
 
     subroutine axis_str(aspect)
-        !! Set axis aspect ratio using string mode: 'equal' or 'auto'
+        !! Set axis aspect ratio using string mode.
+        !!
+        !! Parameters
+        !! aspect : character(len=*), intent(in)
+        !!     'equal' or 'auto'.
         character(len=*), intent(in) :: aspect
         call ensure_fig_init()
         call fig%set_aspect(aspect)
     end subroutine axis_str
 
     subroutine axis_num(ratio)
-        !! Set axis aspect ratio using a numeric value (y-scale = ratio * x-scale)
+        !! Set axis aspect ratio using a numeric value.
+        !!
+        !! Parameters
+        !! ratio : real(wp), intent(in)
+        !!     y-scale = ratio * x-scale.
         real(wp), intent(in) :: ratio
         call ensure_fig_init()
         call fig%set_aspect(ratio)
     end subroutine axis_num
 
     subroutine tight_layout(pad, w_pad, h_pad)
-        !! Automatically adjust subplot parameters to give specified padding
+        !! Automatically adjust subplot parameters to give specified padding.
         !!
-        !! Enables tight layout mode which optimizes the figure layout to
-        !! minimize overlap between subplots, titles, and axis labels.
+        !! Parameters
+        !! pad : real(wp), optional
+        !!     Padding between figure edge and subplot edge.
+        !! w_pad : real(wp), optional
+        !!     Padding between subplots in width.
+        !! h_pad : real(wp), optional
+        !!     Padding between subplots in height.
         real(wp), intent(in), optional :: pad
         real(wp), intent(in), optional :: w_pad
         real(wp), intent(in), optional :: h_pad
@@ -347,7 +413,11 @@ contains
     end subroutine tight_layout
 
     subroutine axhline(y, xmin, xmax, color, linestyle, linewidth, label)
-        !! Draw a horizontal reference line at data value y (matplotlib-compatible)
+        !! Draw a horizontal reference line.
+        !!
+        !! Parameters
+        !! y : real(wp), intent(in)
+        !!     Data value for the line.
         real(wp), intent(in) :: y
         real(wp), intent(in), optional :: xmin, xmax
         character(len=*), intent(in), optional :: color, linestyle, label
@@ -359,7 +429,11 @@ contains
     end subroutine axhline
 
     subroutine axvline(x, ymin, ymax, color, linestyle, linewidth, label)
-        !! Draw a vertical reference line at data value x (matplotlib-compatible)
+        !! Draw a vertical reference line.
+        !!
+        !! Parameters
+        !! x : real(wp), intent(in)
+        !!     Data value for the line.
         real(wp), intent(in) :: x
         real(wp), intent(in), optional :: ymin, ymax
         character(len=*), intent(in), optional :: color, linestyle, label
@@ -371,7 +445,15 @@ contains
     end subroutine axvline
 
     subroutine hlines(y, xmin, xmax, colors, linestyles, linewidth, label)
-        !! Draw one or more horizontal lines at y values between xmin and xmax
+        !! Draw one or more horizontal lines.
+        !!
+        !! Parameters
+        !! y : real(wp), contiguous, intent(in)
+        !!     Line positions.
+        !! xmin : real(wp), intent(in)
+        !!     Line start value.
+        !! xmax : real(wp), intent(in)
+        !!     Line end value.
         real(wp), contiguous, intent(in) :: y(:)
         real(wp), intent(in) :: xmin, xmax
         character(len=*), intent(in), optional :: colors, linestyles, label
@@ -383,7 +465,15 @@ contains
     end subroutine hlines
 
     subroutine vlines(x, ymin, ymax, colors, linestyles, linewidth, label)
-        !! Draw one or more vertical lines at x values between ymin and ymax
+        !! Draw one or more vertical lines.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Line positions.
+        !! ymin : real(wp), intent(in)
+        !!     Line start value.
+        !! ymax : real(wp), intent(in)
+        !!     Line end value.
         real(wp), contiguous, intent(in) :: x(:)
         real(wp), intent(in) :: ymin, ymax
         character(len=*), intent(in), optional :: colors, linestyles, label
@@ -395,7 +485,13 @@ contains
     end subroutine vlines
 
     subroutine set_xticks(positions, labels)
-        !! Set custom x-axis tick positions and optionally labels
+        !! Set custom x-axis tick positions and optional labels.
+        !!
+        !! Parameters
+        !! positions : real(wp), contiguous, intent(in)
+        !!     Tick locations.
+        !! labels : character(len=*), optional
+        !!     Tick labels.
         real(wp), contiguous, intent(in) :: positions(:)
         character(len=*), intent(in), optional :: labels(:)
 
@@ -408,7 +504,13 @@ contains
     end subroutine set_xticks
 
     subroutine set_yticks(positions, labels)
-        !! Set custom y-axis tick positions and optionally labels
+        !! Set custom y-axis tick positions and optional labels.
+        !!
+        !! Parameters
+        !! positions : real(wp), contiguous, intent(in)
+        !!     Tick locations.
+        !! labels : character(len=*), optional
+        !!     Tick labels.
         real(wp), contiguous, intent(in) :: positions(:)
         character(len=*), intent(in), optional :: labels(:)
 

--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -211,6 +211,12 @@ contains
 
     subroutine xlim(xmin, xmax)
         !! Set the x-axis display limits.
+        !!
+        !! Parameters
+        !! xmin : real(wp), intent(in)
+        !!     Lower x bound.
+        !! xmax : real(wp), intent(in)
+        !!     Upper x bound.
         real(wp), intent(in) :: xmin, xmax
         call ensure_fig_init()
         call fig%set_xlim(xmin, xmax)
@@ -218,6 +224,12 @@ contains
 
     subroutine ylim(ymin, ymax)
         !! Set the y-axis display limits.
+        !!
+        !! Parameters
+        !! ymin : real(wp), intent(in)
+        !!     Lower y bound.
+        !! ymax : real(wp), intent(in)
+        !!     Upper y bound.
         real(wp), intent(in) :: ymin, ymax
         call ensure_fig_init()
         call fig%set_ylim(ymin, ymax)
@@ -340,6 +352,10 @@ contains
 
     subroutine set_line_width(width)
         !! Set the default line width for subsequent plots.
+        !!
+        !! Parameters
+        !! width : real(wp), intent(in)
+        !!     Line width.
         real(wp), intent(in) :: width
         call ensure_fig_init()
         call fig%set_line_width(width)
@@ -347,6 +363,10 @@ contains
 
     subroutine set_ydata(ydata)
         !! Replace the y-data of the first plot line.
+        !!
+        !! Parameters
+        !! ydata : real(wp), contiguous, intent(in)
+        !!     New y coordinates.
         real(wp), contiguous, intent(in) :: ydata(:)
         call ensure_fig_init()
         call fig%set_ydata(1, ydata)
@@ -354,6 +374,10 @@ contains
 
     subroutine use_axis(axis_name)
         !! Switch the active axes by name.
+        !!
+        !! Parameters
+        !! axis_name : character(len=*), intent(in)
+        !!     Target axes name.
         character(len=*), intent(in) :: axis_name
         call ensure_fig_init()
         call fig%use_axis(axis_name)
@@ -361,6 +385,10 @@ contains
 
     function get_active_axis() result(axis_name)
         !! Return the name of the currently active axes.
+        !!
+        !! Returns
+        !! axis_name : character(len=10)
+        !!     Active axes name.
         character(len=10) :: axis_name
         call ensure_fig_init()
         axis_name = fig%get_active_axis()

--- a/src/interfaces/fortplot_matplotlib_colorbar.f90
+++ b/src/interfaces/fortplot_matplotlib_colorbar.f90
@@ -13,6 +13,27 @@ contains
 
     subroutine colorbar(label, location, fraction, pad, shrink, plot_index, &
                         ticks, ticklabels, label_fontsize)
+        !! Add a colorbar for the active figure.
+        !!
+        !! Parameters
+        !! label : character(len=*), optional
+        !!     Colorbar label.
+        !! location : character(len=*), optional
+        !!     Placement keyword such as 'right' or 'bottom'.
+        !! fraction : real(wp), optional
+        !!     Relative colorbar size.
+        !! pad : real(wp), optional
+        !!     Gap between the plot and the colorbar.
+        !! shrink : real(wp), optional
+        !!     Relative shrink factor.
+        !! plot_index : integer, optional
+        !!     Plot record to use for the color scale.
+        !! ticks : real(wp), optional
+        !!     Explicit tick positions.
+        !! ticklabels : character(len=*), optional
+        !!     Tick label strings.
+        !! label_fontsize : real(wp), optional
+        !!     Font size for the colorbar label.
         character(len=*), intent(in), optional :: label, location
         real(wp), intent(in), optional :: fraction, pad, shrink
         integer, intent(in), optional :: plot_index
@@ -28,4 +49,3 @@ contains
     end subroutine colorbar
 
 end module fortplot_matplotlib_colorbar
-

--- a/src/interfaces/fortplot_matplotlib_errorbar.f90
+++ b/src/interfaces/fortplot_matplotlib_errorbar.f90
@@ -37,6 +37,47 @@ contains
                             marker, color, ecolor, elinewidth, capthick, &
                             barsabove, errorevery, lolims, uplims, xlolims, &
                             xuplims)
+        !! Draw an errorbar plot with RGB colors.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! xerr : real(wp), optional
+        !!     Symmetric x errors.
+        !! yerr : real(wp), optional
+        !!     Symmetric y errors.
+        !! fmt : character(len=*), optional
+        !!     Matplotlib format string.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! capsize : real(wp), optional
+        !!     Errorbar cap size.
+        !! linestyle : character(len=*), optional
+        !!     Line style.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! color : real(wp)(3), optional
+        !!     Line color.
+        !! ecolor : real(wp)(3), optional
+        !!     Errorbar color.
+        !! elinewidth : real(wp), optional
+        !!     Errorbar line width.
+        !! capthick : real(wp), optional
+        !!     Cap line width.
+        !! barsabove : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! errorevery : integer, optional
+        !!     Down-sampling stride for error bars.
+        !! lolims : logical, optional
+        !!     Lower y-limit marker.
+        !! uplims : logical, optional
+        !!     Upper y-limit marker.
+        !! xlolims : logical, optional
+        !!     Lower x-limit marker.
+        !! xuplims : logical, optional
+        !!     Upper x-limit marker.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: xerr(:), yerr(:)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
@@ -65,6 +106,47 @@ contains
                                 linestyle, marker, ecolor, elinewidth, capthick, &
                                 barsabove, errorevery, lolims, uplims, xlolims, &
                                 xuplims)
+        !! Draw an errorbar plot with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! xerr : real(wp), optional
+        !!     Symmetric x errors.
+        !! yerr : real(wp), optional
+        !!     Symmetric y errors.
+        !! fmt : character(len=*), optional
+        !!     Matplotlib format string.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! capsize : real(wp), optional
+        !!     Errorbar cap size.
+        !! linestyle : character(len=*), optional
+        !!     Line style.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! ecolor : character(len=*), optional
+        !!     Errorbar color.
+        !! elinewidth : real(wp), optional
+        !!     Errorbar line width.
+        !! capthick : real(wp), optional
+        !!     Cap line width.
+        !! barsabove : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! errorevery : integer, optional
+        !!     Down-sampling stride for error bars.
+        !! lolims : logical, optional
+        !!     Lower y-limit marker.
+        !! uplims : logical, optional
+        !!     Upper y-limit marker.
+        !! xlolims : logical, optional
+        !!     Lower x-limit marker.
+        !! xuplims : logical, optional
+        !!     Upper x-limit marker.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: xerr(:), yerr(:)
@@ -117,9 +199,15 @@ contains
                                  marker, color, ecolor, elinewidth, capthick, &
                                  barsabove, errorevery, lolims, uplims, xlolims, &
                                  xuplims)
-        !! Integer-capsize overload so matplotlib-style errorbar(..., capsize=4)
-        !! works without forcing a real literal. capsize is required (not
-        !! optional) so this stays distinguishable from errorbar_rgb (#2020).
+        !! Integer-capsize overload for errorbar_rgb.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! capsize : integer, intent(in)
+        !!     Errorbar cap size.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         integer, intent(in) :: capsize
         real(wp), intent(in), optional :: xerr(:), yerr(:)
@@ -144,7 +232,17 @@ contains
                                     linestyle, marker, ecolor, elinewidth, capthick, &
                                     barsabove, errorevery, lolims, uplims, xlolims, &
                                     xuplims)
-        !! Integer-capsize overload of the string-color errorbar (#2020).
+        !! Integer-capsize overload for errorbar_string.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! capsize : integer, intent(in)
+        !!     Errorbar cap size.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         integer, intent(in) :: capsize
@@ -169,6 +267,7 @@ contains
                                  linestyle, marker, color, ecolor, elinewidth, &
                                  capthick, barsabove, errorevery, lolims, uplims, &
                                  xlolims, xuplims)
+        !! Object-oriented alias for errorbar_rgb.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: xerr(:), yerr(:)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
@@ -191,6 +290,7 @@ contains
                                     linestyle, marker, ecolor, elinewidth, capthick, &
                                     barsabove, errorevery, lolims, uplims, xlolims, &
                                     xuplims)
+        !! Object-oriented alias for errorbar_string.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: xerr(:), yerr(:)
@@ -214,7 +314,7 @@ contains
                                      linestyle, marker, color, ecolor, elinewidth, &
                                      capthick, barsabove, errorevery, lolims, &
                                      uplims, xlolims, xuplims)
-        !! Integer-capsize overload of add_errorbar (#2020).
+        !! Integer-capsize overload for add_errorbar_rgb.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         integer, intent(in) :: capsize
         real(wp), intent(in), optional :: xerr(:), yerr(:)
@@ -238,7 +338,7 @@ contains
                                         label, linestyle, marker, ecolor, &
                                         elinewidth, capthick, barsabove, errorevery, &
                                         lolims, uplims, xlolims, xuplims)
-        !! Integer-capsize overload of the string-color add_errorbar (#2020).
+        !! Integer-capsize overload for add_errorbar_string.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         integer, intent(in) :: capsize

--- a/src/interfaces/fortplot_matplotlib_field_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_field_wrappers.f90
@@ -20,10 +20,23 @@ module fortplot_matplotlib_field_wrappers
 contains
 
     subroutine contour(x, y, z, levels, cmap, label, colormap)
-        !! Draw contour lines (matplotlib-compatible)
+        !! Draw contour lines.
         !!
-        !! `cmap` selects the colormap name. `colormap` is a deprecated alias
-        !! kept for backward compatibility.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)
@@ -43,10 +56,25 @@ contains
 
     subroutine contour_filled(x, y, z, levels, cmap, show_colorbar, label, &
                               colormap)
-        !! Draw filled contour regions (matplotlib-compatible)
+        !! Draw filled contour regions.
         !!
-        !! `cmap` is the matplotlib canonical keyword; `colormap` is kept as
-        !! a backward-compatible alias.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Attach a colorbar when .true.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)
@@ -66,7 +94,25 @@ contains
     end subroutine contour_filled
 
     subroutine contourf(x, y, z, levels, cmap, show_colorbar, label, colormap)
-        !! matplotlib-canonical alias for contour_filled
+        !! Matplotlib-canonical alias for contour_filled.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Attach a colorbar when .true.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)
@@ -79,7 +125,23 @@ contains
     end subroutine contourf
 
     subroutine add_contour(x, y, z, levels, cmap, label, colormap)
-        !! Object-oriented contour helper (matplotlib-compatible kwargs)
+        !! Object-oriented contour helper.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)
@@ -91,10 +153,25 @@ contains
 
     subroutine add_contour_filled(x, y, z, levels, cmap, show_colorbar, label, &
                                   colormap)
-        !! Object-oriented filled contour helper (matplotlib-compatible kwargs)
+        !! Object-oriented filled contour helper.
         !!
-        !! `cmap` is the matplotlib-canonical keyword; `colormap` is a
-        !! backward-compatible alias.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Attach a colorbar when .true.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)
@@ -107,7 +184,25 @@ contains
     end subroutine add_contour_filled
 
     subroutine add_contourf(x, y, z, levels, cmap, show_colorbar, label, colormap)
-        !! matplotlib-canonical alias for add_contour_filled
+        !! Matplotlib-canonical alias for add_contour_filled.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Field values on the grid.
+        !! levels : real(wp), optional
+        !!     Contour levels.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Attach a colorbar when .true.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         real(wp), intent(in), optional :: levels(:)

--- a/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_hist_wrappers.f90
@@ -30,6 +30,35 @@ contains
 
     subroutine hist_rgb(data, bins, range, density, weights, cumulative, &
                         histtype, orientation, stacked, log, label, color, alpha)
+        !! Draw a histogram with an RGB color.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! bins : integer, optional
+        !!     Number of bins.
+        !! range : real(wp), optional
+        !!     Lower and upper bin range.
+        !! density : logical, optional
+        !!     Normalize the histogram when .true.
+        !! weights : real(wp), optional
+        !!     Per-sample weights.
+        !! cumulative : logical, optional
+        !!     Accumulate bin counts when .true.
+        !! histtype : character(len=*), optional
+        !!     Histogram style keyword.
+        !! orientation : character(len=*), optional
+        !!     'vertical' or 'horizontal'.
+        !! stacked : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! log : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: data(:)
         integer, intent(in), optional :: bins
         real(wp), intent(in), optional :: range(2)
@@ -50,6 +79,35 @@ contains
     subroutine hist_string(data, color, bins, range, density, weights, &
                            cumulative, histtype, orientation, stacked, log, &
                            label, alpha)
+        !! Draw a histogram with a named color.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! bins : integer, optional
+        !!     Number of bins.
+        !! range : real(wp), optional
+        !!     Lower and upper bin range.
+        !! density : logical, optional
+        !!     Normalize the histogram when .true.
+        !! weights : real(wp), optional
+        !!     Per-sample weights.
+        !! cumulative : logical, optional
+        !!     Accumulate bin counts when .true.
+        !! histtype : character(len=*), optional
+        !!     Histogram style keyword.
+        !! orientation : character(len=*), optional
+        !!     'vertical' or 'horizontal'.
+        !! stacked : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! log : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: data(:)
         character(len=*), intent(in) :: color
         integer, intent(in), optional :: bins
@@ -81,6 +139,35 @@ contains
     subroutine histogram_rgb(data, bins, range, density, weights, cumulative, &
                              histtype, orientation, stacked, log, label, color, &
                              alpha)
+        !! Matplotlib-style alias for hist_rgb.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! bins : integer, optional
+        !!     Number of bins.
+        !! range : real(wp), optional
+        !!     Lower and upper bin range.
+        !! density : logical, optional
+        !!     Normalize the histogram when .true.
+        !! weights : real(wp), optional
+        !!     Per-sample weights.
+        !! cumulative : logical, optional
+        !!     Accumulate bin counts when .true.
+        !! histtype : character(len=*), optional
+        !!     Histogram style keyword.
+        !! orientation : character(len=*), optional
+        !!     'vertical' or 'horizontal'.
+        !! stacked : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! log : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: data(:)
         integer, intent(in), optional :: bins
         real(wp), intent(in), optional :: range(2)
@@ -102,6 +189,35 @@ contains
     subroutine histogram_string(data, color, bins, range, density, weights, &
                                 cumulative, histtype, orientation, stacked, log, &
                                 label, alpha)
+        !! Matplotlib-style alias for hist_string.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! bins : integer, optional
+        !!     Number of bins.
+        !! range : real(wp), optional
+        !!     Lower and upper bin range.
+        !! density : logical, optional
+        !!     Normalize the histogram when .true.
+        !! weights : real(wp), optional
+        !!     Per-sample weights.
+        !! cumulative : logical, optional
+        !!     Accumulate bin counts when .true.
+        !! histtype : character(len=*), optional
+        !!     Histogram style keyword.
+        !! orientation : character(len=*), optional
+        !!     'vertical' or 'horizontal'.
+        !! stacked : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! log : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: data(:)
         character(len=*), intent(in) :: color
         integer, intent(in), optional :: bins

--- a/src/interfaces/fortplot_matplotlib_mesh_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_mesh_wrappers.f90
@@ -13,8 +13,31 @@ contains
                               edgecolors, linewidths, vmin, vmax, colormap)
         !! Draw a pseudocolor mesh (matplotlib-compatible)
         !!
-        !! `cmap` is the matplotlib canonical keyword; `colormap` is kept as
-        !! a backward-compatible alias.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Cell or node values on the grid.
+        !! shading : character(len=*), optional
+        !!     Matplotlib shading keyword.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! edgecolors : real(wp)(3), optional
+        !!     Accepted for matplotlib parity.
+        !! linewidths : real(wp), optional
+        !!     Mesh line width.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         character(len=*), intent(in), optional :: shading, cmap, label, colormap
@@ -77,10 +100,33 @@ contains
 
     subroutine add_pcolormesh(x, y, z, shading, cmap, show_colorbar, label, &
                                   edgecolors, linewidths, vmin, vmax, colormap)
-        !! Object-oriented pcolormesh helper (matplotlib-compatible kwargs)
+        !! Object-oriented pcolormesh helper.
         !!
-        !! `cmap` is the matplotlib-canonical keyword; `colormap` is a
-        !! backward-compatible alias.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Cell or node values on the grid.
+        !! shading : character(len=*), optional
+        !!     Matplotlib shading keyword.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! edgecolors : real(wp)(3), optional
+        !!     Accepted for matplotlib parity.
+        !! linewidths : real(wp), optional
+        !!     Mesh line width.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         character(len=*), intent(in), optional :: shading, cmap, label, colormap
@@ -97,10 +143,31 @@ contains
 
     subroutine add_surface(x, y, z, cmap, show_colorbar, alpha, edgecolor, &
                            linewidth, label, filled, colormap)
-        !! Object-oriented surface helper (matplotlib-compatible kwargs)
+        !! Object-oriented surface helper.
         !!
-        !! `cmap` is the matplotlib-canonical keyword; `colormap` is a
-        !! backward-compatible alias.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X grid coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y grid coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Surface values on the grid.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! show_colorbar : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Surface transparency.
+        !! edgecolor : real(wp)(3), optional
+        !!     Surface edge color.
+        !! linewidth : real(wp), optional
+        !!     Surface line width.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! filled : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: z(:,:)
         character(len=*), intent(in), optional :: cmap, label, colormap

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -112,6 +112,27 @@ contains
     end subroutine plot
 
     subroutine bar_rgb(x, height, width, bottom, label, color, edgecolor, align, alpha)
+        !! Plot a vertical bar chart with RGB colors.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! height : real(wp), contiguous, intent(in)
+        !!     Bar heights.
+        !! width : real(wp), optional
+        !!     Bar width.
+        !! bottom : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! color : real(wp)(3), optional
+        !!     Bar fill color.
+        !! edgecolor : real(wp)(3), optional
+        !!     Bar edge color.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in), optional :: width
         real(wp), intent(in), optional :: bottom(:)
@@ -134,6 +155,27 @@ contains
     end subroutine bar_rgb
 
     subroutine bar_string(x, height, color, width, bottom, label, edgecolor, align, alpha)
+        !! Plot a vertical bar chart with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! height : real(wp), contiguous, intent(in)
+        !!     Bar heights.
+        !! color : character(len=*), intent(in)
+        !!     Bar fill color.
+        !! width : real(wp), optional
+        !!     Bar width.
+        !! bottom : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! edgecolor : character(len=*), optional
+        !!     Bar edge color.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: x(:), height(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: width
@@ -176,6 +218,27 @@ contains
     end subroutine bar_string
 
     subroutine barh_rgb(y, width, height, left, label, color, edgecolor, align, alpha)
+        !! Plot a horizontal bar chart with RGB colors.
+        !!
+        !! Parameters
+        !! y : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! width : real(wp), contiguous, intent(in)
+        !!     Bar lengths.
+        !! height : real(wp), optional
+        !!     Bar thickness.
+        !! left : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! color : real(wp)(3), optional
+        !!     Bar fill color.
+        !! edgecolor : real(wp)(3), optional
+        !!     Bar edge color.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in), optional :: height
         real(wp), intent(in), optional :: left(:)
@@ -198,6 +261,27 @@ contains
     end subroutine barh_rgb
 
     subroutine barh_string(y, width, color, height, left, label, edgecolor, align, alpha)
+        !! Plot a horizontal bar chart with a named color.
+        !!
+        !! Parameters
+        !! y : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! width : real(wp), contiguous, intent(in)
+        !!     Bar lengths.
+        !! color : character(len=*), intent(in)
+        !!     Bar fill color.
+        !! height : real(wp), optional
+        !!     Bar thickness.
+        !! left : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! edgecolor : character(len=*), optional
+        !!     Bar edge color.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: y(:), width(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: height
@@ -240,7 +324,27 @@ contains
     end subroutine barh_string
 
     subroutine bar_rgb_edgecolor(x, height, color, edgecolor, width, bottom, label, align, alpha)
-        !! Bar with RGB-triple color and named-color edgecolor
+        !! Plot a vertical bar chart with RGB fill and named edge color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! height : real(wp), contiguous, intent(in)
+        !!     Bar heights.
+        !! color : real(wp)(3), intent(in)
+        !!     Bar fill color.
+        !! edgecolor : character(len=*), intent(in)
+        !!     Bar edge color.
+        !! width : real(wp), optional
+        !!     Bar width.
+        !! bottom : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in) :: color(3)
         character(len=*), intent(in) :: edgecolor
@@ -275,7 +379,27 @@ contains
     end subroutine bar_rgb_edgecolor
 
     subroutine barh_rgb_edgecolor(y, width, color, edgecolor, height, left, label, align, alpha)
-        !! Barh with RGB-triple color and named-color edgecolor
+        !! Plot a horizontal bar chart with RGB fill and named edge color.
+        !!
+        !! Parameters
+        !! y : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! width : real(wp), contiguous, intent(in)
+        !!     Bar lengths.
+        !! color : real(wp)(3), intent(in)
+        !!     Bar fill color.
+        !! edgecolor : character(len=*), intent(in)
+        !!     Bar edge color.
+        !! height : real(wp), optional
+        !!     Bar thickness.
+        !! left : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in) :: color(3)
         character(len=*), intent(in) :: edgecolor
@@ -310,7 +434,27 @@ contains
     end subroutine barh_rgb_edgecolor
 
     subroutine bar_rgb_array(x, height, color_per_bar, edgecolor_per_bar, width, bottom, label, align, alpha)
-        !! Bar with per-bar RGB color arrays
+        !! Plot a vertical bar chart with per-bar RGB color arrays.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! height : real(wp), contiguous, intent(in)
+        !!     Bar heights.
+        !! color_per_bar : real(wp)(3, *), optional
+        !!     Per-bar fill colors.
+        !! edgecolor_per_bar : real(wp)(3, *), optional
+        !!     Per-bar edge colors.
+        !! width : real(wp), optional
+        !!     Bar width.
+        !! bottom : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: x(:), height(:)
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
@@ -341,7 +485,27 @@ contains
     end subroutine bar_rgb_array
 
     subroutine barh_rgb_array(y, width, color_per_bar, edgecolor_per_bar, height, left, label, align, alpha)
-        !! Barh with per-bar RGB color arrays
+        !! Plot a horizontal bar chart with per-bar RGB color arrays.
+        !!
+        !! Parameters
+        !! y : real(wp), contiguous, intent(in)
+        !!     Bar positions.
+        !! width : real(wp), contiguous, intent(in)
+        !!     Bar lengths.
+        !! color_per_bar : real(wp)(3, *), optional
+        !!     Per-bar fill colors.
+        !! edgecolor_per_bar : real(wp)(3, *), optional
+        !!     Per-bar edge colors.
+        !! height : real(wp), optional
+        !!     Bar thickness.
+        !! left : real(wp), optional
+        !!     Baseline values.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! align : character(len=*), optional
+        !!     Accepted for matplotlib parity.
+        !! alpha : real(wp), optional
+        !!     Bar transparency.
         real(wp), contiguous, intent(in) :: y(:), width(:)
         real(wp), intent(in), optional :: color_per_bar(3, *)
         real(wp), intent(in), optional :: edgecolor_per_bar(3, *)
@@ -391,8 +555,23 @@ contains
     end subroutine resolve_bar_bottom
 
     subroutine boxplot_string(data, position, width, label, show_outliers, horizontal, color)
-        !! Boxplot with named-color string (matplotlib-compatible).
-        !! Converts string color to RGB before delegating to the figure.
+        !! Plot a boxplot with a named color.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! position : real(wp), optional
+        !!     Box position.
+        !! width : real(wp), optional
+        !!     Box width.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! show_outliers : logical, optional
+        !!     Show outlier markers.
+        !! horizontal : logical, optional
+        !!     Draw a horizontal boxplot.
+        !! color : character(len=*), intent(in)
+        !!     Box color.
         real(wp), contiguous, intent(in) :: data(:)
         real(wp), intent(in), optional :: position
         real(wp), intent(in), optional :: width
@@ -417,7 +596,23 @@ contains
     end subroutine boxplot_string
 
     subroutine boxplot_rgb(data, position, width, label, show_outliers, horizontal, color)
-        !! Boxplot with RGB-triple color (matplotlib-compatible).
+        !! Plot a boxplot with an RGB color.
+        !!
+        !! Parameters
+        !! data : real(wp), contiguous, intent(in)
+        !!     Sample values.
+        !! position : real(wp), optional
+        !!     Box position.
+        !! width : real(wp), optional
+        !!     Box width.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! show_outliers : logical, optional
+        !!     Show outlier markers.
+        !! horizontal : logical, optional
+        !!     Draw a horizontal boxplot.
+        !! color : real(wp)(3), optional
+        !!     Box color.
         real(wp), contiguous, intent(in) :: data(:)
         real(wp), intent(in), optional :: position
         real(wp), intent(in), optional :: width
@@ -494,7 +689,27 @@ contains
 
     subroutine add_3d_plot_rgb(x, y, z, label, linestyle, color, linewidth, marker, &
                                  markersize)
-        !! 3D plot wrapper with RGB-triple color (matplotlib-compatible).
+        !! Add a 3D line or marker plot with an RGB color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Z coordinates.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! linestyle : character(len=*), optional
+        !!     Line style string.
+        !! color : real(wp)(3), optional
+        !!     Plot color.
+        !! linewidth : real(wp), optional
+        !!     Line width.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Marker size.
         real(wp), contiguous, intent(in) :: x(:), y(:), z(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
@@ -508,8 +723,27 @@ contains
 
     subroutine add_3d_plot_string(x, y, z, label, linestyle, color, linewidth, marker, &
                                    markersize)
-        !! 3D plot wrapper with named-color string (matplotlib-compatible).
-        !! Converts string color to RGB before delegating to the figure.
+        !! Add a 3D line or marker plot with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Z coordinates.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! linestyle : character(len=*), optional
+        !!     Line style string.
+        !! color : character(len=*), intent(in)
+        !!     Plot color.
+        !! linewidth : real(wp), optional
+        !!     Line width.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Marker size.
         real(wp), contiguous, intent(in) :: x(:), y(:), z(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         character(len=*), intent(in) :: color

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -65,6 +65,27 @@ module fortplot_matplotlib_plot_wrappers
 contains
 
     subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize, alpha)
+        !! Plot x and y data with the active figure or subplot.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! linestyle : character(len=*), optional
+        !!     Line style string.
+        !! color : real(wp)(3), optional
+        !!     RGB line color.
+        !! linewidth : real(wp), optional
+        !!     Line width override.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Marker size override.
+        !! alpha : real(wp), optional
+        !!     Line transparency.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
@@ -411,6 +432,21 @@ contains
     end subroutine boxplot_rgb
 
     subroutine add_plot_rgb(x, y, color, label, linestyle, alpha)
+        !! Add a line plot with an RGB color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! color : real(wp)(3), optional
+        !!     RGB line color.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! linestyle : character(len=*), optional
+        !!     Line style string.
+        !! alpha : real(wp), optional
+        !!     Line transparency.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: color(3)
         character(len=*), intent(in), optional :: label, linestyle
@@ -422,6 +458,21 @@ contains
     end subroutine add_plot_rgb
 
     subroutine add_plot_string(x, y, color, label, linestyle, alpha)
+        !! Add a line plot with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! linestyle : character(len=*), optional
+        !!     Line style string.
+        !! alpha : real(wp), optional
+        !!     Line transparency.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         character(len=*), intent(in), optional :: label, linestyle

--- a/src/interfaces/fortplot_matplotlib_plots.f90
+++ b/src/interfaces/fortplot_matplotlib_plots.f90
@@ -43,7 +43,16 @@ module fortplot_matplotlib_plots
 contains
 
     subroutine imshow(z, cmap, alpha, vmin, vmax, origin, extent, interpolation, aspect)
-        !! Display 2D array as an image (heatmap)
+        !! Parameters
+        !!   z - image data.
+        !!   cmap - colormap name.
+        !!   alpha - opacity.
+        !!   vmin - lower color limit.
+        !!   vmax - upper color limit.
+        !!   origin - array origin keyword.
+        !!   extent - image extent.
+        !!   interpolation - interpolation mode.
+        !!   aspect - aspect keyword.
         real(wp), contiguous, intent(in) :: z(:,:)
         character(len=*), intent(in), optional :: cmap
         real(wp), intent(in), optional :: alpha, vmin, vmax
@@ -57,7 +66,13 @@ contains
     end subroutine imshow
 
     subroutine pie(values, labels, colors, explode, autopct, startangle)
-        !! Create a pie chart
+        !! Parameters
+        !!   values - wedge sizes.
+        !!   labels - wedge labels.
+        !!   colors - wedge colors.
+        !!   explode - wedge offsets.
+        !!   autopct - percentage label format.
+        !!   startangle - rotation angle in degrees.
         real(wp), contiguous, intent(in) :: values(:)
         character(len=*), intent(in), optional :: labels(:)
         character(len=*), intent(in), optional :: colors(:)
@@ -71,7 +86,14 @@ contains
     end subroutine pie
 
     subroutine polar_string(theta, r, fmt, label, linestyle, marker, color)
-        !! String-color variant of polar.
+        !! Parameters
+        !!   theta - angular samples.
+        !!   r - radial samples.
+        !!   fmt - format string.
+        !!   label - legend label.
+        !!   linestyle - line style.
+        !!   marker - marker style.
+        !!   color - named color string.
         real(wp), contiguous, intent(in) :: theta(:), r(:)
         character(len=*), intent(in), optional :: fmt, label
         character(len=*), intent(in), optional :: linestyle, marker
@@ -83,8 +105,14 @@ contains
     end subroutine polar_string
 
     subroutine polar_rgb(theta, r, color, fmt, label, linestyle, marker)
-        !! RGB-color variant of polar. Serialises the RGB triple as a hex
-        !! string so the underlying implementation remains untouched.
+        !! Parameters
+        !!   theta - angular samples.
+        !!   r - radial samples.
+        !!   color - literal RGB triple.
+        !!   fmt - format string.
+        !!   label - legend label.
+        !!   linestyle - line style.
+        !!   marker - marker style.
         real(wp), contiguous, intent(in) :: theta(:), r(:)
         real(wp), intent(in) :: color(3)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
@@ -98,6 +126,14 @@ contains
     end subroutine polar_rgb
 
     subroutine step_string(x, y, where, label, linestyle, color, linewidth)
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y - y coordinates.
+        !!   where - step position keyword.
+        !!   label - legend label.
+        !!   linestyle - line style.
+        !!   color - named color string.
+        !!   linewidth - line width.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: where, label
         character(len=*), intent(in), optional :: linestyle
@@ -110,6 +146,14 @@ contains
     end subroutine step_string
 
     subroutine step_rgb(x, y, color, where, label, linestyle, linewidth)
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y - y coordinates.
+        !!   color - literal RGB triple.
+        !!   where - step position keyword.
+        !!   label - legend label.
+        !!   linestyle - line style.
+        !!   linewidth - line width.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in) :: color(3)
         character(len=*), intent(in), optional :: where, label, linestyle
@@ -124,7 +168,14 @@ contains
     end subroutine step_rgb
 
     subroutine stem(x, y, linefmt, markerfmt, basefmt, label, bottom)
-        !! Create a stem plot
+        !! Parameters
+        !!   x - stem positions.
+        !!   y - stem heights.
+        !!   linefmt - line format.
+        !!   markerfmt - marker format.
+        !!   basefmt - base format.
+        !!   label - legend label.
+        !!   bottom - baseline value.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: linefmt, markerfmt, basefmt
         character(len=*), intent(in), optional :: label
@@ -136,8 +187,12 @@ contains
     end subroutine stem
 
     subroutine fill_string(x, y, color, alpha, step)
-        !! Fill the area between a curve and zero. `step` activates stair
-        !! fill to match matplotlib's `step` argument on `fill_between`.
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y - y coordinates.
+        !!   color - named color string.
+        !!   alpha - fill opacity.
+        !!   step - stair-fill mode.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: alpha
@@ -151,7 +206,12 @@ contains
     end subroutine fill_string
 
     subroutine fill_rgb(x, y, color, alpha, step)
-        !! RGB-color variant of fill.
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y - y coordinates.
+        !!   color - literal RGB triple.
+        !!   alpha - fill opacity.
+        !!   step - stair-fill mode.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in) :: color(3)
         real(wp), intent(in), optional :: alpha
@@ -167,9 +227,11 @@ contains
     end subroutine fill_rgb
 
     subroutine fill_default(x, y, alpha, step)
-        !! `fill` called without an explicit color uses the figure palette.
-        !! Kept as a dedicated overload so matplotlib-style no-color calls
-        !! remain legal through the generic interface.
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y - y coordinates.
+        !!   alpha - fill opacity.
+        !!   step - stair-fill mode.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: alpha
         character(len=*), intent(in), optional :: step
@@ -182,8 +244,15 @@ contains
     end subroutine fill_default
 
     subroutine fill_between_string(x, y1, y2, where, color, alpha, interpolate, step)
-        !! Matplotlib-style fill_between with string color. `y1` is required
-        !! (matching matplotlib); `y2` defaults to zero.
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y1 - lower curve.
+        !!   y2 - upper curve.
+        !!   where - mask for filled spans.
+        !!   color - named color string.
+        !!   alpha - fill opacity.
+        !!   interpolate - interpolate mask edges.
+        !!   step - stair-fill mode.
         real(wp), contiguous, intent(in) :: x(:)
         real(wp), contiguous, intent(in) :: y1(:)
         real(wp), intent(in), optional :: y2(:)
@@ -215,8 +284,15 @@ contains
     end subroutine fill_between_string
 
     subroutine fill_between_rgb(x, y1, y2, where, color, alpha, interpolate, step)
-        !! RGB-color variant of fill_between. Same positional layout as the
-        !! string variant; `color` keyword type distinguishes the two.
+        !! Parameters
+        !!   x - x coordinates.
+        !!   y1 - lower curve.
+        !!   y2 - upper curve.
+        !!   where - mask for filled spans.
+        !!   color - literal RGB triple.
+        !!   alpha - fill opacity.
+        !!   interpolate - interpolate mask edges.
+        !!   step - stair-fill mode.
         real(wp), contiguous, intent(in) :: x(:)
         real(wp), contiguous, intent(in) :: y1(:)
         real(wp), intent(in), optional :: y2(:)
@@ -477,13 +553,15 @@ contains
     end function rgb_to_hex
 
     subroutine twinx()
-        !! Activate a secondary y-axis that shares the x-axis but renders on the right
+        !! Parameters
+        !!   None.
         call ensure_fig_init()
         call fig%twinx()
     end subroutine twinx
 
     subroutine twiny()
-        !! Activate a secondary x-axis that shares the y-axis but renders on the top
+        !! Parameters
+        !!   None.
         call ensure_fig_init()
         call fig%twiny()
     end subroutine twiny

--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -57,9 +57,39 @@ contains
     subroutine scatter_rgb(x, y, s, c, label, marker, markersize, color, &
                             linewidths, edgecolors, alpha, cmap, vmin, vmax, &
                             linewidths_scalar)
-        !! Unified scatter with RGB color; accepts s as scalar or array
-        !! via deferred-shape `s(..)` so interface resolution works
-        !! correctly regardless of whether s is scalar or rank-1.
+        !! Draw a scatter plot with an RGB color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: s(..)
         real(wp), intent(in), optional :: c(:)
@@ -117,9 +147,39 @@ contains
     subroutine scatter_string(x, y, c, label, marker, markersize, color, &
                                linewidths, edgecolors, alpha, s, &
                                linewidths_scalar, cmap, vmin, vmax)
-        !! Unified scatter with string color; accepts s as scalar or array
-        !! via deferred-shape `s(..)` so interface resolution works
-        !! correctly regardless of whether s is scalar or rank-1.
+        !! Draw a scatter plot with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: c(:)
         character(len=*), intent(in), optional :: label, marker, cmap
@@ -216,6 +276,39 @@ contains
     subroutine add_scatter_2d_rgb(x, y, markersize, s, c, label, marker, color, &
                                   linewidths, edgecolors, alpha, cmap, vmin, &
                                   vmax, linewidths_scalar)
+        !! Object-oriented alias for scatter_rgb in 2D.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: markersize
         real(wp), intent(in), optional :: s(..), c(:)
@@ -275,6 +368,39 @@ contains
     subroutine add_scatter_2d_string(x, y, color, c, label, marker, markersize, &
                                      linewidths, edgecolors, alpha, s, &
                                      linewidths_scalar, cmap, vmin, vmax)
+        !! Object-oriented alias for scatter_string in 2D.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: c(:)
@@ -334,6 +460,41 @@ contains
     subroutine add_scatter_3d_rgb(x, y, z, s, c, label, marker, markersize, &
                                   color, linewidths, edgecolors, alpha, cmap, &
                                   vmin, vmax, linewidths_scalar)
+        !! Object-oriented alias for scatter_rgb in 3D.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Z coordinates.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
         real(wp), contiguous, intent(in) :: x(:), y(:), z(:)
         real(wp), intent(in), optional :: s(..)
         real(wp), intent(in), optional :: c(:)
@@ -394,6 +555,41 @@ contains
     subroutine add_scatter_3d_string(x, y, z, color, s, c, label, marker, &
                                      markersize, linewidths, edgecolors, alpha, &
                                      linewidths_scalar, cmap, vmin, vmax)
+        !! Object-oriented alias for scatter_string in 3D.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! z : real(wp), contiguous, intent(in)
+        !!     Z coordinates.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! s : real(wp), optional
+        !!     Marker size or per-point marker sizes.
+        !! c : real(wp), optional
+        !!     Per-point scalar values for colormap mapping.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! marker : character(len=*), optional
+        !!     Marker style.
+        !! markersize : real(wp), optional
+        !!     Alias for s when s is absent.
+        !! linewidths : real(wp), optional
+        !!     Marker edge line widths.
+        !! edgecolors : class(*), optional
+        !!     Marker edge colors.
+        !! alpha : real(wp), optional
+        !!     Marker transparency.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! vmin : real(wp), optional
+        !!     Lower color limit.
+        !! vmax : real(wp), optional
+        !!     Upper color limit.
+        !! linewidths_scalar : real(wp), optional
+        !!     Scalar fallback for linewidths.
         real(wp), contiguous, intent(in) :: x(:), y(:), z(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: s(..), c(:)

--- a/src/interfaces/fortplot_matplotlib_session.f90
+++ b/src/interfaces/fortplot_matplotlib_session.f90
@@ -104,7 +104,15 @@ contains
     end function get_global_figure
 
     subroutine figure(num, figsize, dpi)
-        !! Create a matplotlib-style figure using the shared singleton
+        !! Create or reset the shared figure.
+        !!
+        !! Parameters
+        !! num : integer, optional
+        !!     Figure number used for compatibility with matplotlib.
+        !! figsize : real(wp)(2), optional
+        !!     Figure size in inches as [width, height].
+        !! dpi : integer, optional
+        !!     Output resolution in dots per inch.
         integer, intent(in), optional :: num
         real(wp), dimension(2), intent(in), optional :: figsize
         integer, intent(in), optional :: dpi
@@ -163,11 +171,15 @@ contains
     end subroutine figure
 
     subroutine subplot(nrows, ncols, index)
-        !! Select a subplot in an nrows-by-ncols grid (matplotlib-compatible)
+        !! Select a subplot in an `nrows` by `ncols` grid.
         !!
-        !! Behavior:
-        !! - On first call or when grid shape differs, (re)create the grid
-        !! - Set the current subplot selection to `index` (row-major order)
+        !! Parameters
+        !! nrows : integer
+        !!     Number of subplot rows.
+        !! ncols : integer
+        !!     Number of subplot columns.
+        !! index : integer
+        !!     1-based subplot index in row-major order.
         integer, intent(in) :: nrows, ncols, index
         character(len=256) :: msg
         integer :: rows, cols
@@ -200,15 +212,19 @@ contains
     end subroutine subplot
 
     subroutine subplots(nrows, ncols, axes, sharex, sharey)
-        !! Initialize an nrows-by-ncols subplot grid (matplotlib-compatible)
+        !! Initialize a subplot grid.
         !!
-        !! Matplotlib returns (fig, axes). Fortran cannot return tuples, so
-        !! this wrapper fills the optional `axes` output with a 2D array of
-        !! axis indices matching the grid (row-major). Callers that do not
-        !! need the axis matrix may omit it, preserving backward compatibility.
-        !!
-        !! `sharex` and `sharey` are accepted for API parity but are not yet
-        !! wired into the rendering pipeline.
+        !! Parameters
+        !! nrows : integer
+        !!     Number of subplot rows.
+        !! ncols : integer
+        !!     Number of subplot columns.
+        !! axes : integer, allocatable, optional
+        !!     Output 2D array of subplot indices in row-major order.
+        !! sharex : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! sharey : logical, optional
+        !!     Accepted for matplotlib parity.
         integer, intent(in) :: nrows, ncols
         integer, allocatable, intent(out), optional :: axes(:,:)
         logical, intent(in), optional :: sharex, sharey
@@ -246,7 +262,17 @@ contains
     end subroutine ignore_unused_subplots_kwargs
 
     function subplots_grid(nrows, ncols) result(axes)
-        !! Create subplot grid and return axis indices in row-major order
+        !! Create a subplot grid and return axis indices in row-major order.
+        !!
+        !! Parameters
+        !! nrows : integer
+        !!     Number of subplot rows.
+        !! ncols : integer
+        !!     Number of subplot columns.
+        !!
+        !! Returns
+        !! axes : integer, allocatable(:,:)
+        !!     Row-major subplot index matrix.
         integer, intent(in) :: nrows, ncols
         integer, allocatable :: axes(:,:)
         integer :: i, j
@@ -270,13 +296,17 @@ contains
     end function subplots_grid
 
     subroutine savefig(filename, dpi, transparent, bbox_inches)
-        !! Save current figure using matplotlib-compatible API.
+        !! Save the current figure.
         !!
-        !! `dpi` is applied to the figure before rendering so raster outputs
-        !! honour the requested resolution. `transparent` and `bbox_inches`
-        !! are accepted for signature compatibility; they are not yet wired
-        !! to the raster/vector backends but are no-ops rather than warning
-        !! targets so matplotlib-style code remains quiet.
+        !! Parameters
+        !! filename : character(len=*), intent(in)
+        !!     Output path. The extension selects the backend.
+        !! dpi : integer, optional
+        !!     Raster resolution applied before rendering.
+        !! transparent : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! bbox_inches : character(len=*), optional
+        !!     Accepted for matplotlib parity.
         character(len=*), intent(in) :: filename
         integer, intent(in), optional :: dpi
         logical, intent(in), optional :: transparent
@@ -289,8 +319,19 @@ contains
     end subroutine savefig
 
     subroutine savefig_with_status(filename, status, dpi, transparent, bbox_inches)
-        !! Save figure and return status code for testing scenarios.
-        !! Applies `dpi` and silently accepts `transparent`/`bbox_inches`.
+        !! Save the figure and return a status code.
+        !!
+        !! Parameters
+        !! filename : character(len=*), intent(in)
+        !!     Output path. The extension selects the backend.
+        !! status : integer, intent(out)
+        !!     Return status from the save operation.
+        !! dpi : integer, optional
+        !!     Raster resolution applied before rendering.
+        !! transparent : logical, optional
+        !!     Accepted for matplotlib parity.
+        !! bbox_inches : character(len=*), optional
+        !!     Accepted for matplotlib parity.
         character(len=*), intent(in) :: filename
         integer, intent(out) :: status
         integer, intent(in), optional :: dpi

--- a/src/interfaces/fortplot_matplotlib_session.f90
+++ b/src/interfaces/fortplot_matplotlib_session.f90
@@ -71,7 +71,9 @@ contains
         !! 2. Displays the current plot as ASCII art
         !! 3. Waits for the specified number of seconds
         !!
-        !! @param seconds: Time to pause in seconds
+        !! Parameters
+        !! seconds : real(wp), intent(in)
+        !!     Time to pause in seconds.
         real(wp), intent(in) :: seconds
 
         call draw()
@@ -368,7 +370,23 @@ contains
     end subroutine consume_savefig_stubs
 
     subroutine show_data(x, y, label, title_text, xlabel_text, ylabel_text, blocking)
-        !! Convenience routine mirroring matplotlib.pyplot.show signature with data
+        !! Show a line plot and optionally apply labels before displaying it.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! title_text : character(len=*), optional
+        !!     Figure title.
+        !! xlabel_text : character(len=*), optional
+        !!     X-axis label.
+        !! ylabel_text : character(len=*), optional
+        !!     Y-axis label.
+        !! blocking : logical, optional
+        !!     Keep the viewer open when .true.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: label, title_text
         character(len=*), intent(in), optional :: xlabel_text, ylabel_text
@@ -383,7 +401,11 @@ contains
     end subroutine show_data
 
     subroutine show_figure(blocking)
-        !! Show the global figure via backend implementation
+        !! Display the current figure.
+        !!
+        !! Parameters
+        !! blocking : logical, optional
+        !!     Keep the viewer open when .true.
         logical, intent(in), optional :: blocking
 
         call ensure_global_figure_initialized()
@@ -391,7 +413,11 @@ contains
     end subroutine show_figure
 
     subroutine show_viewer(blocking)
-        !! Launch external viewer with saved figure artifact when available
+        !! Launch the system image viewer for the current figure.
+        !!
+        !! Parameters
+        !! blocking : logical, optional
+        !!     Keep the viewer open when .true.
         logical, intent(in), optional :: blocking
 
         call ensure_global_figure_initialized()

--- a/src/interfaces/fortplot_matplotlib_vector_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_vector_wrappers.f90
@@ -27,14 +27,35 @@ module fortplot_matplotlib_vector_wrappers
 
 contains
 
-   subroutine streamplot(x, y, u, v, density, linewidth, color, &
+    subroutine streamplot(x, y, u, v, density, linewidth, color, &
                               cmap, label, arrowsize, arrowstyle, colormap)
-        !! Stateful streamplot wrapper - delegates to OO interface
+        !! Draw streamlines for a vector field.
         !!
-        !! `cmap` matches matplotlib; `colormap` is a deprecated alias.
-        !! `linewidth` controls streamline line width (matplotlib-canonical).
-        !! `color(3)` sets a solid RGB color for all streamlines.
-        !! `arrowsize` and `arrowstyle` control arrow glyphs on streamlines.
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     X coordinates.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Y coordinates.
+        !! u : real(wp), contiguous, intent(in)
+        !!     X components.
+        !! v : real(wp), contiguous, intent(in)
+        !!     Y components.
+        !! density : real(wp), optional
+        !!     Spacing between traces.
+        !! linewidth : real(wp), optional
+        !!     Trace width.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! cmap : character(len=*), optional
+        !!     Colormap name.
+        !! label : character(len=*), optional
+        !!     Legend label.
+        !! arrowsize : real(wp), optional
+        !!     Arrow size.
+        !! arrowstyle : character(len=*), optional
+        !!     Arrow style string.
+        !! colormap : character(len=*), optional
+        !!     Deprecated alias for cmap.
         real(wp), contiguous, intent(in) :: x(:), y(:)
         real(wp), contiguous, intent(in) :: u(:,:), v(:,:)
         real(wp), intent(in), optional :: density, linewidth, color(3)
@@ -62,13 +83,41 @@ contains
 
     subroutine quiver_rgb(x, y, u, v, scale, color, width, headwidth, &
                           headlength, units, angles, pivot, alpha, scale_units, c, colormap)
-        !! Matplotlib-style quiver with RGB color kwarg.
+        !! Draw a quiver plot with an RGB color.
         !!
-        !! `angles`, `pivot`, `alpha`, `scale_units` are accepted for
-        !! matplotlib parity. `c(:)` is the per-arrow scalar array that
-        !! matplotlib maps through a colormap; when present it overrides the
-        !! solid `color` value (same precedence as scatter's `c` versus
-        !! `color`).
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the x-axis.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the y-axis.
+        !! u : real(wp), contiguous, intent(in)
+        !!     X components.
+        !! v : real(wp), contiguous, intent(in)
+        !!     Y components.
+        !! scale : real(wp), optional
+        !!     Arrow scaling factor.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! width : real(wp), optional
+        !!     Shaft width.
+        !! headwidth : real(wp), optional
+        !!     Arrow head width.
+        !! headlength : real(wp), optional
+        !!     Arrow head length.
+        !! units : character(len=*), optional
+        !!     Length unit keyword.
+        !! angles : character(len=*), optional
+        !!     Angle convention keyword.
+        !! pivot : character(len=*), optional
+        !!     Pivot keyword.
+        !! alpha : real(wp), optional
+        !!     Arrow transparency.
+        !! scale_units : character(len=*), optional
+        !!     Scaling unit keyword.
+        !! c : real(wp), optional
+        !!     Per-arrow scalar values.
+        !! colormap : character(len=*), optional
+        !!     Colormap name.
         real(wp), contiguous, intent(in) :: x(:), y(:), u(:), v(:)
         real(wp), intent(in), optional :: scale
         real(wp), intent(in), optional :: color(3)
@@ -89,7 +138,41 @@ contains
     subroutine quiver_string(x, y, u, v, color, scale, width, headwidth, &
                              headlength, units, angles, pivot, alpha, &
                              scale_units, c, colormap)
-        !! String-color variant of quiver.
+        !! Draw a quiver plot with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the x-axis.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the y-axis.
+        !! u : real(wp), contiguous, intent(in)
+        !!     X components.
+        !! v : real(wp), contiguous, intent(in)
+        !!     Y components.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! scale : real(wp), optional
+        !!     Arrow scaling factor.
+        !! width : real(wp), optional
+        !!     Shaft width.
+        !! headwidth : real(wp), optional
+        !!     Arrow head width.
+        !! headlength : real(wp), optional
+        !!     Arrow head length.
+        !! units : character(len=*), optional
+        !!     Length unit keyword.
+        !! angles : character(len=*), optional
+        !!     Angle convention keyword.
+        !! pivot : character(len=*), optional
+        !!     Pivot keyword.
+        !! alpha : real(wp), optional
+        !!     Arrow transparency.
+        !! scale_units : character(len=*), optional
+        !!     Scaling unit keyword.
+        !! c : real(wp), optional
+        !!     Per-arrow scalar values.
+        !! colormap : character(len=*), optional
+        !!     Colormap name.
         real(wp), contiguous, intent(in) :: x(:), y(:), u(:), v(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: scale
@@ -124,6 +207,41 @@ contains
     subroutine add_quiver_rgb(x, y, u, v, scale, color, width, headwidth, &
                               headlength, units, angles, pivot, alpha, &
                               scale_units, c, colormap)
+        !! Object-oriented alias for quiver with RGB color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the x-axis.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the y-axis.
+        !! u : real(wp), contiguous, intent(in)
+        !!     X components.
+        !! v : real(wp), contiguous, intent(in)
+        !!     Y components.
+        !! scale : real(wp), optional
+        !!     Arrow scaling factor.
+        !! color : real(wp)(3), optional
+        !!     Solid RGB color.
+        !! width : real(wp), optional
+        !!     Shaft width.
+        !! headwidth : real(wp), optional
+        !!     Arrow head width.
+        !! headlength : real(wp), optional
+        !!     Arrow head length.
+        !! units : character(len=*), optional
+        !!     Length unit keyword.
+        !! angles : character(len=*), optional
+        !!     Angle convention keyword.
+        !! pivot : character(len=*), optional
+        !!     Pivot keyword.
+        !! alpha : real(wp), optional
+        !!     Arrow transparency.
+        !! scale_units : character(len=*), optional
+        !!     Scaling unit keyword.
+        !! c : real(wp), optional
+        !!     Per-arrow scalar values.
+        !! colormap : character(len=*), optional
+        !!     Colormap name.
         real(wp), contiguous, intent(in) :: x(:), y(:), u(:), v(:)
         real(wp), intent(in), optional :: scale
         real(wp), intent(in), optional :: color(3)
@@ -143,6 +261,41 @@ contains
     subroutine add_quiver_string(x, y, u, v, color, scale, width, headwidth, &
                                  headlength, units, angles, pivot, alpha, &
                                  scale_units, c, colormap)
+        !! Object-oriented alias for quiver with a named color.
+        !!
+        !! Parameters
+        !! x : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the x-axis.
+        !! y : real(wp), contiguous, intent(in)
+        !!     Arrow origins on the y-axis.
+        !! u : real(wp), contiguous, intent(in)
+        !!     X components.
+        !! v : real(wp), contiguous, intent(in)
+        !!     Y components.
+        !! color : character(len=*), intent(in)
+        !!     Named or hex color string.
+        !! scale : real(wp), optional
+        !!     Arrow scaling factor.
+        !! width : real(wp), optional
+        !!     Shaft width.
+        !! headwidth : real(wp), optional
+        !!     Arrow head width.
+        !! headlength : real(wp), optional
+        !!     Arrow head length.
+        !! units : character(len=*), optional
+        !!     Length unit keyword.
+        !! angles : character(len=*), optional
+        !!     Angle convention keyword.
+        !! pivot : character(len=*), optional
+        !!     Pivot keyword.
+        !! alpha : real(wp), optional
+        !!     Arrow transparency.
+        !! scale_units : character(len=*), optional
+        !!     Scaling unit keyword.
+        !! c : real(wp), optional
+        !!     Per-arrow scalar values.
+        !! colormap : character(len=*), optional
+        !!     Colormap name.
         real(wp), contiguous, intent(in) :: x(:), y(:), u(:), v(:)
         character(len=*), intent(in) :: color
         real(wp), intent(in), optional :: scale

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -98,12 +98,13 @@ contains
         character(len=*), intent(in) :: lines(:)
         integer, intent(in) :: count, signature_line
         character(len=*), intent(in) :: pattern
-        integer :: first_line, i
+        integer :: first_line, last_line, i
 
-        first_line = max(1, signature_line - 24)
+        first_line = signature_line + 1
+        last_line = min(count, signature_line + 32)
         block_has_pattern = .false.
-        do i = first_line, signature_line - 1
-            if (index(lines(i), pattern) > 0) then
+        do i = first_line, last_line
+            if (index(lines(i), trim(pattern)) > 0) then
                 block_has_pattern = .true.
                 return
             end if

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -37,6 +37,15 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize, alpha)', &
                           [character(len=24) :: 'Parameters', 'x', 'markersize', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine imshow(z, cmap, alpha, vmin, vmax, origin, extent, interpolation, aspect)', &
+                          [character(len=24) :: 'Parameters', 'z', 'cmap', 'aspect'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine fill_between_string(x, y1, y2, where, color, alpha, interpolate, step)', &
+                          [character(len=24) :: 'Parameters', 'y1', 'color', 'step'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine twinx()', &
+                          [character(len=24) :: 'Parameters', 'None.'])
 
     print *, 'All python-like API doc tests passed.'
 

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -1,0 +1,113 @@
+program test_python_like_api_docs
+    implicit none
+
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine figure(num, figsize, dpi)', &
+                          [character(len=24) :: 'Parameters', 'num', 'figsize', 'dpi'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine subplot(nrows, ncols, index)', &
+                          [character(len=24) :: 'Parameters', 'nrows', 'ncols', 'index'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine subplots(nrows, ncols, axes, sharex, sharey)', &
+                          [character(len=24) :: 'Parameters', 'axes', 'sharex', 'sharey'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine savefig(filename, dpi, transparent, bbox_inches)', &
+                          [character(len=24) :: 'Parameters', 'filename', 'bbox_inches'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine xlabel(label_text)', &
+                          [character(len=24) :: 'Parameters', 'label_text'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine ylabel(label_text)', &
+                          [character(len=24) :: 'Parameters', 'label_text'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine title(title_text)', &
+                          [character(len=24) :: 'Parameters', 'title_text'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine legend(loc, box, fontsize, position)', &
+                          [character(len=24) :: 'Parameters', 'loc', 'position'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine grid(visible, which, axis, alpha, linestyle, enabled)', &
+                          [character(len=24) :: 'Parameters', 'visible', 'enabled'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_xscale(scale, linthresh, threshold, base, linscale)', &
+                          [character(len=24) :: 'Parameters', 'scale', 'linthresh', 'threshold'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_yscale(scale, linthresh, threshold, base, linscale)', &
+                          [character(len=24) :: 'Parameters', 'scale', 'linthresh', 'threshold'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize, alpha)', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize', 'alpha'])
+
+    print *, 'All python-like API doc tests passed.'
+
+contains
+
+    subroutine assert_doc_block(path, signature, patterns)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: signature
+        character(len=*), dimension(:), intent(in) :: patterns
+
+        integer, parameter :: max_lines = 4096
+        character(len=1024) :: lines(max_lines)
+        character(len=1024) :: line
+        integer :: unit, ios, count, i, j
+        logical :: found_signature, found_pattern
+
+        count = 0
+        open(newunit=unit, file=path, status='old', action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, 'Cannot open ', trim(path)
+            stop 1
+        end if
+
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            count = count + 1
+            if (count > max_lines) then
+                print *, 'Too many lines in ', trim(path)
+                close(unit)
+                stop 1
+            end if
+            lines(count) = line
+        end do
+        close(unit)
+
+        found_signature = .false.
+        do i = 1, count
+            if (index(lines(i), signature) > 0) then
+                found_signature = .true.
+                do j = 1, size(patterns)
+                    found_pattern = block_has_pattern(lines, count, i, patterns(j))
+                    if (.not. found_pattern) then
+                        print *, 'Missing doc text in ', trim(path), ': ', trim(patterns(j))
+                        stop 1
+                    end if
+                end do
+                exit
+            end if
+        end do
+
+        if (.not. found_signature) then
+            print *, 'Missing signature in ', trim(path), ': ', trim(signature)
+            stop 1
+        end if
+    end subroutine assert_doc_block
+
+    logical function block_has_pattern(lines, count, signature_line, pattern)
+        character(len=*), intent(in) :: lines(:)
+        integer, intent(in) :: count, signature_line
+        character(len=*), intent(in) :: pattern
+        integer :: first_line, i
+
+        first_line = max(1, signature_line - 24)
+        block_has_pattern = .false.
+        do i = first_line, signature_line - 1
+            if (index(lines(i), pattern) > 0) then
+                block_has_pattern = .true.
+                return
+            end if
+        end do
+    end function block_has_pattern
+
+end program test_python_like_api_docs

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -61,6 +61,27 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine add_3d_plot_string(x, y, z, label, linestyle, color, linewidth, marker, &', &
                           [character(len=24) :: 'Parameters', 'x', 'markersize', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_colorbar.f90', &
+                          'subroutine colorbar(label, location, fraction, pad, shrink, plot_index, &', &
+                          [character(len=24) :: 'Parameters', 'label', 'plot_index', 'ticks'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_mesh_wrappers.f90', &
+                          'subroutine pcolormesh(x, y, z, shading, cmap, show_colorbar, label, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine contour_filled(x, y, z, levels, cmap, show_colorbar, label, &', &
+                          [character(len=24) :: 'Parameters', 'z', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
+                          'subroutine streamplot(x, y, u, v, density, linewidth, color, &', &
+                          [character(len=24) :: 'Parameters', 'u', 'arrowsize', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine errorbar_string_icap(x, y, color, capsize, xerr, yerr, fmt, label, &', &
+                          [character(len=24) :: 'Parameters', 'color', 'capsize', 'xerr'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine scatter_string(x, y, c, label, marker, markersize, color, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize', 'linewidths_scalar'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_hist_wrappers.f90', &
+                          'subroutine histogram_string(data, color, bins, range, density, weights, &', &
+                          [character(len=24) :: 'Parameters', 'data', 'orientation', 'alpha'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
                           'subroutine imshow(z, cmap, alpha, vmin, vmax, origin, extent, interpolation, aspect)', &
                           [character(len=24) :: 'Parameters', 'z', 'cmap', 'aspect'])

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -13,6 +13,15 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
                           'subroutine savefig(filename, dpi, transparent, bbox_inches)', &
                           [character(len=24) :: 'Parameters', 'filename', 'bbox_inches'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine show_data(x, y, label, title_text, xlabel_text, ylabel_text, blocking)', &
+                          [character(len=24) :: 'Parameters', 'x', 'blocking'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine show_figure(blocking)', &
+                          [character(len=24) :: 'Parameters', 'blocking'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine show_viewer(blocking)', &
+                          [character(len=24) :: 'Parameters', 'blocking'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
                           'subroutine xlabel(label_text)', &
                           [character(len=24) :: 'Parameters', 'label_text'])
@@ -34,9 +43,24 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
                           'subroutine set_yscale(scale, linthresh, threshold, base, linscale)', &
                           [character(len=24) :: 'Parameters', 'scale', 'linthresh', 'threshold'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine xlim(xmin, xmax)', &
+                          [character(len=24) :: 'Parameters', 'xmin', 'xmax'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'function get_active_axis() result(axis_name)', &
+                          [character(len=24) :: 'Returns', 'axis_name'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine plot(x, y, label, linestyle, color, linewidth, marker, markersize, alpha)', &
                           [character(len=24) :: 'Parameters', 'x', 'markersize', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine bar_rgb(x, height, width, bottom, label, color, edgecolor, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'x', 'edgecolor', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine boxplot_string(data, position, width, label, show_outliers, horizontal, color)', &
+                          [character(len=24) :: 'Parameters', 'data', 'horizontal', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine add_3d_plot_string(x, y, z, label, linestyle, color, linewidth, marker, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize', 'color'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
                           'subroutine imshow(z, cmap, alpha, vmin, vmax, origin, extent, interpolation, aspect)', &
                           [character(len=24) :: 'Parameters', 'z', 'cmap', 'aspect'])

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -22,6 +22,30 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
                           'subroutine show_viewer(blocking)', &
                           [character(len=24) :: 'Parameters', 'blocking'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine ion()', &
+                          [character(len=24) :: 'interactive mode'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine ioff()', &
+                          [character(len=24) :: 'Disable interactive mode'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine draw()', &
+                          [character(len=24) :: 'ASCII output'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine ensure_fig_init()', &
+                          [character(len=24) :: 'global figure exists'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine ensure_global_figure_initialized()', &
+                          [character(len=24) :: 'singleton is ready'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'function get_global_figure() result(global_fig)', &
+                          [character(len=24) :: 'global figure pointer'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'function subplots_grid(nrows, ncols) result(axes)', &
+                          [character(len=24) :: 'Returns', 'axes'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_session.f90', &
+                          'subroutine savefig_with_status(filename, status, dpi, transparent, bbox_inches)', &
+                          [character(len=24) :: 'Parameters', 'status', 'bbox_inches'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
                           'subroutine xlabel(label_text)', &
                           [character(len=24) :: 'Parameters', 'label_text'])
@@ -47,6 +71,54 @@ program test_python_like_api_docs
                           'subroutine xlim(xmin, xmax)', &
                           [character(len=24) :: 'Parameters', 'xmin', 'xmax'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine suptitle(title_text, fontsize)', &
+                          [character(len=24) :: 'Parameters', 'title_text', 'fontsize'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine ylim(ymin, ymax)', &
+                          [character(len=24) :: 'Parameters', 'ymin', 'ymax'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine view_init(elev, azim, dist)', &
+                          [character(len=24) :: 'Parameters', 'elev', 'azim'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine xscale(scale, linthresh, threshold, base, linscale)', &
+                          [character(len=24) :: 'Parameters', 'scale', 'threshold'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine yscale(scale, linthresh, threshold, base, linscale)', &
+                          [character(len=24) :: 'Parameters', 'scale', 'threshold'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_line_width(width)', &
+                          [character(len=24) :: 'Parameters', 'width'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_ydata(ydata)', &
+                          [character(len=24) :: 'Parameters', 'ydata'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine use_axis(axis_name)', &
+                          [character(len=24) :: 'Parameters', 'axis_name'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine minorticks_on()', &
+                          [character(len=24) :: 'minor ticks'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine tight_layout(pad, w_pad, h_pad)', &
+                          [character(len=24) :: 'Parameters', 'pad', 'w_pad'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine axhline(y, xmin, xmax, color, linestyle, linewidth, label)', &
+                          [character(len=24) :: 'Parameters', 'y', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine axvline(x, ymin, ymax, color, linestyle, linewidth, label)', &
+                          [character(len=24) :: 'Parameters', 'x', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine hlines(y, xmin, xmax, colors, linestyles, linewidth, label)', &
+                          [character(len=24) :: 'Parameters', 'y', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine vlines(x, ymin, ymax, colors, linestyles, linewidth, label)', &
+                          [character(len=24) :: 'Parameters', 'x', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_xticks(positions, labels)', &
+                          [character(len=24) :: 'Parameters', 'positions', 'labels'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
+                          'subroutine set_yticks(positions, labels)', &
+                          [character(len=24) :: 'Parameters', 'positions', 'labels'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_axes.f90', &
                           'function get_active_axis() result(axis_name)', &
                           [character(len=24) :: 'Returns', 'axis_name'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
@@ -56,8 +128,41 @@ program test_python_like_api_docs
                           'subroutine bar_rgb(x, height, width, bottom, label, color, edgecolor, align, alpha)', &
                           [character(len=24) :: 'Parameters', 'x', 'edgecolor', 'alpha'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine bar_string(x, height, color, width, bottom, label, edgecolor, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'height', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine barh_rgb(y, width, height, left, label, color, edgecolor, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'y', 'left'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine barh_string(y, width, color, height, left, label, edgecolor, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'y', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine bar_rgb_edgecolor(x, height, color, edgecolor, width, bottom, label, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'edgecolor', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine barh_rgb_edgecolor(y, width, color, edgecolor, height, left, label, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'edgecolor', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine bar_rgb_array(x, height, color_per_bar, edgecolor_per_bar, width, bottom, label, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'color_per_bar', 'edgecolor_per_bar'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine barh_rgb_array(y, width, color_per_bar, edgecolor_per_bar, height, left, label, align, alpha)', &
+                          [character(len=24) :: 'Parameters', 'color_per_bar', 'edgecolor_per_bar'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine boxplot_string(data, position, width, label, show_outliers, horizontal, color)', &
                           [character(len=24) :: 'Parameters', 'data', 'horizontal', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine boxplot_rgb(data, position, width, label, show_outliers, horizontal, color)', &
+                          [character(len=24) :: 'Parameters', 'data', 'horizontal', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine add_plot_rgb(x, y, color, label, linestyle, alpha)', &
+                          [character(len=24) :: 'Parameters', 'x', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine add_plot_string(x, y, color, label, linestyle, alpha)', &
+                          [character(len=24) :: 'Parameters', 'x', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
+                          'subroutine add_3d_plot_rgb(x, y, z, label, linestyle, color, linewidth, marker, &', &
+                          [character(len=24) :: 'Parameters', 'z', 'markersize'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine add_3d_plot_string(x, y, z, label, linestyle, color, linewidth, marker, &', &
                           [character(len=24) :: 'Parameters', 'x', 'markersize', 'color'])
@@ -67,18 +172,96 @@ program test_python_like_api_docs
     call assert_doc_block('src/interfaces/fortplot_matplotlib_mesh_wrappers.f90', &
                           'subroutine pcolormesh(x, y, z, shading, cmap, show_colorbar, label, &', &
                           [character(len=24) :: 'Parameters', 'x', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_mesh_wrappers.f90', &
+                          'subroutine add_pcolormesh(x, y, z, shading, cmap, show_colorbar, label, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_mesh_wrappers.f90', &
+                          'subroutine add_surface(x, y, z, cmap, show_colorbar, alpha, edgecolor, &', &
+                          [character(len=24) :: 'Parameters', 'z', 'edgecolor', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine contour(x, y, z, levels, cmap, label, colormap)', &
+                          [character(len=24) :: 'Parameters', 'label', 'colormap'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
                           'subroutine contour_filled(x, y, z, levels, cmap, show_colorbar, label, &', &
                           [character(len=24) :: 'Parameters', 'z', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine contourf(x, y, z, levels, cmap, show_colorbar, label, colormap)', &
+                          [character(len=24) :: 'Parameters', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine add_contour(x, y, z, levels, cmap, label, colormap)', &
+                          [character(len=24) :: 'Parameters', 'label', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine add_contour_filled(x, y, z, levels, cmap, show_colorbar, label, &', &
+                          [character(len=24) :: 'Parameters', 'show_colorbar', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_field_wrappers.f90', &
+                          'subroutine add_contourf(x, y, z, levels, cmap, show_colorbar, label, colormap)', &
+                          [character(len=24) :: 'Parameters', 'show_colorbar', 'colormap'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
                           'subroutine streamplot(x, y, u, v, density, linewidth, color, &', &
                           [character(len=24) :: 'Parameters', 'u', 'arrowsize', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
+                          'subroutine quiver_rgb(x, y, u, v, scale, color, width, headwidth, &', &
+                          [character(len=24) :: 'Parameters', 'scale', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
+                          'subroutine quiver_string(x, y, u, v, color, scale, width, headwidth, &', &
+                          [character(len=24) :: 'Parameters', 'color', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
+                          'subroutine add_quiver_rgb(x, y, u, v, scale, color, width, headwidth, &', &
+                          [character(len=24) :: 'Parameters', 'scale', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_vector_wrappers.f90', &
+                          'subroutine add_quiver_string(x, y, u, v, color, scale, width, headwidth, &', &
+                          [character(len=24) :: 'Parameters', 'color', 'colormap'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine errorbar_rgb(x, y, xerr, yerr, fmt, label, capsize, linestyle, &', &
+                          [character(len=24) :: 'Parameters', 'xerr', 'yerr'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine errorbar_string(x, y, color, xerr, yerr, fmt, label, capsize, &', &
+                          [character(len=24) :: 'Parameters', 'color', 'xerr'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine errorbar_rgb_icap(x, y, capsize, xerr, yerr, fmt, label, linestyle, &', &
+                          [character(len=24) :: 'Parameters', 'capsize', 'xerr'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
                           'subroutine errorbar_string_icap(x, y, color, capsize, xerr, yerr, fmt, label, &', &
                           [character(len=24) :: 'Parameters', 'color', 'capsize', 'xerr'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine add_errorbar_rgb(x, y, xerr, yerr, fmt, label, capsize, &', &
+                          [character(len=24) :: 'Object-oriented alias', 'errorbar_rgb'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine add_errorbar_string(x, y, color, xerr, yerr, fmt, label, capsize, &', &
+                          [character(len=24) :: 'Object-oriented alias', 'errorbar_string'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine add_errorbar_rgb_icap(x, y, capsize, xerr, yerr, fmt, label, &', &
+                          [character(len=24) :: 'Integer-capsize overload', 'add_errorbar_rgb'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_errorbar.f90', &
+                          'subroutine add_errorbar_string_icap(x, y, color, capsize, xerr, yerr, fmt, &', &
+                          [character(len=24) :: 'Integer-capsize overload', 'add_errorbar_string'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine scatter_rgb(x, y, s, c, label, marker, markersize, color, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
                           'subroutine scatter_string(x, y, c, label, marker, markersize, color, &', &
                           [character(len=24) :: 'Parameters', 'x', 'markersize', 'linewidths_scalar'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine add_scatter_2d_rgb(x, y, markersize, s, c, label, marker, color, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine add_scatter_2d_string(x, y, color, c, label, marker, markersize, &', &
+                          [character(len=24) :: 'Parameters', 'x', 'markersize'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine add_scatter_3d_rgb(x, y, z, s, c, label, marker, markersize, &', &
+                          [character(len=24) :: 'Parameters', 'z', 'markersize'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_scatter.f90', &
+                          'subroutine add_scatter_3d_string(x, y, z, color, s, c, label, marker, &', &
+                          [character(len=24) :: 'Parameters', 'z', 'markersize'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_hist_wrappers.f90', &
+                          'subroutine hist_rgb(data, bins, range, density, weights, cumulative, &', &
+                          [character(len=24) :: 'Parameters', 'data', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_hist_wrappers.f90', &
+                          'subroutine hist_string(data, color, bins, range, density, weights, &', &
+                          [character(len=24) :: 'Parameters', 'data', 'color'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_hist_wrappers.f90', &
+                          'subroutine histogram_rgb(data, bins, range, density, weights, cumulative, &', &
+                          [character(len=24) :: 'Parameters', 'data', 'alpha'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_hist_wrappers.f90', &
                           'subroutine histogram_string(data, color, bins, range, density, weights, &', &
                           [character(len=24) :: 'Parameters', 'data', 'orientation', 'alpha'])
@@ -86,10 +269,43 @@ program test_python_like_api_docs
                           'subroutine imshow(z, cmap, alpha, vmin, vmax, origin, extent, interpolation, aspect)', &
                           [character(len=24) :: 'Parameters', 'z', 'cmap', 'aspect'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine pie(values, labels, colors, explode, autopct, startangle)', &
+                          [character(len=24) :: 'Parameters', 'values', 'labels'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine polar_string(theta, r, fmt, label, linestyle, marker, color)', &
+                          [character(len=24) :: 'Parameters', 'theta', 'r'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine polar_rgb(theta, r, color, fmt, label, linestyle, marker)', &
+                          [character(len=24) :: 'Parameters', 'theta', 'r'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine step_string(x, y, where, label, linestyle, color, linewidth)', &
+                          [character(len=24) :: 'Parameters', 'where', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine step_rgb(x, y, color, where, label, linestyle, linewidth)', &
+                          [character(len=24) :: 'Parameters', 'where', 'linewidth'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine stem(x, y, linefmt, markerfmt, basefmt, label, bottom)', &
+                          [character(len=24) :: 'Parameters', 'linefmt', 'bottom'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine fill_string(x, y, color, alpha, step)', &
+                          [character(len=24) :: 'Parameters', 'y', 'step'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine fill_rgb(x, y, color, alpha, step)', &
+                          [character(len=24) :: 'Parameters', 'y', 'step'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine fill_default(x, y, alpha, step)', &
+                          [character(len=24) :: 'Parameters', 'alpha'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
                           'subroutine fill_between_string(x, y1, y2, where, color, alpha, interpolate, step)', &
                           [character(len=24) :: 'Parameters', 'y1', 'color', 'step'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine fill_between_rgb(x, y1, y2, where, color, alpha, interpolate, step)', &
+                          [character(len=24) :: 'Parameters', 'y1', 'step'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
                           'subroutine twinx()', &
+                          [character(len=24) :: 'Parameters', 'None.'])
+    call assert_doc_block('src/interfaces/fortplot_matplotlib_plots.f90', &
+                          'subroutine twiny()', &
                           [character(len=24) :: 'Parameters', 'None.'])
 
     print *, 'All python-like API doc tests passed.'
@@ -131,6 +347,10 @@ contains
         do i = 1, count
             if (index(lines(i), signature) > 0) then
                 found_signature = .true.
+                if (.not. signature_has_doc_block(lines, i)) then
+                    print *, 'Missing doc block in ', trim(path), ': ', trim(signature)
+                    stop 1
+                end if
                 do j = 1, size(patterns)
                     found_pattern = block_has_pattern(lines, count, i, patterns(j))
                     if (.not. found_pattern) then
@@ -147,6 +367,20 @@ contains
             stop 1
         end if
     end subroutine assert_doc_block
+
+    logical function signature_has_doc_block(lines, signature_line)
+        character(len=*), intent(in) :: lines(:)
+        integer, intent(in) :: signature_line
+        integer :: i
+
+        signature_has_doc_block = .false.
+        do i = signature_line + 1, min(size(lines), signature_line + 8)
+            if (index(lines(i), '!!') > 0) then
+                signature_has_doc_block = .true.
+                return
+            end if
+        end do
+    end function signature_has_doc_block
 
     logical function block_has_pattern(lines, count, signature_line, pattern)
         character(len=*), intent(in) :: lines(:)

--- a/test/doc/test_python_like_api_docs.f90
+++ b/test/doc/test_python_like_api_docs.f90
@@ -143,10 +143,12 @@ program test_python_like_api_docs
                           'subroutine barh_rgb_edgecolor(y, width, color, edgecolor, height, left, label, align, alpha)', &
                           [character(len=24) :: 'Parameters', 'edgecolor', 'alpha'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
-                          'subroutine bar_rgb_array(x, height, color_per_bar, edgecolor_per_bar, width, bottom, label, align, alpha)', &
+                          'subroutine bar_rgb_array(x, height, color_per_bar, ' // &
+                          'edgecolor_per_bar, width, bottom, label, align, alpha)', &
                           [character(len=24) :: 'Parameters', 'color_per_bar', 'edgecolor_per_bar'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
-                          'subroutine barh_rgb_array(y, width, color_per_bar, edgecolor_per_bar, height, left, label, align, alpha)', &
+                          'subroutine barh_rgb_array(y, width, color_per_bar, ' // &
+                          'edgecolor_per_bar, height, left, label, align, alpha)', &
                           [character(len=24) :: 'Parameters', 'color_per_bar', 'edgecolor_per_bar'])
     call assert_doc_block('src/interfaces/fortplot_matplotlib_plot_wrappers.f90', &
                           'subroutine boxplot_string(data, position, width, label, show_outliers, horizontal, color)', &


### PR DESCRIPTION
(ref #2032)

## Requirements
- REQ-001: satisfied - added python-like `Parameters` blocks to the remaining public wrapper entry points in `colorbar`, `errorbar`, `field`, `hist`, `mesh`, `scatter`, and `vector`.
- REQ-002: satisfied - alias and deprecated kwargs are documented in the same python-like style where applicable.
- REQ-003: satisfied - `test/doc/test_python_like_api_docs.f90` now checks representative doc blocks from the newly documented modules.

## File Set
Edited:
- `src/interfaces/fortplot_matplotlib_colorbar.f90`
- `src/interfaces/fortplot_matplotlib_errorbar.f90`
- `src/interfaces/fortplot_matplotlib_field_wrappers.f90`
- `src/interfaces/fortplot_matplotlib_hist_wrappers.f90`
- `src/interfaces/fortplot_matplotlib_mesh_wrappers.f90`
- `src/interfaces/fortplot_matplotlib_scatter.f90`
- `src/interfaces/fortplot_matplotlib_vector_wrappers.f90`
- `test/doc/test_python_like_api_docs.f90`

Intentionally left alone:
- `src/interfaces/fortplot_matplotlib_advanced.f90` - re-export facade, no function bodies to document.
- `src/interfaces/fortplot_matplotlib.f90` - re-export facade, no function bodies to document.
- `src/interfaces/fortplot_matplotlib_scatter_dispatch.f90` - internal dispatch helper, outside the user-facing doc sweep.
- `src/interfaces/fortplot_matplotlib_scatter_utils.f90` - internal helper module, outside the user-facing doc sweep.

## Verification
- `fpm test --target test_python_like_api_docs`
  - `Project compiled successfully.`
  - `All python-like API doc tests passed.`
- `make test-ci`
  - `PASS: public API test - PNG written (       28062  bytes)`
  - `Artifact verification passed.`
  - `CI essential test suite completed successfully`
- `$HOME/code/prompts/scripts/check-writing-slop.py --threshold soft src/interfaces/fortplot_matplotlib_colorbar.f90 src/interfaces/fortplot_matplotlib_errorbar.f90 src/interfaces/fortplot_matplotlib_field_wrappers.f90 src/interfaces/fortplot_matplotlib_hist_wrappers.f90 src/interfaces/fortplot_matplotlib_mesh_wrappers.f90 src/interfaces/fortplot_matplotlib_scatter.f90 src/interfaces/fortplot_matplotlib_vector_wrappers.f90 test/doc/test_python_like_api_docs.f90`
  - `PASS: no writing-slop candidates at threshold soft`

<!-- orchestrate: fully-resolved -->
