### PR TITLE
fix: span axhline/axvline across full range on log axes

### DIFF
--- a/src/figures/rendering/fortplot_figure_plot_renderers.f90
+++ b/src/figures/rendering/fortplot_figure_plot_renderers.f90
@@ -38,6 +38,7 @@ contains
 
         real(wp) :: x1, y1, x2, y2
         real(wp) :: x1_scaled, y1_scaled, x2_scaled, y2_scaled
+        logical :: x_normalized, y_normalized
 
         if (.not. allocated(plot%x) .or. .not. allocated(plot%y)) return
         if (size(plot%x) < 2 .or. size(plot%y) < 2) return
@@ -54,6 +55,8 @@ contains
         x2 = plot%x(2)
         y1 = plot%y(1)
         y2 = plot%y(2)
+        x_normalized = .false.
+        y_normalized = .false.
 
         ! For horizontal lines (y1 == y2), x values may be normalized
         if (abs(y1 - y2) < 1.0e-9_wp) then
@@ -61,9 +64,11 @@ contains
             if (x1 >= 0.0_wp .and. x1 <= 1.0_wp .and. &
                 x2 >= 0.0_wp .and. x2 <= 1.0_wp .and. &
                 (x1 < 0.01_wp .or. x2 > 0.99_wp)) then
-                ! Convert normalized x to data coordinates
+                ! x_min/x_max are already in transformed (e.g. log) space, so the
+                ! interpolated span is too and must not be transformed again.
                 x1 = x_min + x1*(x_max - x_min)
                 x2 = x_min + x2*(x_max - x_min)
+                x_normalized = .true.
             end if
         end if
 
@@ -73,17 +78,28 @@ contains
             if (y1 >= 0.0_wp .and. y1 <= 1.0_wp .and. &
                 y2 >= 0.0_wp .and. y2 <= 1.0_wp .and. &
                 (y1 < 0.01_wp .or. y2 > 0.99_wp)) then
-                ! Convert normalized y to data coordinates
                 y1 = y_min + y1*(y_max - y_min)
                 y2 = y_min + y2*(y_max - y_min)
+                y_normalized = .true.
             end if
         end if
 
-        ! Apply scale transformations
-        x1_scaled = apply_scale_transform(x1, xscale, symlog_threshold)
-        x2_scaled = apply_scale_transform(x2, xscale, symlog_threshold)
-        y1_scaled = apply_scale_transform(y1, yscale, symlog_threshold)
-        y2_scaled = apply_scale_transform(y2, yscale, symlog_threshold)
+        ! Apply scale transforms only to axes still holding data coordinates;
+        ! normalized spans were interpolated in transformed space already.
+        if (x_normalized) then
+            x1_scaled = x1
+            x2_scaled = x2
+        else
+            x1_scaled = apply_scale_transform(x1, xscale, symlog_threshold)
+            x2_scaled = apply_scale_transform(x2, xscale, symlog_threshold)
+        end if
+        if (y_normalized) then
+            y1_scaled = y1
+            y2_scaled = y2
+        else
+            y1_scaled = apply_scale_transform(y1, yscale, symlog_threshold)
+            y2_scaled = apply_scale_transform(y2, yscale, symlog_threshold)
+        end if
 
         ! Draw the line
         call backend%line(x1_scaled, y1_scaled, x2_scaled, y2_scaled)

