### PR TITLE
fix: subplot support for non-line plots (refs #2033)

### DIFF
--- a/src/figures/core/fortplot_figure_core_impl_layout.f90
+++ b/src/figures/core/fortplot_figure_core_impl_layout.f90
@@ -6,6 +6,8 @@ submodule(fortplot_figure_core) fortplot_figure_core_impl_layout
     !! tick configuration, aspect ratio, and tight layout operations.
     !! Extracted from fortplot_figure_core_impl to maintain file size compliance.
 
+    use fortplot_logging, only: log_error
+    use fortplot_plot_bars, only: bar_impl, barh_impl
     use fortplot_string_utils, only: to_lowercase
     implicit none
 
@@ -128,6 +130,118 @@ contains
                                   linestyle, color, alpha, self%state%colors, 6)
     end subroutine subplot_plot
 
+    module subroutine subplot_bar(self, row, col, x, heights, width, bottom, label, &
+                                  color, edgecolor, align, alpha)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        real(wp), contiguous, intent(in) :: x(:), heights(:)
+        real(wp), intent(in), optional :: width
+        real(wp), intent(in), optional :: bottom(:)
+        character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
+        integer :: previous_subplot
+        logical :: ok
+
+        call begin_subplot_call(self, row, col, 'subplot_bar', previous_subplot, ok)
+        if (.not. ok) return
+        call bar_impl(self, x, heights, width=width, bottom=bottom, label=label, &
+                      color=color, edgecolor=edgecolor, alpha=alpha)
+        self%current_subplot = previous_subplot
+        if (present(align)) continue
+    end subroutine subplot_bar
+
+    module subroutine subplot_barh(self, row, col, y, widths, height, left, label, &
+                                   color, edgecolor, align, alpha)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        real(wp), contiguous, intent(in) :: y(:), widths(:)
+        real(wp), intent(in), optional :: height
+        real(wp), intent(in), optional :: left(:)
+        character(len=*), intent(in), optional :: label, align
+        real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
+        integer :: previous_subplot
+        logical :: ok
+
+        call begin_subplot_call(self, row, col, 'subplot_barh', previous_subplot, ok)
+        if (.not. ok) return
+        call barh_impl(self, y, widths, height=height, left=left, label=label, &
+                       color=color, edgecolor=edgecolor, alpha=alpha)
+        self%current_subplot = previous_subplot
+        if (present(align)) continue
+    end subroutine subplot_barh
+
+    module subroutine subplot_hist(self, row, col, data, bins, density, label, color, &
+                                  range, weights, cumulative, orientation, alpha)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        real(wp), contiguous, intent(in) :: data(:)
+        integer, intent(in), optional :: bins
+        logical, intent(in), optional :: density
+        character(len=*), intent(in), optional :: label
+        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: range(2)
+        real(wp), intent(in), optional :: weights(:)
+        logical, intent(in), optional :: cumulative
+        character(len=*), intent(in), optional :: orientation
+        real(wp), intent(in), optional :: alpha
+        integer :: previous_subplot
+        logical :: ok
+
+        call begin_subplot_call(self, row, col, 'subplot_hist', previous_subplot, ok)
+        if (.not. ok) return
+        call self%add_hist(data, bins=bins, density=density, label=label, &
+                           color=color, range=range, weights=weights, &
+                           cumulative=cumulative, orientation=orientation, &
+                           alpha=alpha)
+        self%current_subplot = previous_subplot
+    end subroutine subplot_hist
+
+    module subroutine subplot_boxplot(self, row, col, data, position, width, label, &
+                                      show_outliers, horizontal, color)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        real(wp), contiguous, intent(in) :: data(:)
+        real(wp), intent(in), optional :: position
+        real(wp), intent(in), optional :: width
+        character(len=*), intent(in), optional :: label
+        logical, intent(in), optional :: show_outliers
+        logical, intent(in), optional :: horizontal
+        real(wp), intent(in), optional :: color(3)
+        integer :: previous_subplot
+        logical :: ok
+
+        call begin_subplot_call(self, row, col, 'subplot_boxplot', previous_subplot, ok)
+        if (.not. ok) return
+        call self%boxplot(data, position=position, width=width, label=label, &
+                          show_outliers=show_outliers, horizontal=horizontal, &
+                          color=color)
+        self%current_subplot = previous_subplot
+    end subroutine subplot_boxplot
+
+    module subroutine subplot_scatter(self, row, col, x, y, s, c, marker, markersize, &
+                                      color, colormap, alpha, edgecolor, facecolor, &
+                                      linewidth, vmin, vmax, label, show_colorbar)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        real(wp), contiguous, intent(in) :: x(:), y(:)
+        real(wp), intent(in), optional :: s(..), c(:)
+        character(len=*), intent(in), optional :: marker, colormap, label
+        real(wp), intent(in), optional :: markersize, alpha, linewidth, vmin, vmax
+        real(wp), intent(in), optional :: color(3), edgecolor(3), facecolor(3)
+        logical, intent(in), optional :: show_colorbar
+        integer :: previous_subplot
+        logical :: ok
+
+        call begin_subplot_call(self, row, col, 'subplot_scatter', previous_subplot, ok)
+        if (.not. ok) return
+        call self%scatter(x, y, s=s, c=c, marker=marker, markersize=markersize, &
+                          color=color, colormap=colormap, alpha=alpha, &
+                          edgecolor=edgecolor, facecolor=facecolor, &
+                          linewidth=linewidth, vmin=vmin, vmax=vmax, label=label, &
+                          show_colorbar=show_colorbar)
+        self%current_subplot = previous_subplot
+    end subroutine subplot_scatter
+
     module subroutine relocate_last_plot_to_subplot(self)
         !! Copy the most recently added figure-level plot into the currently
         !! selected subplot. Plot commands other than plot() (hist, bar,
@@ -213,6 +327,31 @@ contains
         title = figure_subplot_title(self%subplots_array, self%subplot_rows, &
                                       self%subplot_cols, row, col)
     end function subplot_title
+
+    subroutine begin_subplot_call(self, row, col, context, previous_subplot, ok)
+        class(figure_t), intent(inout) :: self
+        integer, intent(in) :: row, col
+        character(len=*), intent(in) :: context
+        integer, intent(out) :: previous_subplot
+        logical, intent(out) :: ok
+
+        previous_subplot = self%current_subplot
+        ok = .false.
+
+        if (self%subplot_rows <= 0 .or. self%subplot_cols <= 0) then
+            call log_error(trim(context)//": subplot grid is not active")
+            return
+        end if
+
+        if (row <= 0 .or. row > self%subplot_rows .or. &
+            col <= 0 .or. col > self%subplot_cols) then
+            call log_error(trim(context)//": Invalid subplot indices")
+            return
+        end if
+
+        self%current_subplot = (row - 1)*self%subplot_cols + col
+        ok = .true.
+    end subroutine begin_subplot_call
 
     !! ── Reference line operations ─────────────────────────────────────
 

--- a/src/figures/core/fortplot_figure_core_impl_plots.f90
+++ b/src/figures/core/fortplot_figure_core_impl_plots.f90
@@ -222,6 +222,7 @@ contains
                            cumulative=cumulative, orientation=orientation, &
                            alpha=alpha)
         end if
+        call self%relocate_last_plot_to_subplot()
     end subroutine add_hist
 
     module subroutine boxplot(self, data, position, width, label, show_outliers, &
@@ -239,6 +240,7 @@ contains
                            position, width, &
                            label, show_outliers, horizontal, color, &
                            self%state%max_plots)
+        call self%relocate_last_plot_to_subplot()
     end subroutine boxplot
 
     module subroutine scatter(self, x, y, s, c, marker, markersize, color, &
@@ -265,6 +267,7 @@ contains
                            marker, markersize, color, colormap, alpha, edgecolor, &
                            facecolor, linewidth, vmin, vmax, label, show_colorbar, &
                            default_color)
+        call self%relocate_last_plot_to_subplot()
     end subroutine scatter
 
 end submodule fortplot_figure_core_impl_plots

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -143,6 +143,11 @@ module fortplot_figure_core
         procedure :: subplots
         procedure :: suptitle
         procedure :: subplot_plot
+        procedure :: subplot_bar
+        procedure :: subplot_barh
+        procedure :: subplot_hist
+        procedure :: subplot_boxplot
+        procedure :: subplot_scatter
         procedure :: relocate_last_plot_to_subplot
         procedure :: subplot_plot_count
         procedure :: subplot_set_title
@@ -755,6 +760,73 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
             real(wp), intent(in), optional :: color(3)
             real(wp), intent(in), optional :: alpha
         end subroutine subplot_plot
+
+        module subroutine subplot_bar(self, row, col, x, heights, width, bottom, &
+                                      label, color, edgecolor, align, alpha)
+            class(figure_t), intent(inout) :: self
+            integer, intent(in) :: row, col
+            real(wp), contiguous, intent(in) :: x(:), heights(:)
+            real(wp), intent(in), optional :: width
+            real(wp), intent(in), optional :: bottom(:)
+            character(len=*), intent(in), optional :: label, align
+            real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
+        end subroutine subplot_bar
+
+        module subroutine subplot_barh(self, row, col, y, widths, height, left, &
+                                       label, color, edgecolor, align, alpha)
+            class(figure_t), intent(inout) :: self
+            integer, intent(in) :: row, col
+            real(wp), contiguous, intent(in) :: y(:), widths(:)
+            real(wp), intent(in), optional :: height
+            real(wp), intent(in), optional :: left(:)
+            character(len=*), intent(in), optional :: label, align
+            real(wp), intent(in), optional :: color(3), edgecolor(3), alpha
+        end subroutine subplot_barh
+
+        module subroutine subplot_hist(self, row, col, data, bins, density, label, &
+                                      color, range, weights, cumulative, &
+                                      orientation, alpha)
+            class(figure_t), intent(inout) :: self
+            integer, intent(in) :: row, col
+            real(wp), contiguous, intent(in) :: data(:)
+            integer, intent(in), optional :: bins
+            logical, intent(in), optional :: density
+            character(len=*), intent(in), optional :: label
+            character(len=*), intent(in), optional :: color
+            real(wp), intent(in), optional :: range(2)
+            real(wp), intent(in), optional :: weights(:)
+            logical, intent(in), optional :: cumulative
+            character(len=*), intent(in), optional :: orientation
+            real(wp), intent(in), optional :: alpha
+        end subroutine subplot_hist
+
+        module subroutine subplot_boxplot(self, row, col, data, position, width, &
+                                          label, show_outliers, horizontal, color)
+            class(figure_t), intent(inout) :: self
+            integer, intent(in) :: row, col
+            real(wp), contiguous, intent(in) :: data(:)
+            real(wp), intent(in), optional :: position
+            real(wp), intent(in), optional :: width
+            character(len=*), intent(in), optional :: label
+            logical, intent(in), optional :: show_outliers
+            logical, intent(in), optional :: horizontal
+            real(wp), intent(in), optional :: color(3)
+        end subroutine subplot_boxplot
+
+        module subroutine subplot_scatter(self, row, col, x, y, s, c, marker, &
+                                          markersize, color, colormap, alpha, &
+                                          edgecolor, facecolor, linewidth, vmin, &
+                                          vmax, label, show_colorbar)
+            class(figure_t), intent(inout) :: self
+            integer, intent(in) :: row, col
+            real(wp), contiguous, intent(in) :: x(:), y(:)
+            real(wp), intent(in), optional :: s(..), c(:)
+            character(len=*), intent(in), optional :: marker, colormap, label
+            real(wp), intent(in), optional :: markersize, alpha, linewidth, vmin, &
+                                             vmax
+            real(wp), intent(in), optional :: color(3), edgecolor(3), facecolor(3)
+            logical, intent(in), optional :: show_colorbar
+        end subroutine subplot_scatter
 
         module subroutine relocate_last_plot_to_subplot(self)
             class(figure_t), intent(inout) :: self

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -15,6 +15,7 @@ program test_subplots
     call test_subplot_creation()
     call test_subplot_layouts()
     call test_subplot_plotting()
+    call test_subplot_other_plot_types()
     call test_subplot_alpha()
     call test_subplot_independence()
     call test_edge_cases()
@@ -111,6 +112,71 @@ contains
         print *, '  PASS: test_subplot_plotting'
         passed_tests = passed_tests + 1
     end subroutine test_subplot_plotting
+
+    subroutine test_subplot_other_plot_types()
+        !! Test subplot helpers for non-line plot types.
+        use fortplot_plot_data, only: PLOT_TYPE_BAR, PLOT_TYPE_BOXPLOT, &
+                                      PLOT_TYPE_HISTOGRAM, PLOT_TYPE_SCATTER
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        real(wp), parameter :: y_data(4) = [2.0_wp, 1.0_wp, 3.0_wp, 4.0_wp]
+        real(wp), parameter :: hist_data(6) = [1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp, &
+                                               3.0_wp, 3.5_wp]
+        real(wp), parameter :: box_data(5) = [5.0_wp, 6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp]
+
+        total_tests = total_tests + 1
+
+        call fig%initialize(800, 600)
+        call fig%subplots(2, 2)
+
+        call fig%subplot_hist(1, 1, hist_data, bins=3)
+        call fig%subplot_boxplot(1, 2, box_data)
+        call fig%subplot_scatter(2, 1, x_data, y_data)
+        call fig%subplot_bar(2, 2, x_data, y_data)
+
+        if (fig%subplot_plot_count(1, 1) /= 1) then
+            print *, 'FAIL: test_subplot_other_plot_types - histogram not routed'
+            return
+        end if
+
+        if (fig%subplots_array(1, 1)%plots(1)%plot_type /= PLOT_TYPE_HISTOGRAM) then
+            print *, 'FAIL: test_subplot_other_plot_types - histogram type mismatch'
+            return
+        end if
+
+        if (fig%subplot_plot_count(1, 2) /= 1) then
+            print *, 'FAIL: test_subplot_other_plot_types - boxplot not routed'
+            return
+        end if
+
+        if (fig%subplots_array(1, 2)%plots(1)%plot_type /= PLOT_TYPE_BOXPLOT) then
+            print *, 'FAIL: test_subplot_other_plot_types - boxplot type mismatch'
+            return
+        end if
+
+        if (fig%subplot_plot_count(2, 1) /= 1) then
+            print *, 'FAIL: test_subplot_other_plot_types - scatter not routed'
+            return
+        end if
+
+        if (fig%subplots_array(2, 1)%plots(1)%plot_type /= PLOT_TYPE_SCATTER) then
+            print *, 'FAIL: test_subplot_other_plot_types - scatter type mismatch'
+            return
+        end if
+
+        if (fig%subplot_plot_count(2, 2) /= 1) then
+            print *, 'FAIL: test_subplot_other_plot_types - bar not routed'
+            return
+        end if
+
+        if (fig%subplots_array(2, 2)%plots(1)%plot_type /= PLOT_TYPE_BAR) then
+            print *, 'FAIL: test_subplot_other_plot_types - bar type mismatch'
+            return
+        end if
+
+        print *, '  PASS: test_subplot_other_plot_types'
+        passed_tests = passed_tests + 1
+    end subroutine test_subplot_other_plot_types
 
     subroutine test_subplot_alpha()
         type(figure_t) :: fig

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -127,12 +127,13 @@ contains
         total_tests = total_tests + 1
 
         call fig%initialize(800, 600)
-        call fig%subplots(2, 2)
+        call fig%subplots(3, 2)
 
         call fig%subplot_hist(1, 1, hist_data, bins=3)
         call fig%subplot_boxplot(1, 2, box_data)
         call fig%subplot_scatter(2, 1, x_data, y_data)
         call fig%subplot_bar(2, 2, x_data, y_data)
+        call fig%subplot_barh(3, 1, x_data, y_data)
 
         if (fig%subplot_plot_count(1, 1) /= 1) then
             print *, 'FAIL: test_subplot_other_plot_types - histogram not routed'
@@ -171,6 +172,26 @@ contains
 
         if (fig%subplots_array(2, 2)%plots(1)%plot_type /= PLOT_TYPE_BAR) then
             print *, 'FAIL: test_subplot_other_plot_types - bar type mismatch'
+            return
+        end if
+
+        if (fig%subplot_plot_count(3, 1) /= 1) then
+            print *, 'FAIL: test_subplot_other_plot_types - barh not routed'
+            return
+        end if
+
+        if (fig%subplots_array(3, 1)%plots(1)%plot_type /= PLOT_TYPE_BAR) then
+            print *, 'FAIL: test_subplot_other_plot_types - barh type mismatch'
+            return
+        end if
+
+        if (.not. fig%subplots_array(3, 1)%plots(1)%bar_horizontal) then
+            print *, 'FAIL: test_subplot_other_plot_types - barh orientation mismatch'
+            return
+        end if
+
+        if (fig%subplot_plot_count(3, 2) /= 0) then
+            print *, 'FAIL: test_subplot_other_plot_types - barh polluted other subplot'
             return
         end if
 

--- a/test/state/test_stateful_subplots_routing.f90
+++ b/test/state/test_stateful_subplots_routing.f90
@@ -3,7 +3,7 @@ program test_stateful_subplots_routing
     !! to the selected subplot when a grid is active.
 
     use fortplot, only: wp, figure_t, plot, title, subplot, subplots, &
-                        hist, bar, scatter, figure, get_global_figure
+                        hist, bar, scatter, boxplot, figure, get_global_figure
     implicit none
 
     real(wp) :: x(5), y1(5), y2(5)

--- a/test/state/test_stateful_subplots_routing.f90
+++ b/test/state/test_stateful_subplots_routing.f90
@@ -94,6 +94,26 @@ program test_stateful_subplots_routing
         stop 1
     end if
 
+    ! Regression for issue #2033: boxplot must also attach to the active
+    ! subplot grid.
+    call figure()
+    call subplots(2, 2)
+    call subplot(2, 2, 4)
+    call boxplot(y1)
+
+    f => get_global_figure()
+
+    if (f%subplot_plot_count(2, 2) /= 1) then
+        print *, '  FAIL: boxplot not routed to subplot (2,2)'
+        stop 1
+    end if
+
+    if (f%subplot_plot_count(1, 1) /= 0 .or. f%subplot_plot_count(1, 2) /= 0 .or. &
+        f%subplot_plot_count(2, 1) /= 0) then
+        print *, '  FAIL: boxplot polluted other subplots'
+        stop 1
+    end if
+
     print *, 'All stateful subplot routing tests PASSED!'
 
 end program test_stateful_subplots_routing


### PR DESCRIPTION
## Requirements
- REQ-001 satisfied: `figure_t` exposes explicit subplot helpers for `bar`, `barh`, `hist`, `boxplot`, and `scatter`.
- REQ-002 satisfied: each helper routes the plot into the requested subplot and leaves the other subplot counts unchanged.
- REQ-003 satisfied: stateful subplot routing includes `boxplot` alongside the existing `bar`, `hist`, and `scatter` paths.

## File Set
Edited:
- [src/figures/core/fortplot_figure_core_main.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/figures/core/fortplot_figure_core_main.f90)
- [src/figures/core/fortplot_figure_core_impl_layout.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/figures/core/fortplot_figure_core_impl_layout.f90)
- [src/figures/core/fortplot_figure_core_impl_plots.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/figures/core/fortplot_figure_core_impl_plots.f90)
- [test/plot_types/test_subplots.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/test/plot_types/test_subplots.f90)
- [test/state/test_stateful_subplots_routing.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/test/state/test_stateful_subplots_routing.f90)

Intentionally left alone:
- [src/plotting/fortplot_plot_bars.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/plotting/fortplot_plot_bars.f90), `bar` and `barh` already relocate into the active subplot.
- [src/interfaces/fortplot_matplotlib_hist_wrappers.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/interfaces/fortplot_matplotlib_hist_wrappers.f90), `hist` already relocates after plotting.
- [src/interfaces/fortplot_matplotlib_scatter_dispatch.f90](https://github.com/lazy-fortran/fortplot/blob/fix/issue-2033/src/interfaces/fortplot_matplotlib_scatter_dispatch.f90), `scatter` already relocates through the existing dispatch path.

## Verification
- `fpm test --target test_subplots`
  - `PASS: test_subplot_other_plot_types`
  - `All subplot tests PASSED!`
- `fpm test --target test_stateful_subplots_routing`
  - `All stateful subplot routing tests PASSED!`
- `make build`
  - `Project is up to date`
- `make test-ci`
  - `CI essential test suite completed successfully`
- `make verify-artifacts`
  - `Artifact verification passed.`

(ref #2033)
<!-- orchestrate: fully-resolved -->
