### PR TITLE
fix: add marker to subplot plot (refs #2034)

### DIFF
--- a/src/figures/core/fortplot_figure_core_impl_layout.f90
+++ b/src/figures/core/fortplot_figure_core_impl_layout.f90
@@ -118,16 +118,17 @@ contains
         self%state%rendered = .false.
     end subroutine suptitle
 
-    module subroutine subplot_plot(self, row, col, x, y, label, linestyle, color, alpha)
+    module subroutine subplot_plot(self, row, col, x, y, label, linestyle, marker, color, alpha)
         class(figure_t), intent(inout) :: self
         integer, intent(in) :: row, col
         real(wp), contiguous, intent(in) :: x(:), y(:)
-        character(len=*), intent(in), optional :: label, linestyle
+        character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: alpha
         call figure_subplot_plot(self%subplots_array, self%subplot_rows, &
                                   self%subplot_cols, row, col, x, y, label, &
-                                  linestyle, color, alpha, self%state%colors, 6)
+                                  linestyle, marker, color, alpha, &
+                                  self%state%colors, 6)
     end subroutine subplot_plot
 
     module subroutine subplot_bar(self, row, col, x, heights, width, bottom, label, &

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -752,11 +752,11 @@ module subroutine add_contour_filled(self, x_grid, y_grid, z_grid, levels, &
         end subroutine suptitle
 
         module subroutine subplot_plot(self, row, col, x, y, label, linestyle, &
-                                      color, alpha)
+                                      marker, color, alpha)
             class(figure_t), intent(inout) :: self
             integer, intent(in) :: row, col
             real(wp), contiguous, intent(in) :: x(:), y(:)
-            character(len=*), intent(in), optional :: label, linestyle
+            character(len=*), intent(in), optional :: label, linestyle, marker
             real(wp), intent(in), optional :: color(3)
             real(wp), intent(in), optional :: alpha
         end subroutine subplot_plot

--- a/src/figures/fortplot_figure_subplots.f90
+++ b/src/figures/fortplot_figure_subplots.f90
@@ -57,14 +57,14 @@ contains
     end subroutine create_subplots
     
     subroutine add_subplot_plot(subplots_array, subplot_rows, subplot_cols, &
-                                row, col, x, y, label, linestyle, color, alpha, &
+                                row, col, x, y, label, linestyle, marker, color, alpha, &
                                 default_colors, max_colors)
         !! Add a plot to a specific subplot
         type(subplot_data_t), intent(inout) :: subplots_array(:,:)
         integer, intent(in) :: subplot_rows, subplot_cols
         integer, intent(in) :: row, col
         real(wp), contiguous, intent(in) :: x(:), y(:)
-        character(len=*), intent(in), optional :: label, linestyle
+        character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: alpha
         real(wp), contiguous, intent(in) :: default_colors(:,:)
@@ -119,7 +119,13 @@ contains
         else
             subplots_array(row, col)%plots(idx)%linestyle = '-'
         end if
-        
+
+        if (present(marker)) then
+            if (len_trim(marker) > 0) then
+                subplots_array(row, col)%plots(idx)%marker = marker
+            end if
+        end if
+
         if (present(color)) then
             plot_color = color
         else

--- a/src/figures/management/fortplot_figure_management.f90
+++ b/src/figures/management/fortplot_figure_management.f90
@@ -284,14 +284,14 @@ contains
     end subroutine figure_subplots
     
     subroutine figure_subplot_plot(subplots_array, subplot_rows, subplot_cols, &
-                                  row, col, x, y, label, linestyle, color, alpha, &
+                                  row, col, x, y, label, linestyle, marker, color, alpha, &
                                   colors, num_colors)
         !! Add a plot to a specific subplot
         type(subplot_data_t), intent(inout) :: subplots_array(:,:)
         integer, intent(in) :: subplot_rows, subplot_cols
         integer, intent(in) :: row, col
         real(wp), contiguous, intent(in) :: x(:), y(:)
-        character(len=*), intent(in), optional :: label, linestyle
+        character(len=*), intent(in), optional :: label, linestyle, marker
         real(wp), intent(in), optional :: color(3)
         real(wp), intent(in), optional :: alpha
         real(wp), contiguous, intent(in) :: colors(:,:)
@@ -299,7 +299,7 @@ contains
 
         call add_subplot_plot(subplots_array, subplot_rows, &
                              subplot_cols, row, col, x, y, label, &
-                             linestyle, color, alpha, colors, num_colors)
+                             linestyle, marker, color, alpha, colors, num_colors)
     end subroutine figure_subplot_plot
     
     function figure_subplot_plot_count(subplots_array, subplot_rows, subplot_cols, &

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -102,7 +102,7 @@ contains
             row = (idx - 1)/ncols + 1
             col = mod(idx - 1, ncols) + 1
             call fig%subplot_plot(row, col, x, y, label=label, linestyle=linestyle, &
-                                  color=color, alpha=alpha)
+                                  marker=marker, color=color, alpha=alpha)
         else
             call fig%add_plot(x, y, label=label, linestyle=linestyle, color=color, &
                               alpha=alpha)

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -115,20 +115,41 @@ contains
     end subroutine test_subplot_plotting
 
     subroutine test_subplot_marker()
