### PR TITLE
fix: render math operators and keep unknown LaTeX commands literal

### DIFF
--- a/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
@@ -23,9 +23,10 @@ contains
         do i = 1, n
             ch = input(i:i)
 
-            if (ch == '(' .or. ch == ')' .or. ch == '\\') then
+            ! Fortran has no backslash escape: achar(92) is a literal '\'.
+            if (ch == '(' .or. ch == ')' .or. ch == achar(92)) then
                 j = j + 1
-                if (j <= len(output)) output(j:j) = '\\'
+                if (j <= len(output)) output(j:j) = achar(92)
                 j = j + 1
                 if (j <= len(output)) output(j:j) = ch
             else
@@ -67,6 +68,37 @@ contains
             symbol_char = achar(92)//'266'
             return
         end if
+
+        ! Math relations and operators in Adobe Symbol encoding
+        select case (unicode_codepoint)
+        case (8733)  ! U+221D proportional
+            symbol_char = achar(92)//'265'
+            return
+        case (8776)  ! U+2248 approxequal
+            symbol_char = achar(92)//'273'
+            return
+        case (8764)  ! U+223C similar
+            symbol_char = achar(92)//'176'
+            return
+        case (8747)  ! U+222B integral
+            symbol_char = achar(92)//'362'
+            return
+        case (8711)  ! U+2207 nabla / gradient
+            symbol_char = achar(92)//'321'
+            return
+        case (8804)  ! U+2264 lessequal
+            symbol_char = achar(92)//'243'
+            return
+        case (8805)  ! U+2265 greaterequal
+            symbol_char = achar(92)//'263'
+            return
+        case (8800)  ! U+2260 notequal
+            symbol_char = achar(92)//'271'
+            return
+        case (8801)  ! U+2261 equivalence
+            symbol_char = achar(92)//'272'
+            return
+        end select
 
         ! Arrows in Symbol encoding
         select case (unicode_codepoint)

--- a/src/utilities/text/fortplot_latex_parser.f90
+++ b/src/utilities/text/fortplot_latex_parser.f90
@@ -30,11 +30,26 @@ module fortplot_latex_parser
         953, 954, 955, 956, 957, 958, 959, 960, &
         961, 963, 964, 965, 966, 967, 968, 969 ]
     
-    ! Unicode codepoints for uppercase Greek letters  
+    ! Unicode codepoints for uppercase Greek letters
     integer, parameter :: UPPERCASE_CODEPOINTS(24) = [ &
         913, 914, 915, 916, 917, 918, 919, 920, &
         921, 922, 923, 924, 925, 926, 927, 928, &
         929, 931, 932, 933, 934, 935, 936, 937 ]
+
+    ! Common math operators and relations rendered as bare Unicode, matching the
+    ! Greek-letter convenience layer. Backends map these codepoints to their own
+    ! glyphs (PDF Symbol/WinAnsi, raster TrueType).
+    character(len=*), parameter :: MATH_OPERATORS(15) = [ &
+        "times   ", "cdot    ", "pm      ", "varphi  ", &
+        "propto  ", "approx  ", "sim     ", "int     ", &
+        "infty   ", "partial ", "nabla   ", "leq     ", &
+        "geq     ", "neq     ", "equiv   " ]
+
+    integer, parameter :: MATH_OPERATOR_CODEPOINTS(15) = [ &
+        215, 183, 177, 966, &
+        8733, 8776, 8764, 8747, &
+        8734, 8706, 8711, 8804, &
+        8805, 8800, 8801 ]
 
 contains
 
@@ -183,6 +198,16 @@ contains
                 return
             end if
         end do
+
+        ! Check math operators and relations
+        do i = 1, size(MATH_OPERATORS)
+            if (trim(latex_command) == trim(MATH_OPERATORS(i))) then
+                codepoint = MATH_OPERATOR_CODEPOINTS(i)
+                call codepoint_to_utf8(codepoint, unicode_char)
+                success = .true.
+                return
+            end if
+        end do
     end subroutine latex_to_unicode
     
     subroutine codepoint_to_utf8(codepoint, utf8_char)
