### PR TITLE
docs: document fo as the primary build workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,22 @@ Self-contained Fortran plotting library. Backends: PNG (raster), PDF (vector), A
 
 ## Build, test, run
 
-- `make build` / `fpm build`
-- `make test` / `fpm test` (all tests)
-- `make test-ci` (fast CI subset)
-- `make example` (regenerates `output/example/...`)
-- `make verify-artifacts` (rendering gate: required for any change that touches plots, ticks, labels, or backends)
-- `make doc` (FORD → `build/doc/index.html`)
-- `make clean`
+Primary dev workflow is `fo` (cmake/ninja under the hood, hash-cached; avoids the
+flaky fpm parallel-build backend). Run it before every commit.
 
-`fpm test --target <name>` runs one test. `make test ARGS="--target test_public_api"` does the same via the Makefile.
+- `fo` — full pipeline: build, test, lint, fmt hint
+- `fo build` — build only (`--debug` adds `-g -O0 -fcheck=all -fbacktrace`)
+- `fo test <name>` — run one test target; `fo test --all` runs all
+- `fo check` — build + test, one-line status
+- `fo lint` / `fo fmt` (`fo fmt --check` to verify without editing)
+
+Make/fpm/CMake stay the CI and downstream build (do not remove):
+
+- `make build` / `fpm build`; `make test` / `fpm test` (all); `make test-ci` (fast CI subset)
+- `make verify-artifacts` — rendering gate; no `fo` equivalent, so use `make` here. Required for any change that touches plots, ticks, labels, or backends.
+- `make example` (regenerates `output/example/...`); `make doc` (FORD → `build/doc/index.html`); `make clean`
+
+`fo test <name>` or `fpm test --target <name>` runs one test.
 
 ## Conventions
 
@@ -53,7 +60,7 @@ GitHub Actions runs `make example` → copies outputs to `doc/media/examples/<ex
 
 ## Quality gates before claiming done
 
-1. `make build` succeeds.
-2. `make test` (or at least `make test-ci`) passes — no skipped or weakened tests.
+1. `fo build` (or `make build`) succeeds.
+2. `fo check` / `fo test --all` (or `make test`, at least `make test-ci`) passes — no skipped or weakened tests.
 3. For rendering changes: `make verify-artifacts` passes and the evidence is attached.
-4. No new file exceeds the size limits above.
+4. Changed Fortran is fmt-clean (`fo fmt --check`), and no new file exceeds the size limits above.

--- a/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_text_escape.f90
@@ -71,31 +71,31 @@ contains
 
         ! Math relations and operators in Adobe Symbol encoding
         select case (unicode_codepoint)
-        case (8733)  ! U+221D proportional
+        case (8733) ! U+221D proportional
             symbol_char = achar(92)//'265'
             return
-        case (8776)  ! U+2248 approxequal
+        case (8776) ! U+2248 approxequal
             symbol_char = achar(92)//'273'
             return
-        case (8764)  ! U+223C similar
+        case (8764) ! U+223C similar
             symbol_char = achar(92)//'176'
             return
-        case (8747)  ! U+222B integral
+        case (8747) ! U+222B integral
             symbol_char = achar(92)//'362'
             return
-        case (8711)  ! U+2207 nabla / gradient
+        case (8711) ! U+2207 nabla / gradient
             symbol_char = achar(92)//'321'
             return
-        case (8804)  ! U+2264 lessequal
+        case (8804) ! U+2264 lessequal
             symbol_char = achar(92)//'243'
             return
-        case (8805)  ! U+2265 greaterequal
+        case (8805) ! U+2265 greaterequal
             symbol_char = achar(92)//'263'
             return
-        case (8800)  ! U+2260 notequal
+        case (8800) ! U+2260 notequal
             symbol_char = achar(92)//'271'
             return
-        case (8801)  ! U+2261 equivalence
+        case (8801) ! U+2261 equivalence
             symbol_char = achar(92)//'272'
             return
         end select


### PR DESCRIPTION
## Summary

Documents `fo` as the primary build/test workflow for fortplot.

- Lead the "Build, test, run" and "Quality gates" sections of `CLAUDE.md` with `fo` (`fo build` / `fo test <name>` / `fo check` / `fo fmt`). `fo` wraps cmake/ninja with hash caching and avoids the flaky fpm parallel-build backend.
- Keep make/fpm/CMake documented for CI, the `make verify-artifacts` rendering gate (no `fo` equivalent), and downstream consumers. The user-facing `README.md` is left on make/fpm because external users do not have `fo`.
- Collapse the double space before the inline comments I added earlier in `fortplot_pdf_text_escape.f90` (the operator Symbol-code cases) to a single space, so `fo fmt --check` passes on that file.

## Verification

```
fo build                  # exit 0
fo fmt --check src/backends/vector/pdf/fortplot_pdf_text_escape.f90   # exit 0 (was: needs formatting)
```

`fo` itself is healthy on this repo: `fo build`, `fo test`, and `fo check` (`Build: OK ... Tests: pass`) all succeed, so no `fo` fix was required. Docs-only plus a whitespace-only comment change; no runtime behavior affected.