--- a/test/reflines/test_axhline_log_span.f90
+++ b/test/reflines/test_axhline_log_span.f90
@@ -1,0 +1,165 @@
+program test_axhline_log_span
+    !! Regression test for issue 2047: axhline/axvline must span the full axis on
+    !! log-scaled axes. The refline endpoints are interpolated in transformed
+    !! space, so applying the scale transform a second time truncated the line.
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_figure_core, only: figure_t
+    use fortplot_test_output_helpers, only: ensure_test_output_dir
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp) :: x(50), y(50)
+    integer :: i, status
+    character(len=:), allocatable :: output_dir, path
+
+    call ensure_test_output_dir('reflines', output_dir)
+    do i = 1, 50
+        x(i) = 10.0_wp**(-2.0_wp + 3.3_wp*real(i - 1, wp)/49.0_wp)
+        y(i) = 1.0e9_wp*x(i)
+    end do
+
+    call test_axhline_spans_full_log_x()
+    call test_axvline_spans_full_log_y()
+
+    print '(A)', 'All axhline/axvline log-span tests passed'
+
+contains
+
+    subroutine test_axhline_spans_full_log_x()
+        call fig%initialize(width=640, height=480)
+        call fig%add_plot(x, y)
+        call fig%axhline(8.5e7_wp, linestyle='--')
+        call fig%set_xscale('log')
+        call fig%set_yscale('log')
+        call fig%set_xlim(1.0e-2_wp, 2.0e1_wp)
+        call fig%set_ylim(1.0e7_wp, 1.0e11_wp)
+        path = trim(output_dir)//'test_axhline_log_span.txt'
+        call fig%savefig_with_status(path, status)
+        if (status /= 0) then
+            print '(A)', 'FAIL: could not save axhline log figure'
+            stop 1
+        end if
+        call fig%clear()
+        call assert_hline_spans(path)
+        print '(A)', 'test_axhline_spans_full_log_x: PASSED'
+    end subroutine test_axhline_spans_full_log_x
+
+    subroutine test_axvline_spans_full_log_y()
+        call fig%initialize(width=640, height=480)
+        call fig%add_plot(x, y)
+        call fig%axvline(0.5_wp, linestyle='--')
+        call fig%set_xscale('log')
+        call fig%set_yscale('log')
+        call fig%set_xlim(1.0e-2_wp, 2.0e1_wp)
+        call fig%set_ylim(1.0e7_wp, 1.0e11_wp)
+        path = trim(output_dir)//'test_axvline_log_span.txt'
+        call fig%savefig_with_status(path, status)
+        if (status /= 0) then
+            print '(A)', 'FAIL: could not save axvline log figure'
+            stop 1
+        end if
+        call fig%clear()
+        call assert_vline_spans(path)
+        print '(A)', 'test_axvline_spans_full_log_y: PASSED'
+    end subroutine test_axvline_spans_full_log_y
+
+    subroutine assert_hline_spans(file_path)
+        !! The horizontal reference line is the text row with the most marker
+        !! glyphs. Assert its markers reach both the left and right edges of the
+        !! plot area, i.e. the line spans the full x-range.
+        character(len=*), intent(in) :: file_path
+        character(len=512) :: line, best
+        integer :: unit, ios, cnt, best_cnt, width, first_col, last_col
+
+        best = ''
+        best_cnt = 0
+        open (newunit=unit, file=file_path, status='old', action='read')
+        do
+            read (unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            cnt = count_marks(line)
+            if (cnt > best_cnt) then
+                best_cnt = cnt
+                best = line
+            end if
+        end do
+        close (unit)
+
+        if (best_cnt < 5) then
+            print '(A)', 'FAIL: no reference-line row found'
+            stop 1
+        end if
+        width = len_trim(best)
+        first_col = mark_index(best, .true.)
+        last_col = mark_index(best, .false.)
+        ! Left marker near the left border, right marker near the right border.
+        if (first_col > width/4) then
+            print '(A,I0,A,I0)', 'FAIL: hline does not reach left edge, first=', &
+                first_col, ' width=', width
+            stop 1
+        end if
+        if (last_col < (3*width)/4) then
+            print '(A,I0,A,I0)', 'FAIL: hline truncated, last mark col=', &
+                last_col, ' width=', width
+            stop 1
+        end if
+    end subroutine assert_hline_spans
+
+    subroutine assert_vline_spans(file_path)
+        !! The vertical reference line occupies one column across many rows.
+        !! Assert marker rows appear in both the top and bottom thirds of the
+        !! plot, i.e. the line spans the full y-range.
+        character(len=*), intent(in) :: file_path
+        character(len=512) :: line
+        integer :: unit, ios, row, nrows, top_hits, bottom_hits
+        character(len=512), allocatable :: rows(:)
+
+        allocate (rows(0))
+        open (newunit=unit, file=file_path, status='old', action='read')
+        do
+            read (unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            rows = [rows, line]
+        end do
+        close (unit)
+
+        nrows = size(rows)
+        top_hits = 0
+        bottom_hits = 0
+        do row = 1, nrows
+            if (count_marks(rows(row)) >= 1) then
+                if (row <= nrows/3) top_hits = top_hits + 1
+                if (row > (2*nrows)/3) bottom_hits = bottom_hits + 1
+            end if
+        end do
+        if (top_hits < 1 .or. bottom_hits < 1) then
+            print '(A,I0,A,I0)', 'FAIL: vline does not span full height, top=', &
+                top_hits, ' bottom=', bottom_hits
+            stop 1
+        end if
+    end subroutine assert_vline_spans
+
+    integer function count_marks(line) result(cnt)
+        character(len=*), intent(in) :: line
+        integer :: j
+        cnt = 0
+        do j = 1, len_trim(line)
+            if (line(j:j) == '#' .or. line(j:j) == '*' .or. line(j:j) == 'o') &
+                cnt = cnt + 1
+        end do
+    end function count_marks
+
+    integer function mark_index(line, want_first) result(idx)
+        character(len=*), intent(in) :: line
+        logical, intent(in) :: want_first
+        integer :: j
+        idx = 0
+        do j = 1, len_trim(line)
+            if (line(j:j) == '#' .or. line(j:j) == '*' .or. line(j:j) == 'o') then
+                idx = j
+                if (want_first) return
+            end if
+        end do
+    end function mark_index
+
+end program test_axhline_log_span


### PR DESCRIPTION
## Summary

Fixes #2047: `axhline`/`axvline` only spanned part of the axis on log-scaled axes.

`render_refline_plot` receives the axis limits already in transformed (log) space. `axhline`/`axvline` store their spanning coordinate as normalized axes fractions `[0,1]`, which the renderer interpolates into `[x_min, x_max]` (already transformed space) and then passed through `apply_scale_transform` a second time. The double transform took `log10` of an already-log value (and `log10` of a negative for the left endpoint, raising `IEEE_INVALID`), so the reference line was truncated to part of the axis. Linear axes were unaffected because the transform is the identity there.

The fix tracks whether each endpoint came from the normalized span and skips the redundant transform for those, while still transforming `hlines`/`vlines` endpoints that hold real data coordinates. Result: exactly one transform on data coordinates, zero on normalized ones.

Scope note: the issue's "related usability note" (a working `legend(loc="best")` / semi-transparent frame) is a separate feature request and is not addressed here.

## Verification

New regression test `test/reflines/test_axhline_log_span.f90` renders an `axhline` on a log x-axis and an `axvline` on a log y-axis to the deterministic ASCII backend and asserts the reference line reaches both edges (axhline) / spans top and bottom thirds (axvline).

### Failing before (buggy double-transform reintroduced)

```
Note: The following floating-point exceptions are signalling: IEEE_INVALID_FLAG
FAIL: hline truncated, last mark col=52 width=82
```

52/82 = 63% of the axis width — the line stops well short of the right edge.

### Passing after (this branch)

```
test_axhline_spans_full_log_x: PASSED
test_axvline_spans_full_log_y: PASSED
All axhline/axvline log-span tests passed
```

Full gates:

```
make test             # ALL TESTS PASSED (fpm test)
make verify-artifacts # Artifact verification passed.
```

PNG renders of the issue reproducer confirm the dashed `axhline` now spans `1e-2 .. 20` (full width) and `axvline(0.5)` spans the full height on log axes; a linear `axhline`/`axvline` figure is unchanged.

An independent adversarial review confirmed the branch logic (one transform per data coord, zero on normalized), the two-block interaction, short-circuit safety, and linear-scale identity (no regression).