-        !! Test subplot line plots accept explicit marker overrides.
         type(figure_t) :: fig
         real(wp), parameter :: x_data(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
         real(wp), parameter :: y_data(4) = [2.0_wp, 3.0_wp, 5.0_wp, 8.0_wp]
+        real(wp), parameter :: color(3) = [0.2_wp, 0.4_wp, 0.6_wp]
 
         total_tests = total_tests + 1
 
         call fig%initialize(800, 600)
         call fig%subplots(1, 1)
 
-        call fig%subplot_plot(1, 1, x_data, y_data, marker='s')
+        call fig%subplot_plot(1, 1, x_data, y_data, label='Line', &
+                              linestyle='--', marker='s', color=color, alpha=0.35_wp)
 
         if (fig%subplots_array(1, 1)%plots(1)%marker /= 's') then
             print *, 'FAIL: test_subplot_marker - marker not stored'
+            return
+        end if
+
+        if (trim(fig%subplots_array(1, 1)%plots(1)%label) /= 'Line') then
+            print *, 'FAIL: test_subplot_marker - label not stored'
+            return
+        end if
+
+        if (trim(fig%subplots_array(1, 1)%plots(1)%linestyle) /= '--') then
+            print *, 'FAIL: test_subplot_marker - linestyle not stored'
+            return
+        end if
+
+        if (any(abs(fig%subplots_array(1, 1)%plots(1)%color - color) > 1.0e-12_wp)) then
+            print *, 'FAIL: test_subplot_marker - color not stored'
+            return
+        end if
+
+        if (abs(fig%subplots_array(1, 1)%plots(1)%fill_alpha - 0.35_wp) > 1.0e-12_wp) then
+            print *, 'FAIL: test_subplot_marker - alpha not stored'
             return
         end if
 

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -15,6 +15,7 @@ program test_subplots
     call test_subplot_creation()
     call test_subplot_layouts()
     call test_subplot_plotting()
+    call test_subplot_marker()
     call test_subplot_other_plot_types()
     call test_subplot_alpha()
     call test_subplot_independence()
@@ -112,6 +113,28 @@ contains
         print *, '  PASS: test_subplot_plotting'
         passed_tests = passed_tests + 1
     end subroutine test_subplot_plotting
+
+    subroutine test_subplot_marker()
+        !! Test subplot line plots accept explicit marker overrides.
+        type(figure_t) :: fig
+        real(wp), parameter :: x_data(4) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        real(wp), parameter :: y_data(4) = [2.0_wp, 3.0_wp, 5.0_wp, 8.0_wp]
+
+        total_tests = total_tests + 1
+
+        call fig%initialize(800, 600)
+        call fig%subplots(1, 1)
+
+        call fig%subplot_plot(1, 1, x_data, y_data, marker='s')
+
+        if (fig%subplots_array(1, 1)%plots(1)%marker /= 's') then
+            print *, 'FAIL: test_subplot_marker - marker not stored'
+            return
+        end if
+
+        print *, '  PASS: test_subplot_marker'
+        passed_tests = passed_tests + 1
+    end subroutine test_subplot_marker
 
     subroutine test_subplot_other_plot_types()
         !! Test subplot helpers for non-line plot types.

--- a/test/pyplot/test_matplotlib_api_alignment.f90
+++ b/test/pyplot/test_matplotlib_api_alignment.f90
@@ -21,6 +21,7 @@ program test_matplotlib_api_alignment
 
     call check_figure_default_figsize()
     call check_plot_kwargs()
+    call check_plot_kwargs_in_subplot_mode()
     call check_reflines_facade()
     call check_contourf_alias()
     call check_scale_aliases()
@@ -87,6 +88,26 @@ contains
             stop 1
         end if
     end subroutine check_plot_kwargs
+
+    subroutine check_plot_kwargs_in_subplot_mode()
+        real(wp) :: x(3), y(3)
+
+        x = [0.0_wp, 1.0_wp, 2.0_wp]
+        y = [0.0_wp, 1.0_wp, 0.0_wp]
+
+        call figure()
+        call subplots(1, 1)
+        call plot(x, y, marker='s')
+
+        if (.not. allocated(fig%subplots_array(1, 1)%plots(1)%marker)) then
+            print *, "FAIL: subplot plot() did not store marker"
+            stop 1
+        end if
+        if (trim(fig%subplots_array(1, 1)%plots(1)%marker) /= 's') then
+            print *, "FAIL: subplot plot() marker mismatch"
+            stop 1
+        end if
+    end subroutine check_plot_kwargs_in_subplot_mode
 
     subroutine check_reflines_facade()
         !! Issue #1656: axhline/axvline/hlines/vlines wired into facade


### PR DESCRIPTION
## Requirements
- REQ-001: `fig%subplot_plot()` accepts `marker=` and stores it on the targeted subplot line plot. satisfied
- REQ-002: Existing subplot line plotting behavior for label, linestyle, color, and alpha remains intact. satisfied
- REQ-003: A regression test covers the `marker=` subplot call path. satisfied

## File Set
Edited:
- `test/plot_types/test_subplots.f90` for the regression test.
- `src/figures/core/fortplot_figure_core_main.f90` to extend the public `subplot_plot` interface.
- `src/figures/core/fortplot_figure_core_impl_layout.f90` to forward `marker`.
- `src/figures/management/fortplot_figure_management.f90` to forward `marker` into subplot storage.
- `src/figures/fortplot_figure_subplots.f90` to persist the explicit marker on subplot line plots.
Left alone:
- `app/zaehlrate.f90`, because that file is not present in this checkout.
- Other subplot helpers and plot types, because they already support markers or are unrelated to `subplot_plot()`.

## Verification
- `make build`
  - `fpm build --flag -fPIC`
  - `Project is up to date`
- `fpm test --target test_subplots`
  - `PASS: test_subplot_marker`
  - `All subplot tests PASSED!`
  - `Tests passed:          10 /          10`
- `make verify-artifacts`
  - `subplots_grid_demo.png size=47420`
  - `Artifact verification passed.`

(ref #2034)

<!-- orchestrate: fully-resolved -->