@@ -263,8 +288,15 @@ contains
                                                     result_text, i)
                             cycle
                         end if
+
+                        ! Unknown alphabetic command: drop the backslash and keep
+                        ! the name literal (e.g. '\foo' -> 'foo'). Never drop a
+                        ! leading character.
+                        i = i + 1
+                        cycle
                     end if
-                    ! If not a recognized command, fall through and copy the backslash
+                    ! Non-alphabetic escape (\_, \^, \\, \$): copy the backslash so
+                    ! the mathtext layer can treat the next character literally.
                 end if
 
                 result_text(pos:pos) = input_text(i:i)

--- a/src/utilities/text/fortplot_unicode.f90
+++ b/src/utilities/text/fortplot_unicode.f90
@@ -197,12 +197,18 @@ contains
             ascii_equiv = 'and'
         case (8744)  ! U+2228 logical or
             ascii_equiv = 'or'
+        case (8733)  ! U+221D proportional to
+            ascii_equiv = '~'
         case (8747)  ! U+222B integral
             ascii_equiv = 'int'
+        case (8764)  ! U+223C tilde operator (similar)
+            ascii_equiv = '~'
         case (8776)  ! U+2248 almost equal to
             ascii_equiv = '~='
         case (8800)  ! U+2260 not equal to
             ascii_equiv = '!='
+        case (8801)  ! U+2261 identical to (equivalence)
+            ascii_equiv = '='
         case (8804)  ! U+2264 less-than or equal to
             ascii_equiv = '<='
         case (8805)  ! U+2265 greater-than or equal to

--- a/test/text/test_mathtext_operators.f90
+++ b/test/text/test_mathtext_operators.f90
@@ -1,0 +1,149 @@
+program test_mathtext_operators
+    !! Regression tests for issues 2045 and 2046: math operators render as bare
+    !! Unicode, unknown LaTeX commands never drop a leading character, and PDF
+    !! string escaping handles backslashes.
+    use fortplot_latex_parser, only: process_latex_in_text, latex_to_unicode
+    use fortplot_pdf_text_escape, only: escape_pdf_string
+    use fortplot_unicode, only: utf8_to_codepoint, unicode_codepoint_to_ascii
+    implicit none
+
+    call test_operator_mapping()
+    call test_operators_in_text()
+    call test_unknown_command_keeps_name()
+    call test_escaped_specials_stay_literal()
+    call test_pdf_escape_backslash()
+    call test_ascii_fallbacks()
+
+    print *, "All mathtext operator tests passed!"
+
+contains
+
+    subroutine expect_codepoint(command, expected)
+        character(len=*), intent(in) :: command
+        integer, intent(in) :: expected
+        character(len=20) :: unicode_char
+        logical :: success
+        integer :: codepoint
+
+        call latex_to_unicode(command, unicode_char, success)
+        if (.not. success) then
+            print *, "ERROR: operator not mapped: ", command
+            stop 1
+        end if
+        codepoint = utf8_to_codepoint(unicode_char, 1)
+        if (codepoint /= expected) then
+            print *, "ERROR: wrong codepoint for ", command, codepoint, &
+                " expected ", expected
+            stop 1
+        end if
+    end subroutine expect_codepoint
+
+    subroutine test_operator_mapping()
+        call expect_codepoint("times", 215)
+        call expect_codepoint("cdot", 183)
+        call expect_codepoint("pm", 177)
+        call expect_codepoint("varphi", 966)
+        call expect_codepoint("propto", 8733)
+        call expect_codepoint("approx", 8776)
+        call expect_codepoint("sim", 8764)
+        call expect_codepoint("int", 8747)
+        call expect_codepoint("infty", 8734)
+        call expect_codepoint("partial", 8706)
+        call expect_codepoint("nabla", 8711)
+        call expect_codepoint("leq", 8804)
+        call expect_codepoint("geq", 8805)
+        call expect_codepoint("neq", 8800)
+        call expect_codepoint("equiv", 8801)
+        print *, "test_operator_mapping: PASSED"
+    end subroutine test_operator_mapping
+
+    subroutine test_operators_in_text()
+        character(len=200) :: result
+        integer :: rlen
+
+        call process_latex_in_text("A = \int f dx", result, rlen)
+        if (index(result(1:rlen), "int") /= 0 .or. index(result(1:rlen), '\') /= 0) then
+            print *, "ERROR: \int not converted: ", result(1:rlen)
+            stop 1
+        end if
+
+        call process_latex_in_text("a \sim b \approx c \propto d", result, rlen)
+        if (index(result(1:rlen), "sim") /= 0 .or. &
+            index(result(1:rlen), "approx") /= 0 .or. &
+            index(result(1:rlen), "propto") /= 0) then
+            print *, "ERROR: relation operators not converted: ", result(1:rlen)
+            stop 1
+        end if
+        print *, "test_operators_in_text: PASSED"
+    end subroutine test_operators_in_text
+
+    subroutine test_unknown_command_keeps_name()
+        character(len=200) :: result
+        integer :: rlen
+
+        ! Unknown command drops the backslash but keeps the whole name; the
+        ! leading letter must not be lost (issue 2045).
+        call process_latex_in_text("bad \foobar end", result, rlen)
+        if (index(result(1:rlen), "foobar") == 0) then
+            print *, "ERROR: unknown command mangled: ", result(1:rlen)
+            stop 1
+        end if
+        if (index(result(1:rlen), '\') /= 0) then
+            print *, "ERROR: backslash retained for unknown command: ", result(1:rlen)
+            stop 1
+        end if
+        print *, "test_unknown_command_keeps_name: PASSED"
+    end subroutine test_unknown_command_keeps_name
+
+    subroutine test_escaped_specials_stay_literal()
+        character(len=200) :: result
+        integer :: rlen
+
+        ! Non-alphabetic escapes keep their backslash for the mathtext layer.
+        call process_latex_in_text("x\_y a\^b", result, rlen)
+        if (index(result(1:rlen), '\_') == 0 .or. index(result(1:rlen), '\^') == 0) then
+            print *, "ERROR: escaped specials not preserved: ", result(1:rlen)
+            stop 1
+        end if
+        print *, "test_escaped_specials_stay_literal: PASSED"
+    end subroutine test_escaped_specials_stay_literal
+
+    subroutine test_ascii_fallbacks()
+        !! Every operator codepoint must have a readable ASCII fallback so the
+        !! ASCII backend never emits raw U+XXXX fragments (issue 2045/2046).
+        integer, parameter :: codepoints(15) = [ &
+            215, 183, 177, 966, 8733, 8776, 8764, 8747, &
+            8734, 8706, 8711, 8804, 8805, 8800, 8801 ]
+        character(len=16) :: ascii_equiv
+        integer :: i
+
+        do i = 1, size(codepoints)
+            call unicode_codepoint_to_ascii(codepoints(i), ascii_equiv)
+            if (index(ascii_equiv, 'U+') /= 0) then
+                print *, "ERROR: no ASCII fallback for codepoint ", codepoints(i), &
+                    " got ", trim(ascii_equiv)
+                stop 1
+            end if
+        end do
+        print *, "test_ascii_fallbacks: PASSED"
+    end subroutine test_ascii_fallbacks
+
+    subroutine test_pdf_escape_backslash()
+        character(len=32) :: out
+        integer :: olen
+
+        call escape_pdf_string(achar(92)//"n", out, olen)
+        ! A literal backslash must be doubled so PDF readers do not treat the
+        ! following character as an escape (issue 2045: \times -> imes).
+        if (olen < 3) then
+            print *, "ERROR: backslash not escaped, len=", olen
+            stop 1
+        end if
+        if (out(1:3) /= achar(92)//achar(92)//"n") then
+            print *, "ERROR: backslash escaping wrong: ", out(1:olen)
+            stop 1
+        end if
+        print *, "test_pdf_escape_backslash: PASSED"
+    end subroutine test_pdf_escape_backslash
+
+end program test_mathtext_operators


### PR DESCRIPTION
## Summary

Fixes #2045 and #2046: math operators rendered literally in labels/titles, unknown LaTeX commands dropped a leading character, and title/axis-label mathtext behaved inconsistently.

- Add common operators/relations to the single shared `process_latex_in_text` stage that every backend funnels through, so `\int \times \cdot \pm \varphi \propto \approx \sim \infty \partial \nabla \leq \geq \neq \equiv` render as bare Unicode identically in titles, axis labels, and legends across PNG, PDF, and ASCII.
- Unknown alphabetic commands now drop only the backslash and keep the full name literal (`\foo` -> `foo`) instead of losing the leading character.
- Fix `escape_pdf_string`: it compared a length-1 char against the two-byte literal `'\\'` (Fortran has no backslash escapes), so a literal backslash was never escaped. PDF readers then interpreted `\t`/`\c` as control escapes and dropped characters (`\times` -> `imes`). Now compares against `achar(92)`.
- Add Adobe Symbol-font octal codes for the new operator glyphs, and ASCII fallbacks for `propto`, `sim`, `equiv` so the ASCII backend never emits raw `U+XXXX` fragments.

Subscripts/superscripts continue to follow matplotlib parity: `^`/`_` are math only inside `$...$` (e.g. `$\nu^{1/3}$`, `$\Delta_{en}$`), matching the existing documented behaviour and locked-in tests. Operators render bare, consistent with the existing Greek-letter convenience layer.

Scope note: the two "minor, possibly related" bullets in #2046 (the `..` path warning and the identical-values warning) are intentional security/diagnostic guardrails and are left unchanged here; they belong in separate issues rather than a silent weakening.

## Verification

New regression test `test/text/test_mathtext_operators.f90` (operator mappings, unknown-command stripping, escaped-specials preservation, PDF backslash escaping, ASCII fallbacks).

Full suite and rendering gate:

```
make test            # ALL TESTS PASSED (fpm test)
make verify-artifacts # Artifact verification passed.
```

### Before (on main)

PDF and ASCII of the issue reproducers:

```
# PDF (pdftotext) title/xlabel
scaling ∆η sim (ν/a) ν
bad: imes cdot a varphi oobar pm approx propto
# ASCII xlabel for "x \propto \nabla"
x U+221D grad
```

`\int \sim \propto \approx \pm \cdot \varphi` printed literally; `\times` -> `imes`, `\foobar` -> `oobar` (leading char dropped).

### After (this branch)

Same reproducers:

```
# PDF (pdftotext)
scaling ∆η ∼ (ν/a) ν
bad: × · a φ foobar ± ≈ ∝
# dollar-delimited scripts, PDF
1/3
ν
and ∆en with ∫
flux ∝ ∇ φ
axis × · ±
# ASCII xlabel for "x \propto \nabla"
x ~ grad
```

PNG render of `title("$\nu^{1/3}$ and $\Delta_{en}$ with \int")`, `ylabel("flux \propto \nabla \varphi")`, `xlabel("axis \times \cdot \pm")` shows every glyph with correct superscript/subscript and no missing-glyph boxes. `grep -c 'U+'` over the ASCII output is `0`.

Adversarial review (independent agent) confirmed the Adobe Symbol octal codes, Unicode codepoints, string-width padding, loop/index safety, and short-circuit safety; it caught the missing ASCII fallbacks, now fixed and covered by the new test.
