### PR TITLE
cleanup: remove lint backlog

### DIFF
--- a/app/fortplot_render.f90
+++ b/app/fortplot_render.f90
@@ -15,7 +15,6 @@ program fortplot_render
     !!   mpl      - matplotlib look (default)
     !!   vegalite - Vega-Lite look
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_spec_types, only: spec_t
     use fortplot_spec_builder, only: spec_savefig
     use fortplot_spec_json_parse, only: json_to_spec, &

--- a/example/fortran/display_demo/display_demo.f90
+++ b/example/fortran/display_demo/display_demo.f90
@@ -9,7 +9,6 @@ program display_demo
     !!   make example ARGS="display_demo"
 
     use fortplot
-    use fortplot_errors, only: SUCCESS
     use iso_fortran_env, only: wp => real64
     implicit none
 

--- a/example/fortran/pcolormesh_demo/pcolormesh_demo.f90
+++ b/example/fortran/pcolormesh_demo/pcolormesh_demo.f90
@@ -2,7 +2,7 @@ program pcolormesh_demo
     !! Comprehensive demo of pcolormesh functionality
     !! Shows different colormap and data patterns
     use iso_fortran_env, only: wp => real64
-    use fortplot, only: figure_t, pcolormesh, savefig, figure, xlabel, ylabel, title
+    use fortplot, only: pcolormesh, savefig, figure, xlabel, ylabel, title
     implicit none
     
     call demo_basic_gradient()

--- a/example/fortran/subplot_demo/subplot_demo.f90
+++ b/example/fortran/subplot_demo/subplot_demo.f90
@@ -16,7 +16,7 @@ program subplot_demo
     !! - plot(), title(), xlabel(), ylabel() work within current subplot context
     !! - savefig() renders entire subplot grid to output file
 
-    use iso_fortran_env, only: real64, wp => real64
+    use iso_fortran_env, only: wp => real64
     use fortplot, only: figure, plot, xlabel, ylabel, title, suptitle, savefig, &
                         show, subplot
     implicit none

--- a/src/animation/fortplot_animation_core.f90
+++ b/src/animation/fortplot_animation_core.f90
@@ -1,11 +1,8 @@
 module fortplot_animation_core
-    use iso_fortran_env, only: real64, wp => real64
-    use iso_c_binding, only: c_char, c_int, c_null_char
+    use iso_fortran_env, only: wp => real64
     use fortplot_constants, only: MILLISECONDS_PER_SECOND
-    use fortplot_figure_core, only: figure_t, plot_data_t
+    use fortplot_figure_core, only: figure_t
     ! savefig is part of figure_t, not rendering module
-    use fortplot_pipe, only: open_ffmpeg_pipe, write_png_to_pipe, close_ffmpeg_pipe
-    use fortplot_utils, only: initialize_backend, ensure_directory_exists
     use fortplot_logging, only: log_error, log_info, log_warning
     implicit none
     private

--- a/src/animation/fortplot_animation_pipeline.f90
+++ b/src/animation/fortplot_animation_pipeline.f90
@@ -1,8 +1,12 @@
 module fortplot_animation_pipeline
-    use iso_fortran_env, only: real64, wp => real64
-    use fortplot_animation_core, only: animation_t, DEFAULT_FRAME_INTERVAL_MS, DEFAULT_ANIMATION_FPS, &
-        MIN_VALID_VIDEO_SIZE, MIN_EXPECTED_VIDEO_SIZE, MAX_FILENAME_LENGTH, &
-        MAX_RETRY_ATTEMPTS, BASE_RETRY_DELAY_MS
+    use iso_fortran_env, only: wp => real64
+    use fortplot_animation_core, only: animation_t, &
+                                       DEFAULT_ANIMATION_FPS, &
+                                       MIN_VALID_VIDEO_SIZE, &
+                                       MIN_EXPECTED_VIDEO_SIZE, &
+                                       MAX_FILENAME_LENGTH, &
+                                       MAX_RETRY_ATTEMPTS, &
+                                       BASE_RETRY_DELAY_MS
     use fortplot_constants, only: MILLISECONDS_PER_SECOND
     use fortplot_animation_rendering, only: render_frame_to_png
     use fortplot_animation_validation, only: validate_generated_video_enhanced

--- a/src/animation/fortplot_animation_rendering.f90
+++ b/src/animation/fortplot_animation_rendering.f90
@@ -1,7 +1,6 @@
 module fortplot_animation_rendering
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t, plot_data_t
-    use fortplot_utils, only: initialize_backend
     implicit none
     private
 

--- a/src/animation/fortplot_animation_validation.f90
+++ b/src/animation/fortplot_animation_validation.f90
@@ -1,8 +1,9 @@
 module fortplot_animation_validation
-    use iso_fortran_env, only: real64, wp => real64
-    use fortplot_animation_core, only: MIN_VALID_VIDEO_SIZE, MIN_EXPECTED_VIDEO_SIZE, &
-        MAX_FILENAME_LENGTH, MAX_RETRY_ATTEMPTS, BASE_RETRY_DELAY_MS
-    use fortplot_logging, only: log_error, log_info, log_warning
+    use fortplot_animation_core, only: MIN_VALID_VIDEO_SIZE, &
+                                       MAX_FILENAME_LENGTH, &
+                                       MAX_RETRY_ATTEMPTS, &
+                                       BASE_RETRY_DELAY_MS
+    use fortplot_logging, only: log_info, log_warning
     implicit none
     private
 

--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -133,15 +133,17 @@ contains
         type(ascii_context) :: ctx
         integer :: w, h
 
-        if (present(width) .and. width > 0) then
-            w = merge(max(80, min(120, nint(real(width, wp) / 10.0_wp))), width, width > 200)
-        else
-            w = 80
+        w = 80
+        if (present(width)) then
+            if (width > 0) then
+                w = merge(max(80, min(120, nint(real(width, wp) / 10.0_wp))), width, width > 200)
+            end if
         end if
-        if (present(height) .and. height > 0) then
-            h = merge(max(20, min(30, nint(real(height, wp) / 20.0_wp))), height, height > 60)
-        else
-            h = 24
+        h = 24
+        if (present(height)) then
+            if (height > 0) then
+                h = merge(max(20, min(30, nint(real(height, wp) / 20.0_wp))), height, height > 60)
+            end if
         end if
 
         call setup_canvas(ctx, w, h)

--- a/src/backends/ascii/fortplot_ascii_backend_ops.f90
+++ b/src/backends/ascii/fortplot_ascii_backend_ops.f90
@@ -5,7 +5,6 @@ module fortplot_ascii_backend_ops
     !!
     !! Author: fortplot contributors
 
-   use fortplot_context, only: plot_context
    use fortplot_plot_data, only: plot_data_t
    use fortplot_ascii_utils, only: text_element_t
    use fortplot_ascii_elements, only: draw_ascii_axes_and_labels

--- a/src/backends/ascii/fortplot_ascii_drawing.f90
+++ b/src/backends/ascii/fortplot_ascii_drawing.f90
@@ -8,7 +8,7 @@ module fortplot_ascii_drawing
 
     use fortplot_constants, only: EPSILON_COMPARE, ASCII_CHAR_ASPECT
     use fortplot_margins, only: plot_area_t
-    use fortplot_ascii_utils, only: get_char_density, ASCII_CHARS
+    use fortplot_ascii_utils, only: ASCII_CHARS
     use fortplot_ascii_utils, only: get_blend_char
     use fortplot_ascii_axis_policy, only: put_cell, glyph_layer, LAYER_EMPTY, &
                                           LAYER_GRID, LAYER_DATA, LAYER_AXIS, &

--- a/src/backends/ascii/fortplot_ascii_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_elements.f90
@@ -18,7 +18,6 @@ module fortplot_ascii_elements
     use fortplot_ascii_legend, only: reset_ascii_legend_lines_helper, append_ascii_legend_line_helper
     use fortplot_ascii_legend, only: register_legend_entry_helper, assign_pending_autopct_helper
     use fortplot_ascii_text, only: draw_ascii_axes_and_labels, ascii_draw_text_helper
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
     private

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -7,7 +7,7 @@ module fortplot_ascii_primitives
     !! Author: fortplot contributors
     
     use fortplot_margins, only: plot_area_t
-    use fortplot_ascii_utils, only: get_char_density, get_blend_char, ASCII_CHARS
+    use fortplot_ascii_utils, only: get_blend_char, ASCII_CHARS
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_text_color, only: pack_rgb
     use, intrinsic :: iso_fortran_env, only: wp => real64

--- a/src/backends/ascii/fortplot_ascii_text_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_text_elements.f90
@@ -43,8 +43,10 @@ contains
         ! Store text element for later rendering
         if (num_text_elements < size(text_elements)) then
             num_text_elements = num_text_elements + 1
-            use_plot_area = present(plot_area) .and. plot_area%width > 0 .and. &
-                            plot_area%height > 0
+            use_plot_area = .false.
+            if (present(plot_area)) then
+                use_plot_area = plot_area%width > 0 .and. plot_area%height > 0
+            end if
 
             ! Convert coordinates - check if already in screen coordinates
             screen_coords = x >= 1.0_wp .and. x <= real(plot_width, wp) .and. &

--- a/src/backends/ascii/legend/fortplot_ascii_legend.f90
+++ b/src/backends/ascii/legend/fortplot_ascii_legend.f90
@@ -10,7 +10,6 @@ module fortplot_ascii_legend
     use fortplot_legend, only: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT, &
                                LEGEND_EAST
     use fortplot_latex_parser, only: process_latex_in_text
-    use fortplot_ascii_utils, only: is_legend_entry_text, is_registered_legend_label, is_autopct_text
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     use fortplot_context, only: plot_context
     use, intrinsic :: iso_fortran_env, only: wp => real64

--- a/src/backends/ascii/legend/fortplot_ascii_legend_decode.f90
+++ b/src/backends/ascii/legend/fortplot_ascii_legend_decode.f90
@@ -5,7 +5,6 @@ submodule (fortplot_ascii_legend) fortplot_ascii_legend_decode
     !! Single Responsibility: Decode raw legend lines and implement
     !! the ASCII legend render interface.
 
-    use fortplot_ascii_utils, only: is_legend_entry_text, is_registered_legend_label, is_autopct_text
     use fortplot_ascii_mathtext, only: sanitize_ascii_text
     implicit none
 
@@ -27,15 +26,19 @@ contains
         trimmed_text = trim(adjustl(raw_text))
         if (len_trim(trimmed_text) == 0) return
 
-        if (len(trimmed_text) >= 3 .and. trimmed_text(1:3) == '-- ') then
-            if (len(trimmed_text) > 3) then
-                call sanitize_ascii_text(trim(adjustl(trimmed_text(4:))), sanitized, sanitized_len)
-                entry_label = trim(sanitized(1:sanitized_len))
-            else
-                entry_label = ''
+        if (len(trimmed_text) >= 3) then
+            if (trimmed_text(1:3) == '-- ') then
+                if (len(trimmed_text) > 3) then
+                    call sanitize_ascii_text(trim(adjustl(trimmed_text(4:))), sanitized, sanitized_len)
+                    entry_label = trim(sanitized(1:sanitized_len))
+                else
+                    entry_label = ''
+                end if
+                formatted_line = '  - '//trim(entry_label)
+                return
             end if
-            formatted_line = '  - '//trim(entry_label)
-        else
+        end if
+
             formatted_line = '  '//trim(trimmed_text)
             first_space = index(trimmed_text, ' ')
             if (first_space > 0 .and. first_space < len(trimmed_text)) then
@@ -45,7 +48,6 @@ contains
                 call sanitize_ascii_text(trim(trimmed_text), sanitized, sanitized_len)
                 entry_label = trim(sanitized(1:sanitized_len))
             end if
-        end if
     end subroutine decode_ascii_legend_line
 
     module subroutine ascii_render_legend_impl(legend, legend_lines, num_legend_lines, raw_labels)

--- a/src/backends/memory/fortplot_contour_rendering.f90
+++ b/src/backends/memory/fortplot_contour_rendering.f90
@@ -9,8 +9,6 @@ module fortplot_contour_rendering
     use fortplot_context, only: plot_context
     use fortplot_scales, only: apply_scale_transform
     use fortplot_colormap, only: colormap_value_to_color
-    use fortplot_contour_algorithms, only: calculate_marching_squares_config, &
-                                           get_contour_lines, smooth_contour_chain
     use fortplot_plot_data, only: plot_data_t
     use fortplot_contour_level_calculation, only: compute_default_contour_levels
     use fortplot_contour_tracing, only: trace_contour_level

--- a/src/backends/memory/fortplot_line_rendering.f90
+++ b/src/backends/memory/fortplot_line_rendering.f90
@@ -10,7 +10,6 @@ module fortplot_line_rendering
     use fortplot_scales, only: apply_scale_transform
     use fortplot_utils
     use fortplot_plot_data
-    use fortplot_coordinate_validation, only: validate_coordinate_arrays
     implicit none
     
     private

--- a/src/backends/memory/fortplot_rendering.f90
+++ b/src/backends/memory/fortplot_rendering.f90
@@ -4,7 +4,6 @@ module fortplot_rendering
     !! This module orchestrates the rendering pipeline by delegating to
     !! specialized rendering modules for different plot types. (no pre-transform exports)
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_line_rendering
     use fortplot_marker_rendering
     use fortplot_contour_rendering

--- a/src/backends/raster/fortplot_png.f90
+++ b/src/backends/raster/fortplot_png.f90
@@ -4,7 +4,7 @@ module fortplot_png
                                raster_draw_axes_and_labels, raster_render_ylabel
     use fortplot_zlib_core, only: zlib_compress_into, crc32_calculate
     use fortplot_logging, only: log_error, log_info
-    use, intrinsic :: iso_fortran_env, only: wp => real64, int8, int32
+    use, intrinsic :: iso_fortran_env, only: wp => real64, int8
     implicit none
 
     private

--- a/src/backends/raster/fortplot_png_encoder.f90
+++ b/src/backends/raster/fortplot_png_encoder.f90
@@ -1,5 +1,4 @@
 module fortplot_png_encoder
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
     private

--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -9,30 +9,31 @@ module fortplot_raster
 
     use iso_c_binding
     use fortplot_context, only: plot_context, setup_canvas
-    use fortplot_constants, only: EPSILON_COMPARE, REFERENCE_DPI
+    use fortplot_constants, only: REFERENCE_DPI
     use fortplot_bitmap, only: composite_bitmap_to_raster_0, get_text_bitmap_metrics, &
                                render_text_to_bitmap_with_size, &
                                rotate_bitmap_about_anchor
-    use fortplot_text, only: calculate_text_width, calculate_text_width_with_size, &
-                             calculate_text_height
+    use fortplot_text, only: calculate_text_width_with_size
     use fortplot_text_rendering, only: render_text_to_image, render_text_with_size
     use fortplot_text_helpers, only: prepare_text_for_raster
     use fortplot_logging, only: log_error
-    use fortplot_errors, only: fortplot_error_t, ERROR_INTERNAL
     use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
     use fortplot_markers, only: get_marker_size, marker_size_scale, &
                                 MARKER_CIRCLE, MARKER_SQUARE, &
                                 MARKER_DIAMOND, MARKER_CROSS
-    use fortplot_raster_drawing, only: draw_line_distance_aa, blend_pixel, &
+    use fortplot_raster_drawing, only: draw_line_distance_aa, &
                                        distance_point_to_line_segment, &
-                                       ipart, fpart, rfpart, color_to_byte, &
+                                       ipart, &
+                                       fpart, &
+                                       rfpart, &
+                                       color_to_byte, &
                                        draw_circle_antialiased, &
                                        draw_circle_outline_antialiased, &
                                        draw_circle_with_edge_face, &
                                        draw_square_with_edge_face, &
-                                       draw_diamond_with_edge_face, draw_x_marker
-    use fortplot_raster_line_styles, only: draw_styled_line, reset_pattern_distance, &
-                                           set_raster_line_style
+                                       draw_diamond_with_edge_face, &
+                                       draw_x_marker
+    use fortplot_raster_line_styles, only: draw_styled_line
     use fortplot_raster_core, only: raster_image_t, create_raster_image, &
                                     destroy_raster_image, pt2px, scale_px
     use fortplot_raster_axes, only: raster_draw_axes_and_labels, raster_render_ylabel, &

--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -23,11 +23,6 @@ module fortplot_raster_axes
                                             raster_draw_x_axis_tick_labels_only_wrapper, &
                                             raster_draw_y_axis_tick_labels_only_wrapper
     use fortplot_scales, only: apply_scale_transform
-    use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
-                                         format_tick_value_consistent
-    use fortplot_text, only: calculate_text_width
-    use fortplot_text_rendering, only: render_text_to_image
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 

--- a/src/backends/raster/fortplot_raster_axes_secondary.f90
+++ b/src/backends/raster/fortplot_raster_axes_secondary.f90
@@ -8,7 +8,6 @@ module fortplot_raster_axes_secondary
         raster_draw_x_axis_ticks_top
     use fortplot_raster_labels, only: raster_render_ylabel_right, &
                                        raster_draw_top_xlabel
-    use fortplot_scales, only: apply_scale_transform
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
     use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
                                          format_tick_value_consistent

--- a/src/backends/raster/fortplot_raster_context_impl.f90
+++ b/src/backends/raster/fortplot_raster_context_impl.f90
@@ -9,7 +9,7 @@ submodule (fortplot_raster) fortplot_raster_context_impl
 
 contains
 
-    !! ── Context wrapper methods (delegate to specialized modules) ──────
+    !! Context wrapper methods (delegate to specialized modules)
 
     module subroutine raster_save_dummy(this, filename)
         !! Dummy save method - see issue #496 for implementation improvement roadmap
@@ -254,7 +254,7 @@ contains
                                           view_y_max=this%y_max)
     end subroutine raster_draw_axis_labels_only_context
 
-    !! ── Coordinate management ──────────────────────────────────────────
+    !! Coordinate management
 
     module subroutine raster_save_coordinates(this, x_min, x_max, y_min, y_max)
         !! Save current coordinate system

--- a/src/backends/raster/fortplot_raster_impl.f90
+++ b/src/backends/raster/fortplot_raster_impl.f90
@@ -7,7 +7,7 @@ submodule (fortplot_raster) fortplot_raster_impl
 
 contains
 
-    !! ── Drawing primitives ─────────────────────────────────────────────
+    !! Drawing primitives
 
     module subroutine raster_draw_line(this, x1, y1, x2, y2)
         use fortplot_line_styles, only: scale_pattern_to_pixels, get_pattern_length
@@ -78,7 +78,7 @@ contains
         call this%raster%set_line_style(style)
     end subroutine raster_set_line_style_context
 
-    !! ── Marker drawing ─────────────────────────────────────────────────
+    !! Marker drawing
 
     module subroutine raster_draw_marker(this, x, y, style, size)
         class(raster_context), intent(inout) :: this
@@ -197,7 +197,7 @@ contains
         this%raster%marker_face_alpha = face_alpha
     end subroutine raster_set_marker_colors_with_alpha
 
-    !! ── Arrow drawing ──────────────────────────────────────────────────
+    !! Arrow drawing
 
     module subroutine raster_draw_arrow(this, x, y, dx, dy, size, style)
         !! Draw arrow head for streamplot arrows in raster backend

--- a/src/backends/raster/fortplot_raster_markers.f90
+++ b/src/backends/raster/fortplot_raster_markers.f90
@@ -9,12 +9,9 @@ module fortplot_raster_markers
     !! as the primitive drawing functions to ensure perfect alignment with lines.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: EPSILON_GEOMETRY, EPSILON_COMPARE
     use fortplot_raster_primitives, only: blend_pixel, draw_line_distance_aa, &
                                           draw_filled_quad_raster, &
                                           draw_filled_quad_raster_alpha
-    use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, &
-                                MARKER_DIAMOND, MARKER_CROSS
     implicit none
 
     private

--- a/src/backends/raster/fortplot_raster_text_impl.f90
+++ b/src/backends/raster/fortplot_raster_text_impl.f90
@@ -4,7 +4,7 @@ submodule (fortplot_raster) fortplot_raster_text_impl
 
 contains
 
-    !! ── Text rendering ─────────────────────────────────────────────────
+    !! Text rendering
 
     module subroutine raster_draw_text(this, x, y, text)
         class(raster_context), intent(inout) :: this
@@ -235,6 +235,8 @@ contains
         integer :: baseline_y
         logical :: have_metrics
 
+        associate (unused_ha => ha, unused_va => va)
+        end associate
         text_w = calculate_text_width_with_size(trim(text), pixel_height)
         text_h = max(1, int(pixel_height))
         ascent_px = 0.0_wp
@@ -290,7 +292,7 @@ contains
                                           rot_w, rot_h, x0, y0)
     end subroutine raster_draw_rotated_text_with_bbox
 
-    !! ── Utility methods ────────────────────────────────────────────────
+    !! Utility methods
 
     module function raster_get_ascii_output(this) result(output)
         !! Get ASCII output (not applicable for raster backend)

--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -4,7 +4,7 @@ module fortplot_raster_ticks
     use fortplot_constants, only: TICK_MARK_LENGTH, X_TICK_LABEL_PAD, &
                                   Y_TICK_LABEL_RIGHT_PAD, Y_TICK_LABEL_LEFT_PAD, &
                                   X_TICK_LABEL_TOP_PAD
-    use fortplot_text_rendering, only: render_text_to_image, render_text_with_size, &
+    use fortplot_text_rendering, only: render_text_with_size, &
                                        calculate_text_width, &
                                        calculate_text_width_with_size, &
                                        calculate_text_height, &

--- a/src/backends/raster/fortplot_raster_ticks_secondary.f90
+++ b/src/backends/raster/fortplot_raster_ticks_secondary.f90
@@ -1,8 +1,9 @@
 module fortplot_raster_ticks_secondary
     !! Secondary axis ticks (right/top) and minor ticks for raster backend
     !! Extracted from fortplot_raster_ticks for size compliance (refs #1694)
-    use fortplot_constants, only: TICK_MARK_LENGTH, X_TICK_LABEL_PAD, &
-                                  Y_TICK_LABEL_RIGHT_PAD, Y_TICK_LABEL_LEFT_PAD, &
+    use fortplot_constants, only: TICK_MARK_LENGTH, &
+                                  Y_TICK_LABEL_RIGHT_PAD, &
+                                  Y_TICK_LABEL_LEFT_PAD, &
                                   X_TICK_LABEL_TOP_PAD
     use fortplot_text_rendering, only: render_text_with_size, &
                                        calculate_text_width, &
@@ -11,8 +12,7 @@ module fortplot_raster_ticks_secondary
                                        calculate_text_height_with_size, &
                                        DEFAULT_FONT_SIZE
     use fortplot_text_helpers, only: prepare_text_for_raster
-    use fortplot_constants, only: REFERENCE_DPI, FALLBACK_LABEL_HEIGHT_PX, &
-                                  MIN_TICK_LABEL_GAP_PX
+    use fortplot_constants, only: FALLBACK_LABEL_HEIGHT_PX
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_line_styles, only: draw_styled_line
     use fortplot_raster_core, only: raster_image_t, scale_px, pt2px

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -14,9 +14,8 @@ module fortplot_pdf
 
     use fortplot_context, only: plot_context, setup_canvas
     use fortplot_plot_data, only: plot_data_t
-    use fortplot_latex_parser, only: process_latex_in_text
-    use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_constants, only: EPSILON_COMPARE, REFERENCE_DPI
+    use fortplot_margins, only: plot_margins_t, plot_area_t
+    use fortplot_constants, only: REFERENCE_DPI
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_colormap, only: colormap_value_to_color
     use fortplot_logging, only: log_error, log_info

--- a/src/backends/vector/fortplot_pdf_io.f90
+++ b/src/backends/vector/fortplot_pdf_io.f90
@@ -2,7 +2,7 @@ module fortplot_pdf_io
     !! PDF file I/O operations
     !! Handles PDF document structure, writing, and file management
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64, int8, int64
+    use, intrinsic :: iso_fortran_env, only: int64
     use fortplot_pdf_core, only: pdf_context_core
     use fortplot_pdf_objects, only: &
         write_info_object, write_catalog_object, write_pages_object, &

--- a/src/backends/vector/pdf/fortplot_pdf_axes.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes.f90
@@ -7,24 +7,11 @@ module fortplot_pdf_axes
     !! - fortplot_pdf_axes_text: title/label text rendering with mathtext
 
     use iso_fortran_env, only: wp => real64
-    use fortplot_pdf_core, only: pdf_context_core, PDF_MARGIN, &
-                                 PDF_TICK_SIZE, PDF_LABEL_SIZE, &
-                                 PDF_TICK_LABEL_SIZE, PDF_TITLE_SIZE
-    use fortplot_constants, only: XLABEL_VERTICAL_OFFSET
-    use fortplot_pdf_drawing, only: pdf_stream_writer
-    use fortplot_pdf_text, only: draw_pdf_text, draw_pdf_text_bold, &
-                                 draw_mixed_font_text, draw_rotated_mixed_font_text, &
-                                 draw_pdf_mathtext, estimate_pdf_text_width
-    use fortplot_text_helpers, only: prepare_mathtext_if_needed
-    use fortplot_text_layout, only: has_mathtext, preprocess_math_text
-    use fortplot_latex_parser, only: process_latex_in_text
-    use fortplot_mathtext, only: mathtext_element_t, parse_mathtext
-    use fortplot_pdf_mathtext_render, only: render_mathtext_element_pdf
-    use fortplot_unicode, only: utf8_char_length, utf8_to_codepoint
-    use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
-                                         format_tick_value_consistent
-    use fortplot_scales, only: apply_scale_transform
+    use fortplot_pdf_core, only: pdf_context_core, &
+                                 PDF_TICK_SIZE, &
+                                 PDF_LABEL_SIZE, &
+                                 PDF_TICK_LABEL_SIZE, &
+                                 PDF_TITLE_SIZE
     ! Sub-modules
     use fortplot_pdf_axes_tick_data, only: initialize_tick_arrays, &
                                            generate_x_axis_ticks, &

--- a/src/backends/vector/pdf/fortplot_pdf_axes_drawing.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_drawing.f90
@@ -5,13 +5,12 @@ module fortplot_pdf_axes_drawing
     !! Depends on fortplot_pdf_axes_tick_data for tick data generation.
 
     use iso_fortran_env, only: wp => real64
-    use fortplot_pdf_core, only: pdf_context_core, PDF_MARGIN, &
-                                 PDF_TICK_SIZE, PDF_LABEL_SIZE, &
-                                 PDF_TICK_LABEL_SIZE, PDF_TITLE_SIZE, &
+    use fortplot_pdf_core, only: pdf_context_core, &
+                                 PDF_TICK_SIZE, &
+                                 PDF_LABEL_SIZE, &
+                                 PDF_TICK_LABEL_SIZE, &
+                                 PDF_TITLE_SIZE, &
                                  PDF_Y_TICK_LABEL_PAD
-    use fortplot_pdf_axes_tick_data, only: initialize_tick_arrays, &
-                                           generate_x_axis_ticks, &
-                                           generate_y_axis_ticks
     use fortplot_pdf_text, only: estimate_pdf_text_width
     use fortplot_pdf_axes_text, only: render_mixed_text
     implicit none

--- a/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_axes_text.f90
@@ -7,14 +7,14 @@ module fortplot_pdf_axes_text
     use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE, PDF_TITLE_SIZE, &
                                  PDF_TICK_LABEL_SIZE, PDF_Y_TICK_LABEL_PAD
     use fortplot_constants, only: AXIS_LABEL_PAD_PT
-    use fortplot_pdf_text, only: draw_pdf_text, draw_pdf_text_bold, &
-                                 draw_mixed_font_text, draw_rotated_mixed_font_text, &
-                                 draw_pdf_mathtext, estimate_pdf_text_width
+    use fortplot_pdf_text, only: draw_mixed_font_text, &
+                                 draw_rotated_mixed_font_text, &
+                                 draw_pdf_mathtext, &
+                                 estimate_pdf_text_width
     use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_text_layout, only: has_mathtext, preprocess_math_text
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_mathtext, only: mathtext_element_t, parse_mathtext
-    use fortplot_pdf_mathtext_render, only: render_mathtext_element_pdf
     use fortplot_unicode, only: utf8_char_length, utf8_to_codepoint
     implicit none
     private

--- a/src/backends/vector/pdf/fortplot_pdf_coordinate.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_coordinate.f90
@@ -4,13 +4,7 @@ module fortplot_pdf_coordinate
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_pdf_core, only: pdf_context_core
-    use fortplot_pdf_text, only: draw_mixed_font_text, draw_rotated_mixed_font_text, &
-                                 draw_pdf_mathtext
-    use fortplot_latex_parser, only: process_latex_in_text
-    use fortplot_pdf_drawing, only: draw_pdf_arrow, draw_pdf_circle_with_outline, &
-                                    draw_pdf_square_with_outline, &
-                                    draw_pdf_diamond_with_outline, &
-                                    draw_pdf_x_marker
+    use fortplot_pdf_text, only: draw_rotated_mixed_font_text
     use fortplot_plot_data, only: plot_data_t
     use fortplot_margins, only: plot_area_t, plot_margins_t
     implicit none

--- a/src/backends/vector/pdf/fortplot_pdf_drawing.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_drawing.f90
@@ -8,9 +8,7 @@ module fortplot_pdf_drawing
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use, intrinsic :: ieee_arithmetic, only: ieee_is_nan, ieee_is_finite
-    use fortplot_vector, only: vector_stream_writer, vector_graphics_state
-    use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, &
-                                MARKER_DIAMOND, MARKER_CROSS
+    use fortplot_vector, only: vector_stream_writer
     use fortplot_logging, only: log_debug
     implicit none
 

--- a/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
+++ b/src/backends/vector/pdf/fortplot_pdf_mathtext_render.f90
@@ -5,7 +5,6 @@ module fortplot_pdf_mathtext_render
     use fortplot_mathtext, only: mathtext_element_t, parse_mathtext, ELEMENT_SQRT
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE
-    use fortplot_pdf_text_render, only: draw_mixed_font_text
     use fortplot_pdf_text_segments, only: render_mixed_font_at_position, &
                                           switch_to_helvetica_font, &
                                           switch_to_symbol_font

--- a/src/core/fortplot_margins.f90
+++ b/src/core/fortplot_margins.f90
@@ -7,8 +7,6 @@ module fortplot_margins
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_ticks, only: calculate_tick_labels, format_tick_value, calculate_nice_axis_limits
-    use fortplot_ticks, only: calculate_tick_labels_log, calculate_tick_labels_symlog
     implicit none
     
     private

--- a/src/core/fortplot_projection.f90
+++ b/src/core/fortplot_projection.f90
@@ -57,6 +57,8 @@ contains
         real(wp) :: planar
         integer :: i, n
 
+        associate (unused_dist => dist)
+        end associate
         n = size(x3d)
 
         ! Calculate trig functions

--- a/src/documentation/fortplot_doc_processing.f90
+++ b/src/documentation/fortplot_doc_processing.f90
@@ -10,15 +10,16 @@ module fortplot_doc_processing
                                       EXAMPLES_INDEX_PATH, INDEX_START_MARKER, &
                                       INDEX_END_MARKER, FALLBACK_COUNT, &
                                       FALLBACK_EXAMPLES
-    use fortplot_doc_utils, only: build_file_path, check_file_exists, &
-                                  get_file_extension, lowercase_string, &
-                                  replace_extension, title_case, &
-                                  build_readme_path, build_output_path, &
-                                  build_fortran_url, build_local_fortran_path, &
-                                  get_output_title, get_fortran_filename, &
+    use fortplot_doc_utils, only: lowercase_string, &
+                                  replace_extension, &
+                                  title_case, &
+                                  build_readme_path, &
+                                  build_output_path, &
+                                  build_fortran_url, &
+                                  build_local_fortran_path, &
+                                  get_output_title, &
+                                  get_fortran_filename, &
                                   get_example_run_target
-    use fortplot_directory_listing, only: list_directory_entries
-    use fortplot_logging, only: log_warning
     use fortplot_doc_output, only: write_output_section, scan_directory_for_media
     implicit none
     private
@@ -160,8 +161,8 @@ contains
         work = trim(link)
         if (len_trim(work) == 0) return
 
-        if (len(work) >= 2 .and. work(1:2) == './') then
-            work = work(3:)
+        if (len(work) >= 2) then
+            if (work(1:2) == './') work = work(3:)
         end if
 
         pos = index(work, '/example/fortran/')

--- a/src/documentation/fortplot_documentation.f90
+++ b/src/documentation/fortplot_documentation.f90
@@ -12,10 +12,14 @@ module fortplot_documentation
         util_build_local_fortran_path => build_local_fortran_path, &
         util_get_fortran_filename => get_fortran_filename, &
         util_get_example_run_target => get_example_run_target
-    use fortplot_doc_constants, only: PATH_MAX_LEN, FILENAME_MAX_LEN, LINE_MAX_LEN, &
-                                      MAX_EXAMPLES, MAX_MEDIA_FILES, &
-                                      VIDEO_WIDTH, VIDEO_HEIGHT, &
-                                      GITHUB_BASE_URL, OUTPUT_BASE_DIR
+    use fortplot_doc_constants, only: PATH_MAX_LEN, &
+                                      LINE_MAX_LEN, &
+                                      MAX_EXAMPLES, &
+                                      MAX_MEDIA_FILES, &
+                                      VIDEO_WIDTH, &
+                                      VIDEO_HEIGHT, &
+                                      GITHUB_BASE_URL, &
+                                      OUTPUT_BASE_DIR
     use fortplot_doc_processing, only: get_example_count, get_example_dir, &
                                        get_example_name, process_example
     use fortplot_doc_output, only: write_generated_outputs, scan_directory_for_media

--- a/src/external/fortplot_zlib_checksums.f90
+++ b/src/external/fortplot_zlib_checksums.f90
@@ -4,7 +4,7 @@ module fortplot_zlib_checksums
     !! Extracted from fortplot_zlib_compress for size compliance (Issue #1694).
 
     use, intrinsic :: iso_fortran_env, only: int8, int32
-    use fortplot_logging, only: log_debug, set_log_level, LOG_LEVEL_DEBUG
+    use fortplot_logging, only: set_log_level, LOG_LEVEL_DEBUG
     use fortplot_string_utils, only: parse_boolean_env
     implicit none
 

--- a/src/external/fortplot_zlib_compress.f90
+++ b/src/external/fortplot_zlib_compress.f90
@@ -2,7 +2,6 @@ module fortplot_zlib_compress
     !! Deflate compression, CRC32, and Adler-32 checksum implementation
     !! Extracted from fortplot_zlib_core for size compliance (Issue #1747)
     use, intrinsic :: iso_fortran_env, only: int8, int32
-    use iso_c_binding, only: c_ptr, c_loc, c_f_pointer, c_associated
     use fortplot_zlib_checksums, only: crc32_calculate, calculate_adler32, &
                                        initialize_zlib_debug
     implicit none

--- a/src/external/fortplot_zlib_decompress.f90
+++ b/src/external/fortplot_zlib_decompress.f90
@@ -5,9 +5,8 @@ module fortplot_zlib_decompress
     !! Compression functions live in fortplot_zlib_compress.
 
     use, intrinsic :: iso_fortran_env, only: int8, int32
-    use iso_c_binding, only: c_ptr, c_loc, c_f_pointer, c_associated
     use fortplot_zlib_compress, only: init_fixed_huffman_tables, bit_reverse
-    use fortplot_zlib_checksums, only: crc32_calculate, calculate_adler32
+    use fortplot_zlib_checksums, only: calculate_adler32
     implicit none
 
     private

--- a/src/figures/core/fortplot_figure_core_config.f90
+++ b/src/figures/core/fortplot_figure_core_config.f90
@@ -12,7 +12,7 @@ module fortplot_figure_core_config
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_initialization
     use fortplot_figure_grid
-    use fortplot_plot_data, only: AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_configuration, only: set_figure_labels, set_figure_scales, set_figure_limits
     use fortplot_string_utils, only: to_lowercase
     use fortplot_logging, only: log_warning

--- a/src/figures/core/fortplot_figure_core_impl_layout.f90
+++ b/src/figures/core/fortplot_figure_core_impl_layout.f90
@@ -13,7 +13,7 @@ submodule(fortplot_figure_core) fortplot_figure_core_impl_layout
 
 contains
 
-    !! ── Twin axis operations ──────────────────────────────────────────
+    !! Twin axis operations
 
     module subroutine twinx(self)
         class(figure_t), intent(inout) :: self
@@ -96,7 +96,7 @@ contains
         end select
     end function get_active_axis
 
-    !! ── Subplot operations ────────────────────────────────────────────
+    !! Subplot operations
 
     module subroutine subplots(self, nrows, ncols)
         class(figure_t), intent(inout) :: self
@@ -354,7 +354,7 @@ contains
         ok = .true.
     end subroutine begin_subplot_call
 
-    !! ── Reference line operations ─────────────────────────────────────
+    !! Reference line operations
 
     module subroutine axhline(self, y, xmin, xmax, color, linestyle, linewidth, label)
         class(figure_t), intent(inout) :: self
@@ -398,7 +398,7 @@ contains
                           ymin, ymax, colors, linestyles, linewidth, label)
     end subroutine vlines
 
-    !! ── Tick operations ───────────────────────────────────────────────
+    !! Tick operations
 
     module subroutine set_minor_ticks(self, x, y)
         class(figure_t), intent(inout) :: self
@@ -426,7 +426,7 @@ contains
         self%state%rendered = .false.
     end subroutine minorticks_on
 
-    !! ── Aspect ratio ──────────────────────────────────────────────────
+    !! Aspect ratio
 
     module subroutine set_aspect_str(self, aspect)
         class(figure_t), intent(inout) :: self
@@ -459,7 +459,7 @@ contains
         self%state%rendered = .false.
     end subroutine set_aspect_num
 
-    !! ── Layout ────────────────────────────────────────────────────────
+    !! Layout
 
     module subroutine tight_layout(self, pad, w_pad, h_pad)
         class(figure_t), intent(inout) :: self

--- a/src/figures/core/fortplot_figure_core_impl_plots.f90
+++ b/src/figures/core/fortplot_figure_core_impl_plots.f90
@@ -11,7 +11,7 @@ submodule(fortplot_figure_core) fortplot_figure_core_impl_plots
 
 contains
 
-    !! ── Initialization ────────────────────────────────────────────────
+    !! Initialization
 
     module subroutine initialize(self, width, height, backend, dpi)
         class(figure_t), intent(inout) :: self
@@ -26,7 +26,7 @@ contains
                               self%plot_count, width, height, backend, dpi)
     end subroutine initialize
 
-    !! ── Basic plot operations ─────────────────────────────────────────
+    !! Basic plot operations
 
     module subroutine add_plot_real(self, x, y, label, linestyle, color, alpha)
         class(figure_t), intent(inout) :: self
@@ -145,7 +145,7 @@ contains
                                   colormap=colormap)
     end subroutine add_pcolormesh
 
-    !! ── Specialized plot operations ───────────────────────────────────
+    !! Specialized plot operations
 
     module subroutine streamplot(self, x, y, u, v, density, color, &
                                   linewidth, rtol, &
@@ -202,20 +202,19 @@ contains
         real(wp) :: color_rgb(3)
         logical :: has_color
 
-        if (present(color) .and. len_trim(color) > 0) then
-            call resolve_color_string_or_rgb(color_str=color, context='hist', &
-                                             rgb_out=color_rgb, has_color=has_color)
-            if (has_color) then
-                call core_hist(self%plots, self%state, self%plot_count, data, bins, &
-                               density, label, color_rgb, range=range, weights=weights, &
-                               cumulative=cumulative, orientation=orientation, &
-                               alpha=alpha)
-            else
-                call core_hist(self%plots, self%state, self%plot_count, data, bins, &
-                               density, label, range=range, weights=weights, &
-                               cumulative=cumulative, orientation=orientation, &
-                               alpha=alpha)
+        has_color = .false.
+        if (present(color)) then
+            if (len_trim(color) > 0) then
+                call resolve_color_string_or_rgb(color_str=color, context='hist', &
+                                                 rgb_out=color_rgb, has_color=has_color)
             end if
+        end if
+
+        if (has_color) then
+            call core_hist(self%plots, self%state, self%plot_count, data, bins, &
+                           density, label, color_rgb, range=range, weights=weights, &
+                           cumulative=cumulative, orientation=orientation, &
+                           alpha=alpha)
         else
             call core_hist(self%plots, self%state, self%plot_count, data, bins, &
                            density, label, range=range, weights=weights, &

--- a/src/figures/core/fortplot_figure_core_impl_state.f90
+++ b/src/figures/core/fortplot_figure_core_impl_state.f90
@@ -11,7 +11,7 @@ submodule(fortplot_figure_core) fortplot_figure_core_impl_state
 
 contains
 
-    !! ── State management ──────────────────────────────────────────────
+    !! State management
 
     module subroutine grid(self, enabled, which, axis, alpha, linestyle)
         class(figure_t), intent(inout) :: self
@@ -124,7 +124,7 @@ contains
                           self%title, self%xlabel, self%ylabel)
     end subroutine destroy
 
-    !! ── Property accessors ────────────────────────────────────────────
+    !! Property accessors
 
     module function get_width(self) result(width)
         class(figure_t), intent(in) :: self
@@ -181,7 +181,7 @@ contains
         self%state%rendered = .false.
     end subroutine set_dpi
 
-    !! ── Animation support ─────────────────────────────────────────────
+    !! Animation support
 
     module subroutine setup_png_backend_for_animation(self)
         class(figure_t), intent(inout) :: self
@@ -209,7 +209,7 @@ contains
                                                    self%state%rendered)
     end subroutine extract_png_data_for_animation
 
-    !! ── Backend operations ────────────────────────────────────────────
+    !! Backend operations
 
     module subroutine backend_color(self, r, g, b)
         class(figure_t), intent(inout) :: self
@@ -250,7 +250,7 @@ contains
         if (had_arrows) self%state%rendered = .false.
     end subroutine clear_backend_arrows
 
-    !! ── Range accessors ───────────────────────────────────────────────
+    !! Range accessors
 
     module function get_x_min(self) result(x_min)
         class(figure_t), intent(in) :: self

--- a/src/figures/core/fortplot_figure_core_io.f90
+++ b/src/figures/core/fortplot_figure_core_io.f90
@@ -9,13 +9,12 @@ module fortplot_figure_core_io
     !! - Single Responsibility Principle compliance
     !! - Clean separation from plot management
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_utils, only: get_backend_from_filename
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_figure_configuration, only: setup_figure_backend, &
         set_figure_labels, set_figure_scales
-    use fortplot_errors, only: SUCCESS, ERROR_FILE_IO, is_error
-    use fortplot_logging, only: log_error, log_warning
+    use fortplot_errors, only: SUCCESS, ERROR_FILE_IO
+    use fortplot_logging, only: log_error
     use fortplot_png, only: png_context
     use fortplot_pdf, only: pdf_context
     use fortplot_ascii, only: ascii_context
@@ -23,7 +22,7 @@ module fortplot_figure_core_io
     use fortplot_svg, only: svg_context
     use fortplot_figure_render_engine, only: figure_render
     use fortplot_figure_io, only: save_backend_with_status
-    use fortplot_figure_utilities, only: is_interactive_environment, wait_for_user_input
+    use fortplot_figure_utilities, only: wait_for_user_input
     use fortplot_plot_data, only: plot_data_t, subplot_data_t
     implicit none
 

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -21,9 +21,6 @@ module fortplot_figure_core
                                   AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t, ensure_figure_storage
     use fortplot_figure_plot_management, only: next_plot_color, next_patch_color
-    use fortplot_figure_properties, only: figure_backend_color, &
-                                          figure_backend_associated, &
-                                          figure_backend_line
     use fortplot_figure_reflines, only: core_axhline, core_axvline, &
                                         core_hlines, core_vlines
     use fortplot_string_utils, only: to_lowercase

--- a/src/figures/core/fortplot_figure_core_operations.f90
+++ b/src/figures/core/fortplot_figure_core_operations.f90
@@ -17,7 +17,7 @@ module fortplot_figure_core_operations
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_annotations, only: text_annotation_t
-    use fortplot_plot_data, only: plot_data_t, arrow_data_t, subplot_data_t
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t
     use fortplot_figure_initialization, only: figure_state_t, ensure_figure_storage
     use fortplot_figure_operations
     use fortplot_figure_management

--- a/src/figures/core/fortplot_figure_core_ranges.f90
+++ b/src/figures/core/fortplot_figure_core_ranges.f90
@@ -11,8 +11,7 @@ module fortplot_figure_core_ranges
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_plot_data, only: plot_data_t, arrow_data_t, &
-                                   AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_rendering_pipeline, only: calculate_figure_data_ranges
     use fortplot_figure_boxplot, only: update_boxplot_ranges
     implicit none
@@ -135,16 +134,20 @@ contains
         real(wp) :: x_min_new, x_max_new, y_min_new, y_max_new
 
         ! Safety check: ensure pcolormesh arrays are allocated before accessing
-        if (.not. allocated(plots(plot_count)%pcolormesh_data%x_vertices) .or. &
-            .not. allocated(plots(plot_count)%pcolormesh_data%y_vertices)) then
+        if (.not. allocated(plots(plot_count)%pcolormesh_data%x_vertices)) then
+            return
+        end if
+        if (.not. allocated(plots(plot_count)%pcolormesh_data%y_vertices)) then
             ! Arrays not allocated - pcolormesh initialization failed
             ! Skip data range update to prevent segfault
             return
         end if
 
         ! Additional safety: check arrays have valid size
-        if (size(plots(plot_count)%pcolormesh_data%x_vertices) == 0 .or. &
-            size(plots(plot_count)%pcolormesh_data%y_vertices) == 0) then
+        if (size(plots(plot_count)%pcolormesh_data%x_vertices) == 0) then
+            return
+        end if
+        if (size(plots(plot_count)%pcolormesh_data%y_vertices) == 0) then
             ! Zero-size arrays - skip data range update
             return
         end if

--- a/src/figures/fortplot_figure_accessors.f90
+++ b/src/figures/fortplot_figure_accessors.f90
@@ -5,7 +5,6 @@ module fortplot_figure_accessors
     !! to meet QADS size limits.
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_context, only: plot_context
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_figure_configuration, only: setup_figure_backend
     use fortplot_plot_data, only: plot_data_t

--- a/src/figures/fortplot_figure_grid.f90
+++ b/src/figures/fortplot_figure_grid.f90
@@ -78,7 +78,6 @@ contains
                                 grid_color_hex, &
                                 sticky_x_min, sticky_x_max, sticky_y_min, sticky_y_max)
         !! Render grid lines on the figure
-        use fortplot_figure_rendering_pipeline, only: expand_data_range
         class(plot_context), intent(inout) :: backend
         logical, intent(in) :: grid_enabled
         character(len=10), intent(in) :: grid_which

--- a/src/figures/fortplot_figure_io.f90
+++ b/src/figures/fortplot_figure_io.f90
@@ -2,7 +2,6 @@ module fortplot_figure_io
     !! File I/O operations for figure backends
     !! Contains save operations for PNG, PDF, SVG, and ASCII formats
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_errors, only: SUCCESS, ERROR_FILE_IO
     use fortplot_logging, only: log_error

--- a/src/figures/fortplot_figure_plot_dispatch.f90
+++ b/src/figures/fortplot_figure_plot_dispatch.f90
@@ -6,15 +6,24 @@ module fortplot_figure_plot_dispatch
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
-    use fortplot_plot_data, only: plot_data_t, arrow_data_t, PLOT_TYPE_LINE, &
-                                  PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
-                                  PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
-                                  PLOT_TYPE_BOXPLOT, PLOT_TYPE_ERRORBAR, &
-                                  PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, &
-                                  PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
+    use fortplot_plot_data, only: plot_data_t, &
+                                  PLOT_TYPE_LINE, &
+                                  PLOT_TYPE_CONTOUR, &
+                                  PLOT_TYPE_PCOLORMESH, &
+                                  PLOT_TYPE_SCATTER, &
+                                  PLOT_TYPE_FILL, &
+                                  PLOT_TYPE_BOXPLOT, &
+                                  PLOT_TYPE_ERRORBAR, &
+                                  PLOT_TYPE_SURFACE, &
+                                  PLOT_TYPE_PIE, &
+                                  PLOT_TYPE_BAR, &
+                                  PLOT_TYPE_HISTOGRAM, &
                                   PLOT_TYPE_REFLINE, &
-                                  PLOT_TYPE_QUIVER, PLOT_TYPE_POLAR, &
-                                  AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+                                  PLOT_TYPE_QUIVER, &
+                                  PLOT_TYPE_POLAR, &
+                                  AXIS_PRIMARY, &
+                                  AXIS_TWINX, &
+                                  AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_rendering, only: render_line_plot, render_contour_plot, &
                                   render_pcolormesh_plot, render_fill_between_plot, &

--- a/src/figures/fortplot_figure_plot_management.f90
+++ b/src/figures/fortplot_figure_plot_management.f90
@@ -5,17 +5,17 @@ module fortplot_figure_plot_management
     !! Extracted from fortplot_figure_core to improve modularity
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, &
-                                  PLOT_TYPE_PCOLORMESH, PLOT_TYPE_FILL, &
-                                  PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, &
-                                  PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
+    use fortplot_plot_data, only: plot_data_t, &
+                                  PLOT_TYPE_LINE, &
+                                  PLOT_TYPE_PCOLORMESH, &
+                                  PLOT_TYPE_FILL, &
+                                  PLOT_TYPE_SURFACE, &
+                                  PLOT_TYPE_PIE, &
+                                  PLOT_TYPE_BAR, &
+                                  PLOT_TYPE_HISTOGRAM, &
                                   PLOT_TYPE_SCATTER
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_logging, only: log_warning, log_info
-    use fortplot_legend, only: legend_t
-    use fortplot_errors, only: fortplot_error_t
-    use fortplot_pcolormesh, only: coordinates_from_centers
-    use fortplot_contour_level_calculation, only: compute_default_contour_levels
     use fortplot_figure_legend_setup, only: setup_figure_legend
     use fortplot_figure_grid_plot_registration, only: &
         add_contour_plot_data, add_colored_contour_plot_data, &

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -13,10 +13,9 @@ module fortplot_figure_plots
     use fortplot_plot_data, only: plot_data_t
     use fortplot_figure_plot_management
     use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_figure_pie, only: figure_add_pie
     use fortplot_format_parser, only: parse_format_string
     use fortplot_colors, only: parse_color
-    use fortplot_logging, only: log_warning, log_error
+    use fortplot_logging, only: log_warning
     implicit none
 
     private

--- a/src/figures/fortplot_figure_ranges.f90
+++ b/src/figures/fortplot_figure_ranges.f90
@@ -21,16 +21,20 @@ contains
         real(wp) :: x_min_new, x_max_new, y_min_new, y_max_new
         
         ! Safety check: ensure pcolormesh arrays are allocated before accessing
-        if (.not. allocated(plots(plot_count)%pcolormesh_data%x_vertices) .or. &
-            .not. allocated(plots(plot_count)%pcolormesh_data%y_vertices)) then
+        if (.not. allocated(plots(plot_count)%pcolormesh_data%x_vertices)) then
+            return
+        end if
+        if (.not. allocated(plots(plot_count)%pcolormesh_data%y_vertices)) then
             ! Arrays not allocated - pcolormesh initialization failed
             ! Skip data range update to prevent segfault
             return
         end if
         
         ! Additional safety: check arrays have valid size
-        if (size(plots(plot_count)%pcolormesh_data%x_vertices) == 0 .or. &
-            size(plots(plot_count)%pcolormesh_data%y_vertices) == 0) then
+        if (size(plots(plot_count)%pcolormesh_data%x_vertices) == 0) then
+            return
+        end if
+        if (size(plots(plot_count)%pcolormesh_data%y_vertices) == 0) then
             ! Zero-size arrays - skip data range update
             return
         end if

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -7,14 +7,22 @@ module fortplot_figure_rendering_pipeline
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_figure_data_ranges, only: calculate_figure_data_ranges
-    use fortplot_plot_data, only: plot_data_t, arrow_data_t, PLOT_TYPE_LINE, &
-                                  PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
-                                  PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
-                                  PLOT_TYPE_BOXPLOT, PLOT_TYPE_ERRORBAR, &
-                                  PLOT_TYPE_SURFACE, PLOT_TYPE_PIE, &
-                                  PLOT_TYPE_BAR, PLOT_TYPE_REFLINE, &
-                                  PLOT_TYPE_QUIVER, PLOT_TYPE_POLAR, &
-                                  AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, &
+                                  PLOT_TYPE_CONTOUR, &
+                                  PLOT_TYPE_PCOLORMESH, &
+                                  PLOT_TYPE_SCATTER, &
+                                  PLOT_TYPE_FILL, &
+                                  PLOT_TYPE_BOXPLOT, &
+                                  PLOT_TYPE_ERRORBAR, &
+                                  PLOT_TYPE_SURFACE, &
+                                  PLOT_TYPE_PIE, &
+                                  PLOT_TYPE_BAR, &
+                                  PLOT_TYPE_REFLINE, &
+                                  PLOT_TYPE_QUIVER, &
+                                  PLOT_TYPE_POLAR, &
+                                  AXIS_PRIMARY, &
+                                  AXIS_TWINX, &
+                                  AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_raster, only: raster_context
     use fortplot_raster_axes, only: raster_draw_x_minor_ticks, &
@@ -22,17 +30,6 @@ module fortplot_figure_rendering_pipeline
     use fortplot_tick_calculation, only: calculate_minor_tick_positions, &
                                          calculate_log_minor_tick_positions
     use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
-    use fortplot_rendering, only: render_line_plot, render_contour_plot, &
-                                  render_pcolormesh_plot, render_fill_between_plot, &
-                                  render_markers, render_boxplot_plot, &
-                                  render_errorbar_plot, &
-                                  render_pie_plot, render_bar_plot
-    use fortplot_legend, only: legend_t
-    use fortplot_surface_rendering, only: render_surface_plot
-    use fortplot_polar_rendering, only: render_polar_data, render_polar_boundary, &
-                                        render_polar_radial_gridlines, &
-                                        render_polar_angular_gridlines, &
-                                        render_polar_angular_ticks
     use fortplot_twin_axes_rendering, only: setup_twin_axes_state, &
                                             render_twin_labels
     ! Plot dispatch and renderers extracted to submodules

--- a/src/figures/fortplot_figure_subplots.f90
+++ b/src/figures/fortplot_figure_subplots.f90
@@ -6,7 +6,7 @@ module fortplot_figure_subplots
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_plot_data, only: plot_data_t, subplot_data_t
-    use fortplot_logging, only: log_error, log_warning
+    use fortplot_logging, only: log_error
     implicit none
     
     private

--- a/src/figures/management/fortplot_figure_colorbar.f90
+++ b/src/figures/management/fortplot_figure_colorbar.f90
@@ -168,9 +168,12 @@ contains
         range_val = max(1.0e-12_wp, vmax - vmin)
         mid_val = 0.5_wp*(vmin + vmax)
 
-        use_custom_ticks = present(custom_ticks) .and. size(custom_ticks) > 0
-        use_custom_labels = present(custom_ticklabels) .and. &
-                            size(custom_ticklabels) > 0
+        use_custom_ticks = .false.
+        if (present(custom_ticks)) use_custom_ticks = size(custom_ticks) > 0
+        use_custom_labels = .false.
+        if (present(custom_ticklabels)) then
+            use_custom_labels = size(custom_ticklabels) > 0
+        end if
 
         call render_colorbar_with_context(backend, plot_area, vertical, vmin, &
                                           vmax, range_val, mid_val, colormap, &
@@ -558,9 +561,11 @@ contains
             call render_colorbar_auto_ticks(backend, vertical, vmin, vmax, plot_area)
         end if
 
-        if (present(label) .and. len_trim(label) > 0) then
-            call render_colorbar_label(backend, vertical, vmin, vmax, mid_val, &
-                                       plot_area, trim(label), label_fontsize)
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                call render_colorbar_label(backend, vertical, vmin, vmax, mid_val, &
+                                           plot_area, trim(label), label_fontsize)
+            end if
         end if
 
         call backend%set_coordinates(x_min_saved, x_max_saved, y_min_saved, y_max_saved)

--- a/src/figures/management/fortplot_figure_configuration.f90
+++ b/src/figures/management/fortplot_figure_configuration.f90
@@ -7,7 +7,7 @@ module fortplot_figure_configuration
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_utils, only: initialize_backend, normalize_backend_name
-    use fortplot_plot_data, only: AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
 
     implicit none

--- a/src/figures/management/fortplot_figure_legend_setup.f90
+++ b/src/figures/management/fortplot_figure_legend_setup.f90
@@ -64,10 +64,15 @@ contains
                                                        plots(i)%linestyle)
                         end if
                     else
-                        if (present(backend_name) .and. trim(backend_name) == &
-                            'ascii') then
+                        if (present(backend_name)) then
+                            if (trim(backend_name) == 'ascii') then
                             call legend_data%add_entry(plots(i)%label, &
                                                        plots(i)%color)
+                            else
+                            call legend_data%add_entry(plots(i)%label, &
+                                                       plots(i)%color, &
+                                                       marker='s')
+                            end if
                         else
                             call legend_data%add_entry(plots(i)%label, &
                                                        plots(i)%color, &

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -14,7 +14,7 @@ module fortplot_figure_operations
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
-    use fortplot_plot_data, only: plot_data_t, subplot_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_legend, only: legend_t
     use fortplot_figure_plots, only: figure_add_plot, figure_add_contour, &

--- a/src/figures/management/fortplot_figure_render_steps.f90
+++ b/src/figures/management/fortplot_figure_render_steps.f90
@@ -19,8 +19,7 @@ module fortplot_figure_render_steps
                                                   render_ascii_grid
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
-    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal, &
-                                      only_pie_plots, enforce_aspect_ratio
+    use fortplot_figure_aspect, only: enforce_aspect_ratio
     use fortplot_margins, only: plot_area_t, plot_margins_t, calculate_plot_area
     use fortplot_figure_colorbar, only: render_colorbar
     use fortplot_png, only: png_context
@@ -351,42 +350,48 @@ contains
         do i = 1, plot_count
             if (plots(i)%plot_type == PLOT_TYPE_CONTOUR) then
                 if (plots(i)%fill_contours .and. plots(i)%show_colorbar) then
-                    if (allocated(plots(i)%z_grid) .and. size(plots(i)%z_grid) > 0) then
-                        enabled = .true.
-                        plot_idx = i
-                        return
+                    if (allocated(plots(i)%z_grid)) then
+                        if (size(plots(i)%z_grid) > 0) then
+                            enabled = .true.
+                            plot_idx = i
+                            return
+                        end if
                     end if
                 end if
             end if
 
             if (plots(i)%plot_type == PLOT_TYPE_SURFACE) then
                 if (plots(i)%surface_show_colorbar) then
-                    if (allocated(plots(i)%z_grid) .and. size(plots(i)%z_grid) > 0) then
-                        enabled = .true.
-                        plot_idx = i
-                        return
+                    if (allocated(plots(i)%z_grid)) then
+                        if (size(plots(i)%z_grid) > 0) then
+                            enabled = .true.
+                            plot_idx = i
+                            return
+                        end if
                     end if
                 end if
             end if
 
             if (plots(i)%plot_type == PLOT_TYPE_SCATTER) then
                 if (plots(i)%scatter_colorbar) then
-                    if (allocated(plots(i)%scatter_colors) .and. &
-                        size(plots(i)%scatter_colors) > 0) then
-                        enabled = .true.
-                        plot_idx = i
-                        return
+                    if (allocated(plots(i)%scatter_colors)) then
+                        if (size(plots(i)%scatter_colors) > 0) then
+                            enabled = .true.
+                            plot_idx = i
+                            return
+                        end if
                     end if
                 end if
             end if
 
             if (plots(i)%plot_type == PLOT_TYPE_PCOLORMESH) then
                 if (plots(i)%show_colorbar) then
-                    if (allocated(plots(i)%pcolormesh_data%c_values) .and. &
-                        size(plots(i)%pcolormesh_data%c_values) > 0) then
-                        enabled = .true.
-                        plot_idx = i
-                        return
+                    if (allocated(plots(i)%pcolormesh_data%c_values)) then
+                        if (size(plots(i)%pcolormesh_data%c_values) > 0) then
+                            enabled = .true.
+                            plot_idx = i
+                            return
+                        end if
                     end if
                 end if
             end if

--- a/src/figures/management/fortplot_subplot_rendering.f90
+++ b/src/figures/management/fortplot_subplot_rendering.f90
@@ -9,7 +9,7 @@ module fortplot_subplot_rendering
                                                   render_figure_axes_labels_only
     use fortplot_figure_data_ranges, only: determine_sticky_edges
     use fortplot_margins, only: calculate_plot_area
-    use fortplot_text_layout, only: TITLE_FONT_SIZE, TITLE_FONT_SIZE_PT, calculate_text_height_with_size
+    use fortplot_text_layout, only: TITLE_FONT_SIZE_PT, calculate_text_height_with_size
     use fortplot_pdf_coordinate, only: calculate_pdf_plot_area
     use fortplot_subplot_layout, only: compute_tight_subplot_margins
     use fortplot_raster, only: raster_context

--- a/src/figures/plot_types/fortplot_figure_histogram.f90
+++ b/src/figures/plot_types/fortplot_figure_histogram.f90
@@ -122,7 +122,8 @@ contains
 
         ! Create line segments for each bar
         do i = 1, n_bins
-            if (present(horizontal) .and. horizontal) then
+            if (present(horizontal)) then
+                if (horizontal) then
                 ! Horizontal: bars extend along x-axis
                 x_data(4*(i-1) + 1) = 0.0_wp
                 y_data(4*(i-1) + 1) = bin_edges(i)
@@ -135,6 +136,20 @@ contains
 
                 x_data(4*(i-1) + 4) = 0.0_wp
                 y_data(4*(i-1) + 4) = bin_edges(i + 1)
+                else
+                    ! Vertical (default): bars extend along y-axis
+                    x_data(4*(i-1) + 1) = bin_edges(i)
+                    y_data(4*(i-1) + 1) = 0.0_wp
+
+                    x_data(4*(i-1) + 2) = bin_edges(i)
+                    y_data(4*(i-1) + 2) = bin_counts(i)
+
+                    x_data(4*(i-1) + 3) = bin_edges(i + 1)
+                    y_data(4*(i-1) + 3) = bin_counts(i)
+
+                    x_data(4*(i-1) + 4) = bin_edges(i + 1)
+                    y_data(4*(i-1) + 4) = 0.0_wp
+                end if
             else
                 ! Vertical (default): bars extend along y-axis
                 x_data(4*(i-1) + 1) = bin_edges(i)
@@ -152,9 +167,14 @@ contains
         end do
 
         ! Close the path back to origin
-        if (present(horizontal) .and. horizontal) then
+        if (present(horizontal)) then
+            if (horizontal) then
             x_data(4 * n_bins + 1) = 0.0_wp
             y_data(4 * n_bins + 1) = bin_edges(1)
+            else
+                x_data(4 * n_bins + 1) = bin_edges(1)
+                y_data(4 * n_bins + 1) = 0.0_wp
+            end if
         else
             x_data(4 * n_bins + 1) = bin_edges(1)
             y_data(4 * n_bins + 1) = 0.0_wp

--- a/src/figures/plot_types/fortplot_figure_pie.f90
+++ b/src/figures/plot_types/fortplot_figure_pie.f90
@@ -7,7 +7,6 @@ module fortplot_figure_pie
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PIE
-    use fortplot_figure_plot_management, only: next_plot_color
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_colors, only: parse_color
     use fortplot_logging, only: log_warning, log_error

--- a/src/interfaces/fortplot_matplotlib_plots.f90
+++ b/src/interfaces/fortplot_matplotlib_plots.f90
@@ -7,9 +7,7 @@ module fortplot_matplotlib_plots
     !! mirror matplotlib's stair-fill mode.
 
     use iso_fortran_env, only: wp => real64
-    use fortplot_figure_core, only: figure_t
     use fortplot_global, only: fig => global_figure
-    use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb
     use fortplot_matplotlib_session, only: ensure_fig_init
     use fortplot_logging, only: log_error, log_warning
 

--- a/src/interfaces/fortplot_matplotlib_scatter.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter.f90
@@ -20,19 +20,12 @@ module fortplot_matplotlib_scatter
     !!            per-point coloring and color is ignored.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_global, only: fig => global_figure
     use fortplot_logging, only: log_error
     use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb, &
                                                resolve_sequence_to_rgb
     use fortplot_matplotlib_scatter_dispatch, only: scatter_2d_dispatch, &
                                                     scatter_3d_dispatch, &
                                                     scatter_3d_string_dispatch
-    use fortplot_matplotlib_scatter_utils, only: build_scatter_size_array, &
-                                                 effective_linewidth, &
-                                                 optional_logical, &
-                                                 uniform_edgecolor, &
-                                                 store_scatter_style_arrays
-    use fortplot_scatter_plots, only: add_scatter_2d, add_scatter_3d
 
     implicit none
     private

--- a/src/interfaces/fortplot_matplotlib_scatter_dispatch.f90
+++ b/src/interfaces/fortplot_matplotlib_scatter_dispatch.f90
@@ -10,8 +10,6 @@ module fortplot_matplotlib_scatter_dispatch
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_global, only: fig => global_figure
-    use fortplot_logging, only: log_error
-    use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb
     use fortplot_matplotlib_scatter_utils, only: build_scatter_size_array, &
                                                  effective_linewidth, &
                                                  optional_logical, &

--- a/src/interfaces/fortplot_matplotlib_vector_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_vector_wrappers.f90
@@ -3,7 +3,6 @@ module fortplot_matplotlib_vector_wrappers
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_global, only: fig => global_figure
-    use fortplot_figure_core, only: figure_t
     use fortplot_logging, only: log_error
     use fortplot_matplotlib_color_utils, only: resolve_color_string_or_rgb
     use fortplot_matplotlib_mesh_wrappers, only: resolve_cmap_alias
@@ -75,8 +74,10 @@ contains
             if (allocated(resolved_cmap)) then
                 fig%plots(fig%plot_count)%colormap = resolved_cmap
             end if
-            if (present(label) .and. len_trim(label) > 0) then
-                fig%plots(fig%plot_count)%label = label
+            if (present(label)) then
+                if (len_trim(label) > 0) then
+                    fig%plots(fig%plot_count)%label = label
+                end if
             end if
         end if
     end subroutine streamplot

--- a/src/plotting/fortplot_2d_plots.f90
+++ b/src/plotting/fortplot_2d_plots.f90
@@ -8,7 +8,7 @@ module fortplot_2d_plots
     use fortplot_figure_core, only: figure_t
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE
-    use fortplot_colors, only: parse_color, color_t
+    use fortplot_colors, only: parse_color
     use fortplot_logging, only: log_warning, log_error
     use fortplot_format_parser, only: parse_format_string
     use fortplot_coordinate_validation, only: validate_coordinate_arrays, &
@@ -172,8 +172,10 @@ contains
         color_from_fmt = .false.
 
         ! Set label
-        if (present(label) .and. len_trim(label) > 0) then
-            plot%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                plot%label = label
+            end if
         end if
 
         ! Parse linestyle to extract marker, line style, and color components

--- a/src/plotting/fortplot_contour_algorithms.f90
+++ b/src/plotting/fortplot_contour_algorithms.f90
@@ -193,6 +193,7 @@ contains
 
         integer :: i, j, idx, n_subdiv, n_segments
         real(wp) :: t, x0, y0, x1, y1, x2, y2, x3, y3
+        real(wp) :: x_prev, y_prev
         real(wp) :: px, py
 
         if (n_in < 2) then
@@ -222,8 +223,8 @@ contains
                 x0 = 2.0_wp*x1 - x2
                 y0 = 2.0_wp*y1 - y2
             else
-                x0 = x_in(i - 1)
-                y0 = y_in(i - 1)
+                x0 = x_prev
+                y0 = y_prev
             end if
 
             if (i == n_segments) then
@@ -242,6 +243,8 @@ contains
                 x_out(idx) = px
                 y_out(idx) = py
             end do
+            x_prev = x1
+            y_prev = y1
         end do
 
         idx = idx + 1

--- a/src/plotting/fortplot_errorbar_plots.f90
+++ b/src/plotting/fortplot_errorbar_plots.f90
@@ -131,8 +131,10 @@ contains
             self%plots(plot_idx)%color = self%state%colors(:, color_idx)
         end if
         
-        if (present(label) .and. len_trim(label) > 0) then
-            self%plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                self%plots(plot_idx)%label = label
+            end if
         end if
     end subroutine errorbar_impl
 

--- a/src/plotting/fortplot_plot_bars.f90
+++ b/src/plotting/fortplot_plot_bars.f90
@@ -215,8 +215,10 @@ contains
             plots(plot_idx)%bar_edgecolor_per_bar_set = .true.
         end if
 
-        if (present(label) .and. len_trim(label) > 0) then
-            plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                plots(plot_idx)%label = label
+            end if
         end if
 
         state%plot_count = plot_count

--- a/src/plotting/fortplot_plot_contours.f90
+++ b/src/plotting/fortplot_plot_contours.f90
@@ -9,8 +9,7 @@ module fortplot_plot_contours
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t
-    use fortplot_figure_initialization, only: figure_state_t
-    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH
+    use fortplot_plot_data, only: PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH
     use fortplot_figure_plot_management, only: generate_default_contour_levels
     use fortplot_errors, only: fortplot_error_t, SUCCESS, ERROR_RESOURCE_LIMIT
     use fortplot_logging, only: log_warning
@@ -110,8 +109,10 @@ contains
             call generate_default_contour_levels(self%plots(plot_idx))
         end if
 
-        if (present(label) .and. len_trim(label) > 0) then
-            self%plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                self%plots(plot_idx)%label = label
+            end if
         end if
     end subroutine add_contour_plot_data
     
@@ -181,8 +182,10 @@ contains
             self%plots(plot_idx)%show_colorbar = .false.
         end if
         
-        if (present(label) .and. len_trim(label) > 0) then
-            self%plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                self%plots(plot_idx)%label = label
+            end if
         end if
     end subroutine add_colored_contour_plot_data
     

--- a/src/plotting/fortplot_plot_statistics.f90
+++ b/src/plotting/fortplot_plot_statistics.f90
@@ -10,7 +10,6 @@ module fortplot_plot_statistics
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use fortplot_figure_core, only: figure_t
-    use fortplot_figure_initialization, only: figure_state_t
     use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_HISTOGRAM, PLOT_TYPE_BOXPLOT, &
         IQR_WHISKER_MULTIPLIER
     use fortplot_utils_sort, only: sort_array
@@ -122,8 +121,10 @@ contains
             self%plots(plot_idx)%color = self%state%colors(:, color_idx)
         end if
 
-        if (present(label) .and. len_trim(label) > 0) then
-            self%plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                self%plots(plot_idx)%label = label
+            end if
         end if
 
         if (present(alpha)) then
@@ -267,8 +268,10 @@ contains
             self%plots(plot_idx)%color = self%state%colors(:, color_idx)
         end if
         
-        if (present(label) .and. len_trim(label) > 0) then
-            self%plots(plot_idx)%label = label
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                self%plots(plot_idx)%label = label
+            end if
         end if
     end subroutine add_boxplot_data
     

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -5,7 +5,6 @@ module fortplot_streamplot_core
     !! following SOLID principles and size constraints.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: EPSILON_COMPARE
     use fortplot_figure_core, only: figure_t
     use fortplot_plot_data, only: arrow_data_t
     use fortplot_scales, only: apply_scale_transform

--- a/src/rendering/fortplot_spec_rendering.f90
+++ b/src/rendering/fortplot_spec_rendering.f90
@@ -9,31 +9,26 @@ module fortplot_spec_rendering
     !! fortplot_spec_rendering_utils.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: APPROX_EQUAL_TOLERANCE
-    use fortplot_figure_core_advanced, only: core_scatter
-    use fortplot_figure_core_config, only: core_grid, core_set_line_width, &
-                                           core_set_title, core_set_xlabel, &
-                                           core_set_ylabel, core_set_xscale, &
-                                           core_set_yscale, core_set_xlim, &
+    use fortplot_figure_core_config, only: core_grid, &
+                                           core_set_title, &
+                                           core_set_xlabel, &
+                                           core_set_ylabel, &
+                                           core_set_xscale, &
+                                           core_set_yscale, &
+                                           core_set_xlim, &
                                            core_set_ylim
-    use fortplot_figure_core_operations, only: core_add_plot, core_add_contour, &
-                                               core_add_contour_filled, &
-                                               core_add_pcolormesh, &
-                                               core_add_fill_between, &
-                                               core_streamplot
     use fortplot_figure_core_utils, only: core_figure_legend
     use fortplot_figure_initialization, only: figure_state_t, initialize_figure_state
     use fortplot_figure_management, only: figure_savefig_with_status, figure_show
     use fortplot_plot_data, only: plot_data_t, subplot_data_t
-    use fortplot_spec_types, only: spec_t, data_t, encoding_t, field_plot_t, &
-                                   layer_t, mark_t
+    use fortplot_spec_types, only: spec_t, data_t, encoding_t, layer_t
     use fortplot_annotations, only: text_annotation_t
     use fortplot_spec_config_apply, only: apply_config_to_state, &
                                           apply_padding_to_margins, &
                                           set_legend_position_from_orient
     use fortplot_spec_mark_handlers, only: add_mark_to_state
     use fortplot_spec_field_rendering, only: render_field_plot_to_state
-    use fortplot_spec_rendering_utils, only: approx_equal, ends_with, get_label_from_encoding
+    use fortplot_spec_rendering_utils, only: ends_with
 
     implicit none
     private

--- a/src/rendering/fortplot_spec_rendering_utils.f90
+++ b/src/rendering/fortplot_spec_rendering_utils.f90
@@ -6,7 +6,6 @@ module fortplot_spec_rendering_utils
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_constants, only: APPROX_EQUAL_TOLERANCE
-    use fortplot_colors, only: parse_color
     use fortplot_spec_types, only: encoding_t, data_t
 
     implicit none

--- a/src/spec/fortplot_spec_config_axes.f90
+++ b/src/spec/fortplot_spec_config_axes.f90
@@ -1,7 +1,6 @@
 module fortplot_spec_config_axes
     !! Parse Vega-Lite config axis, view, and mark defaults sub-objects.
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_spec_config_types, only: config_axis_t, &
         config_view_t, config_mark_defaults_t
     use fortplot_spec_json_reader, only: skip_ws, expect_char, &

--- a/src/spec/fortplot_spec_config_defaults.f90
+++ b/src/spec/fortplot_spec_config_defaults.f90
@@ -3,9 +3,12 @@ module fortplot_spec_config_defaults
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_constants, only: TAB10_HEX, TAB10_COUNT
-    use fortplot_spec_config_types, only: config_t, config_axis_t, &
-        config_view_t, config_mark_defaults_t, config_title_t, &
-        config_legend_t, padding_t
+    use fortplot_spec_config_types, only: config_t, &
+                                          config_view_t, &
+                                          config_mark_defaults_t, &
+                                          config_title_t, &
+                                          config_legend_t, &
+                                          padding_t
     implicit none
 
     private

--- a/src/spec/fortplot_spec_config_parse.f90
+++ b/src/spec/fortplot_spec_config_parse.f90
@@ -2,7 +2,6 @@ module fortplot_spec_config_parse
     !! JSON parser for the Vega-Lite config block and related top-level
     !! properties (padding, autosize).
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_spec_config_types, only: config_t, padding_t
     use fortplot_spec_json_reader, only: skip_ws, expect_char, &
         read_string, read_real, read_int, read_bool, skip_value

--- a/src/spec/fortplot_spec_config_styling.f90
+++ b/src/spec/fortplot_spec_config_styling.f90
@@ -2,7 +2,6 @@ module fortplot_spec_config_styling
     !! Parse Vega-Lite config title, legend, range (color palette),
     !! and color-array helpers.
 
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_spec_config_types, only: config_t, &
         config_title_t, config_legend_t
     use fortplot_spec_json_reader, only: skip_ws, expect_char, &

--- a/src/spec/fortplot_spec_json.f90
+++ b/src/spec/fortplot_spec_json.f90
@@ -493,7 +493,9 @@ contains
             write (buf, '(es17.10)') x
             buf = adjustl(buf)
             i = len_trim(buf)
-            do while (i > 1 .and. buf(i:i) == '0')
+            do
+                if (i <= 1) exit
+                if (buf(i:i) /= '0') exit
                 if (buf(i - 1:i - 1) == '.') exit
                 i = i - 1
             end do

--- a/src/spec/fortplot_spec_json_field_plot.f90
+++ b/src/spec/fortplot_spec_json_field_plot.f90
@@ -204,7 +204,9 @@ contains
          write (buf, '(es17.10)') x
          buf = adjustl(buf)
          i = len_trim(buf)
-         do while (i > 1 .and. buf(i:i) == '0')
+         do
+            if (i <= 1) exit
+            if (buf(i:i) /= '0') exit
             if (buf(i - 1:i - 1) == '.') exit
             i = i - 1
          end do

--- a/src/spec/fortplot_spec_json_parse.f90
+++ b/src/spec/fortplot_spec_json_parse.f90
@@ -8,8 +8,7 @@ module fortplot_spec_json_parse
     !! Delegates channel/scale/axis parsing to fortplot_spec_json_channels
     !! and data parsing to fortplot_spec_json_data.
 
-    use fortplot_spec_types, only: spec_t, mark_t, encoding_t, &
-                                   channel_t, layer_t
+    use fortplot_spec_types, only: spec_t
     use fortplot_spec_json_reader, only: skip_ws, expect_char, &
                                           read_string, read_real, &
                                           read_int, read_bool, &
@@ -18,9 +17,7 @@ module fortplot_spec_json_parse
     use fortplot_spec_config_parse, only: parse_config, &
                                            parse_padding, &
                                            parse_autosize
-    use fortplot_spec_json_channels, only: parse_channel, parse_scale, &
-                                          parse_axis, parse_real_array, &
-                                          parse_mark, parse_encoding
+    use fortplot_spec_json_channels, only: parse_mark, parse_encoding
     use fortplot_spec_json_data, only: parse_layers, parse_data, parse_field_plot
 
     implicit none

--- a/src/spec/fortplot_spec_json_reader.f90
+++ b/src/spec/fortplot_spec_json_reader.f90
@@ -54,7 +54,11 @@ contains
         integer, intent(out) :: status
 
         status = 0
-        if (pos > len(json) .or. json(pos:pos) /= '"') then
+        if (pos > len(json)) then
+            status = 200
+            return
+        end if
+        if (json(pos:pos) /= '"') then
             status = 200
             return
         end if
@@ -110,17 +114,18 @@ contains
 
         status = 0
 
-        if (pos + 3 <= len(json) .and. &
-            json(pos:pos + 3) == 'null') then
-            val = transfer(int(Z'7FF8000000000000', 8), 1.0_wp)
-            pos = pos + 4
-            return
+        if (pos + 3 <= len(json)) then
+            if (json(pos:pos + 3) == 'null') then
+                val = transfer(int(Z'7FF8000000000000', 8), 1.0_wp)
+                pos = pos + 4
+                return
+            end if
         end if
 
         start = pos
 
-        if (pos <= len(json) .and. json(pos:pos) == '-') then
-            pos = pos + 1
+        if (pos <= len(json)) then
+            if (json(pos:pos) == '-') pos = pos + 1
         end if
 
         do while (pos <= len(json))
@@ -161,17 +166,21 @@ contains
         integer, intent(out) :: status
 
         status = 0
-        if (pos + 3 <= len(json) .and. &
-            json(pos:pos + 3) == 'true') then
-            val = .true.
-            pos = pos + 4
-        else if (pos + 4 <= len(json) .and. &
-                 json(pos:pos + 4) == 'false') then
-            val = .false.
-            pos = pos + 5
-        else
-            status = 220
+        if (pos + 3 <= len(json)) then
+            if (json(pos:pos + 3) == 'true') then
+                val = .true.
+                pos = pos + 4
+                return
+            end if
         end if
+        if (pos + 4 <= len(json)) then
+            if (json(pos:pos + 4) == 'false') then
+                val = .false.
+                pos = pos + 5
+                return
+            end if
+        end if
+        status = 220
     end subroutine read_bool
 
     subroutine read_literal(json, pos, val, status)

--- a/src/system/fortplot_path_operations.f90
+++ b/src/system/fortplot_path_operations.f90
@@ -33,14 +33,18 @@ contains
                     ! Fallback to local tmp directory
                     mapped_path = "tmp"
                 end if
-            else if (len(path) >= 5 .and. path(1:5) == "/tmp/") then
-                ! Map /tmp/filename to TEMP/filename or tmp/filename
-                call get_environment_variable("TEMP", temp_dir, status=status)
-                if (status == 0 .and. len_trim(temp_dir) > 0) then
-                    mapped_path = trim(temp_dir) // "\" // path(6:)
+            else if (len(path) >= 5) then
+                if (path(1:5) == "/tmp/") then
+                    ! Map /tmp/filename to TEMP/filename or tmp/filename
+                    call get_environment_variable("TEMP", temp_dir, status=status)
+                    if (status == 0 .and. len_trim(temp_dir) > 0) then
+                        mapped_path = trim(temp_dir) // "\" // path(6:)
+                    else
+                        ! Fallback to local tmp directory
+                        mapped_path = "tmp" // path(5:)
+                    end if
                 else
-                    ! Fallback to local tmp directory
-                    mapped_path = "tmp" // path(5:)
+                    mapped_path = path
                 end if
             else
                 mapped_path = path

--- a/src/system/fortplot_system_viewer.f90
+++ b/src/system/fortplot_system_viewer.f90
@@ -1,7 +1,6 @@
 module fortplot_system_viewer
     !! System viewer launching for show() functionality
     !! Handles platform-specific viewer launching and graphical session detection
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use, intrinsic :: iso_c_binding, only: c_int
     use fortplot_logging, only: log_info, log_error
     implicit none

--- a/src/system/fortplot_windows_test_helper.f90
+++ b/src/system/fortplot_windows_test_helper.f90
@@ -2,7 +2,7 @@ module fortplot_windows_test_helper
     !! Windows-specific test helpers for CI compatibility
     !! Issue #300: Windows CI environment compatibility
     
-    use iso_fortran_env, only: real64, int32
+    use iso_fortran_env, only: real64
     use fortplot_system_runtime, only: is_windows
     implicit none
     private
@@ -53,8 +53,10 @@ contains
         
         if (is_windows()) then
             ! Replace /tmp with Windows temp directory
-            if (len_trim(path) >= 4 .and. path(1:4) == "/tmp") then
-                normalized = trim(get_test_temp_dir()) // path(5:)
+            if (len_trim(path) >= 4) then
+                if (path(1:4) == "/tmp") then
+                    normalized = trim(get_test_temp_dir()) // path(5:)
+                end if
             end if
             
             ! Convert forward slashes to backslashes

--- a/src/testing/fortplot_test_helpers.f90
+++ b/src/testing/fortplot_test_helpers.f90
@@ -1,7 +1,7 @@
 module fortplot_test_helpers
     !! Shared test file utilities.
     
-    use iso_fortran_env, only: int32, int64
+    use iso_fortran_env, only: int64
     use fortplot_system_runtime, only: is_windows, create_directory_runtime, &
                                        delete_file_runtime, normalize_path_separators
     use fortplot, only: figure_t

--- a/src/testing/fortplot_test_pdf_tokenizer.f90
+++ b/src/testing/fortplot_test_pdf_tokenizer.f90
@@ -4,7 +4,7 @@ module fortplot_test_pdf_tokenizer
     !! Single Responsibility: Tokenize and parse PDF stream content
     !! Extracted from fortplot_test_pdf_utils to keep modules under 500 lines.
 
-    use, intrinsic :: iso_fortran_env, only: dp => real64, int8, int64
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64
     implicit none
 
     private

--- a/src/testing/fortplot_testing.f90
+++ b/src/testing/fortplot_testing.f90
@@ -1,6 +1,6 @@
 module fortplot_testing
     !! Testing utilities module with proper error handling
-    use fortplot_errors, only: fortplot_error_t, SUCCESS, ERROR_INVALID_INPUT
+    use fortplot_errors, only: SUCCESS, ERROR_INVALID_INPUT
     implicit none
     
     private

--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -157,8 +157,7 @@ contains
             if (input_text(i + 1:i + 5) == 'times') then
                 ! Emit U+00D7 (multiplication sign) so log mantissa labels like
                 ! 4.2 x 10^1 render with matplotlib's cross glyph.
-                call append_current_text(current_text, current_len, &
-                                         achar(195)//achar(151))
+                call append_current_text(current_text, current_len, '×')
                 i = i + 6
                 return
             end if

--- a/src/text/fortplot_text_helpers.f90
+++ b/src/text/fortplot_text_helpers.f90
@@ -1,6 +1,5 @@
 module fortplot_text_helpers
     !! Small helpers for preparing text for backends
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_unicode, only: escape_unicode_for_raster
     implicit none

--- a/src/text/truetype/fortplot_truetype.f90
+++ b/src/text/truetype/fortplot_truetype.f90
@@ -3,8 +3,7 @@ module fortplot_truetype
     !! Based on stb_truetype.h v1.26 by Sean Barrett.
     !! Original C implementation rewritten in Fortran for the fortplot project.
     use fortplot_tt_binary, only: tt_load_file
-    use fortplot_tt_tables, only: tt_is_font, tt_get_font_offset_for_index, &
-        tt_init_font_tables
+    use fortplot_tt_tables, only: tt_get_font_offset_for_index, tt_init_font_tables
     use fortplot_tt_cmap, only: tt_find_glyph_index
     use fortplot_tt_metrics, only: tt_scale_for_pixel_height, &
         tt_get_font_vmetrics, tt_get_glyph_hmetrics, tt_get_glyf_offset, &

--- a/src/text/truetype/fortplot_tt_edge_sort.f90
+++ b/src/text/truetype/fortplot_tt_edge_sort.f90
@@ -51,10 +51,14 @@ contains
         i = 2
         j = n
         do
-            do while (i <= n .and. p(i)%y0 < p(1)%y0)
+            do
+                if (i > n) exit
+                if (p(i)%y0 >= p(1)%y0) exit
                 i = i + 1
             end do
-            do while (j >= 1 .and. p(1)%y0 < p(j)%y0)
+            do
+                if (j < 1) exit
+                if (p(1)%y0 >= p(j)%y0) exit
                 j = j - 1
             end do
             if (i >= j) exit

--- a/src/text/truetype/fortplot_tt_outlines.f90
+++ b/src/text/truetype/fortplot_tt_outlines.f90
@@ -3,7 +3,7 @@ module fortplot_tt_outlines
     !! Parses the glyf table to extract vertex data (moves, lines, quadratic
     !! bezier curves) for simple and composite glyphs. Fortran port of
     !! stbtt__GetGlyphShapeTT from stb_truetype.h lines 1658-1895.
-    use fortplot_tt_binary, only: tt_byte, tt_ushort, tt_short, tt_ulong
+    use fortplot_tt_binary, only: tt_byte, tt_ushort, tt_short
     use fortplot_tt_metrics, only: tt_get_glyf_offset
     use, intrinsic :: iso_fortran_env, only: int8, dp => real64
     implicit none

--- a/src/text/truetype/fortplot_tt_rasterizer.f90
+++ b/src/text/truetype/fortplot_tt_rasterizer.f90
@@ -135,7 +135,9 @@ contains
             end do
 
             ! Insert new edges
-            do while (j <= n_edges .and. edges(j)%y0 <= scan_y_bottom)
+            do
+                if (j > n_edges) exit
+                if (edges(j)%y0 > scan_y_bottom) exit
                 if (edges(j)%y0 /= edges(j)%y1) then
                     num_active = num_active + 1
                     if (num_active > max_active) then

--- a/src/ui/fortplot_axes.f90
+++ b/src/ui/fortplot_axes.f90
@@ -4,7 +4,7 @@ module fortplot_axes
     !! This module handles axis drawing, tick computation, and label formatting
     !! for all scale types. Date-specific logic is delegated to fortplot_axes_date.
 
-    use, intrinsic :: iso_fortran_env, only: int64, wp => real64
+    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_scales
     use fortplot_constants, only: SCIENTIFIC_THRESHOLD_HIGH

--- a/src/ui/fortplot_legend.f90
+++ b/src/ui/fortplot_legend.f90
@@ -9,7 +9,6 @@ module fortplot_legend
     use fortplot_context, only: plot_context
     use fortplot_legend_drawing, only: render_ascii_legend, render_standard_legend, &
                                       calculate_legend_position, backend_is_ascii
-    use fortplot_legend_layout, only: calculate_legend_box
     use fortplot_legend_state, only: legend_t, legend_entry_t, &
                                       LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, &
                                       LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT, &

--- a/src/ui/fortplot_legend_drawing.f90
+++ b/src/ui/fortplot_legend_drawing.f90
@@ -9,7 +9,7 @@ module fortplot_legend_drawing
     use fortplot_legend_layout, only: legend_box_t, calculate_legend_box
     use fortplot_legend_state, only: legend_t, legend_entry_t
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_text, only: calculate_text_height, get_font_ascent_ratio
+    use fortplot_text, only: get_font_ascent_ratio
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 

--- a/src/utilities/colors/fortplot_color_parsing.f90
+++ b/src/utilities/colors/fortplot_color_parsing.f90
@@ -13,7 +13,6 @@ module fortplot_color_parsing
     use fortplot_color_definitions, only: color_t, NUM_NAMED_COLORS, named_color_names, &
         named_color_values, single_letters, letter_to_named, clamp_to_unit, &
         to_lowercase, to_lowercase_char
-    use fortplot_logging, only: log_warning
     implicit none
     
     private

--- a/src/utilities/fortplot_line_styles.f90
+++ b/src/utilities/fortplot_line_styles.f90
@@ -7,8 +7,9 @@ module fortplot_line_styles
     !! SOLID: Single responsibility for line style implementation
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_constants, only: SOLID_LINE_PATTERN_LENGTH, REFERENCE_DPI, &
-                                  DOTTED_PATTERN_PT, DASHED_PATTERN_PT, &
+    use fortplot_constants, only: SOLID_LINE_PATTERN_LENGTH, &
+                                  DOTTED_PATTERN_PT, &
+                                  DASHED_PATTERN_PT, &
                                   DASHDOT_PATTERN_PT
     implicit none
 

--- a/src/utilities/fortplot_polar.f90
+++ b/src/utilities/fortplot_polar.f90
@@ -131,7 +131,7 @@ contains
         integer, intent(in) :: degrees
         character(len=8) :: label
 
-        character(len=2), parameter :: degree_sign = achar(194)//achar(176)
+        character(len=*), parameter :: degree_sign = '°'
 
         write (label, '(I0, A)') degrees, degree_sign
     end function format_angle_label

--- a/src/utilities/text/fortplot_latex_parser.f90
+++ b/src/utilities/text/fortplot_latex_parser.f90
@@ -138,7 +138,8 @@ contains
         is_valid_greek_command = .false.
         
         ! Extract command name (without backslash)
-        if (len(command_text) < 2 .or. command_text(1:1) /= '\') return
+        if (len(command_text) < 2) return
+        if (command_text(1:1) /= '\') return
         
         command_name = command_text(2:)
         

--- a/src/utilities/text/fortplot_unicode.f90
+++ b/src/utilities/text/fortplot_unicode.f90
@@ -18,7 +18,7 @@ module fortplot_unicode
     public :: ascii_minus_to_unicode
 
     ! UTF-8 byte sequence for U+2212 MINUS SIGN (E2 88 92)
-    character(len=*), parameter :: UNICODE_MINUS = achar(226)//achar(136)//achar(146)
+    character(len=*), parameter :: UNICODE_MINUS = '−'
 
 contains
 

--- a/src/utilities/validation/fortplot_coordinate_validation.f90
+++ b/src/utilities/validation/fortplot_coordinate_validation.f90
@@ -6,7 +6,7 @@ module fortplot_coordinate_validation
     !! Addresses Issue #436 - single point plotting failures.
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_is_nan
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use fortplot_logging, only: log_error, log_warning, log_info
     implicit none
     

--- a/src/utilities/validation/fortplot_parameter_validation.f90
+++ b/src/utilities/validation/fortplot_parameter_validation.f90
@@ -8,7 +8,6 @@
 !
 module fortplot_parameter_validation
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use, intrinsic :: iso_fortran_env, only: int32
     use, intrinsic :: ieee_arithmetic, only: ieee_is_nan, ieee_is_finite
     use fortplot_validation_context, only: validation_context_t, parameter_validation_result_t, &
                                           validation_warning, validation_error, &

--- a/test/3d/test_3d.f90
+++ b/test/3d/test_3d.f90
@@ -820,7 +820,8 @@ contains
         end if
 
         fig_ptr => get_global_figure()
-        if (associated(fig_ptr) .and. fig_ptr%plot_count >= 1) then
+        if (associated(fig_ptr)) then
+        if (fig_ptr%plot_count >= 1) then
             if (abs(fig_ptr%plots(1)%color(1) - expected_orange(1)) > 0.01_wp .or. &
                 abs(fig_ptr%plots(1)%color(2) - expected_orange(2)) > 0.01_wp .or. &
                 abs(fig_ptr%plots(1)%color(3) - expected_orange(3)) > 0.01_wp) then
@@ -828,6 +829,7 @@ contains
                          fig_ptr%plots(1)%color(1), fig_ptr%plots(1)%color(2), fig_ptr%plots(1)%color(3)
                 return
             end if
+        end if
         end if
 
         print *, '  PASS: test_3d_plot_string_color'

--- a/test/3d/test_is_3d_empty_allocation.f90
+++ b/test/3d/test_is_3d_empty_allocation.f90
@@ -1,6 +1,5 @@
 program test_is_3d_empty_allocation
     !! Ensure empty z allocation does not trigger 3D detection
-    use iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: plot_data_t
     implicit none
 

--- a/test/ascii/test_ascii.f90
+++ b/test/ascii/test_ascii.f90
@@ -6,7 +6,7 @@ program test_ascii
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure
-    use fortplot_system_runtime, only: is_windows, create_directory_runtime
+    use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 
     real(wp), dimension(100) :: x, sx, cx

--- a/test/axes/test_axis_label_overlap_1573.f90
+++ b/test/axes/test_axis_label_overlap_1573.f90
@@ -3,10 +3,9 @@ program test_axis_label_overlap_1573
     !! Verifies that xlabel is positioned below x-tick labels based on measured
     !! tick label height, and that ylabel width tracking works in all paths.
     use fortplot
-    use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
+    use fortplot_layout, only: plot_area_t
     use fortplot_raster_ticks, only: X_TICK_LABEL_PAD
-    use fortplot_constants, only: XLABEL_VERTICAL_OFFSET, TICK_MARK_LENGTH, &
-                                  AXIS_LABEL_PAD_PT
+    use fortplot_constants, only: TICK_MARK_LENGTH, AXIS_LABEL_PAD_PT
     use fortplot_global, only: global_figure
     use fortplot_raster, only: raster_context
     use fortplot_raster_core, only: pt2px

--- a/test/backends/raster/test_module_separation.f90
+++ b/test/backends/raster/test_module_separation.f90
@@ -3,9 +3,8 @@ program test_module_separation
     !! Following TDD to design proper module structure
     use, intrinsic :: iso_fortran_env, only: wp => real64
     ! Test imports for proposed new module structure
-    use fortplot_layout, only: plot_margins_t, calculate_plot_area
+    use fortplot_layout, only: plot_margins_t
     use fortplot_ticks, only: calculate_tick_labels, calculate_tick_labels_log, calculate_tick_labels_symlog
-    use fortplot_margins, only: draw_basic_axes_frame, get_axis_tick_positions
     implicit none
     
     call test_should_separate_layout_concerns()

--- a/test/backends/vector/pdf_graphics/test_pdf_coordinate_mapping_985.f90
+++ b/test/backends/vector/pdf_graphics/test_pdf_coordinate_mapping_985.f90
@@ -96,7 +96,9 @@ contains
         if (p == 0) return
 
         q = p - 1
-        do while (q >= 1 .and. stream(q:q) /= new_line('a'))
+        do
+            if (q < 1) exit
+            if (stream(q:q) == new_line('a')) exit
             q = q - 1
         end do
         start = max(1, q + 1)
@@ -170,7 +172,9 @@ contains
         i1 = 0; i2 = 0; i3 = 0; i4 = 0
         pos = 1; count = 0
         do while (pos <= L)
-            do while (pos <= L .and. line(pos:pos) == ' ')
+            do
+                if (pos > L) exit
+                if (line(pos:pos) /= ' ') exit
                 pos = pos + 1
             end do
             if (pos > L) exit

--- a/test/backends/vector/pdf_graphics/test_pdf_dash_reset.f90
+++ b/test/backends/vector/pdf_graphics/test_pdf_dash_reset.f90
@@ -1,7 +1,7 @@
 program test_pdf_dash_reset
     !! Verify that PDF axes frame/ticks use solid dash pattern regardless of prior plot styles
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot, only: figure, plot, legend, savefig, title
+    use fortplot, only: plot, legend, savefig, title
     use fortplot_test_pdf_utils, only: extract_pdf_stream_text
     implicit none
 

--- a/test/doc/test_doc_example_command_fences.f90
+++ b/test/doc/test_doc_example_command_fences.f90
@@ -27,7 +27,8 @@ contains
         integer :: n
 
         n = len_trim(name)
-        is_markdown_file = n >= 3 .and. name(n-2:n) == '.md'
+        is_markdown_file = .false.
+        if (n >= 3) is_markdown_file = name(n-2:n) == '.md'
     end function is_markdown_file
 
     subroutine assert_no_bare_commands(path)
@@ -51,9 +52,11 @@ contains
             line_no = line_no + 1
             call trim_right(line)
 
-            if (len_trim(line) >= 3 .and. line(1:3) == '```') then
-                in_fence = .not. in_fence
-                cycle
+            if (len_trim(line) >= 3) then
+                if (line(1:3) == '```') then
+                    in_fence = .not. in_fence
+                    cycle
+                end if
             end if
 
             if (in_fence) cycle

--- a/test/doc/test_example_output_structure.f90
+++ b/test/doc/test_example_output_structure.f90
@@ -207,8 +207,9 @@ contains
             test_path = trim(dir_path)
             ! Remove trailing slash if present
             if (len_trim(test_path) > 0) then
-                if (test_path(len_trim(test_path):len_trim(test_path)) == '/' .or. &
-                    test_path(len_trim(test_path):len_trim(test_path)) == '\') then
+                if (test_path(len_trim(test_path):len_trim(test_path)) == '/') then
+                    test_path = test_path(1:len_trim(test_path)-1)
+                else if (test_path(len_trim(test_path):len_trim(test_path)) == '\') then
                     test_path = test_path(1:len_trim(test_path)-1)
                 end if
             end if

--- a/test/figure/test_figure_labels.f90
+++ b/test/figure/test_figure_labels.f90
@@ -1,6 +1,5 @@
 program test_figure_labels
     use fortplot_figure, only: figure_t
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
     call test_figure_title_setting()

--- a/test/figure/test_figure_state_reset.f90
+++ b/test/figure/test_figure_state_reset.f90
@@ -1,5 +1,4 @@
 program test_figure_state_reset
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure_initialization, only: figure_state_t, initialize_figure_state, &
                                               reset_figure_state
     implicit none

--- a/test/figure/test_set_aspect.f90
+++ b/test/figure/test_set_aspect.f90
@@ -108,7 +108,7 @@ contains
     end subroutine test_set_aspect_invalid_ratio
 
     subroutine test_stateful_axis_interface()
-        use fortplot_matplotlib, only: axis, figure, savefig
+        use fortplot_matplotlib, only: axis, figure
         use fortplot_global, only: global_figure
 
         call figure()

--- a/test/labels/test_ylabel.f90
+++ b/test/labels/test_ylabel.f90
@@ -11,10 +11,9 @@ program test_ylabel
     use fortplot_margins, only: plot_area_t
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
     use fortplot_text, only: calculate_text_width, calculate_text_height
-    use fortplot_constants, only: TICK_MARK_LENGTH
     use fortplot_raster_core, only: raster_image_t, create_raster_image, destroy_raster_image
     use fortplot_test_output_helpers, only: ensure_test_output_dir
-    use, intrinsic :: iso_fortran_env, only: wp => real64, error_unit
+    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
     integer :: total_tests, passed_tests

--- a/test/line_style/test_dashdot_rendering.f90
+++ b/test/line_style/test_dashdot_rendering.f90
@@ -3,9 +3,8 @@ program test_dashdot_rendering
     !! (regression test for issue #1677: dash-dot rendered identically to dotted)
     use, intrinsic :: iso_fortran_env, only: wp => real64, int32
     use fortplot_raster_core, only: raster_image_t, create_raster_image, destroy_raster_image
-    use fortplot_raster_line_styles, only: draw_styled_line, set_raster_line_style
-    use fortplot_line_styles, only: should_draw_at_distance, get_line_pattern, &
-                                    get_pattern_length, scale_pattern_to_pixels
+    use fortplot_raster_line_styles, only: draw_styled_line
+    use fortplot_line_styles, only: get_pattern_length, scale_pattern_to_pixels
     implicit none
 
     call test_dashdot_has_gaps()

--- a/test/plot_types/2d/test_scatter.f90
+++ b/test/plot_types/2d/test_scatter.f90
@@ -4,9 +4,8 @@ program test_scatter
     !! test_scatter_metadata_parity
     use fortplot, only: figure_t, figure, scatter, add_scatter, savefig, wp
     use fortplot_global, only: global_figure
-    use fortplot_plot_data, only: plot_data_t
     use fortplot_scatter_plots, only: add_scatter_plot_data
-    use, intrinsic :: iso_fortran_env, only: dp => real64, error_unit
+    use, intrinsic :: iso_fortran_env, only: dp => real64
     implicit none
 
     integer :: total_tests, passed_tests

--- a/test/plot_types/errorbar/test_errorbar_barsabove_warning.f90
+++ b/test/plot_types/errorbar/test_errorbar_barsabove_warning.f90
@@ -3,8 +3,7 @@ program test_errorbar_barsabove_warning
     !! Tests that errorbar handles barsabove=.true. and .false. without crashing
     !! and that the warning path is exercised.
     use fortplot
-    use fortplot_logging, only: set_log_level, LOG_LEVEL_WARNING, &
-                                initialize_warning_suppression
+    use fortplot_logging, only: initialize_warning_suppression
     implicit none
 
     real(wp), dimension(5) :: x, y, yerr

--- a/test/plot_types/test_subplots.f90
+++ b/test/plot_types/test_subplots.f90
@@ -2,7 +2,7 @@ program test_subplots
     !! Comprehensive test suite for subplot functionality
     !! Consolidates: test_subplot, test_subplots_edge_cases,
     !! test_subplots_returns, test_subplots_stateful
-    use iso_fortran_env, only: real64, wp => real64
+    use iso_fortran_env, only: wp => real64
     use fortplot
     use fortplot_test_output_helpers, only: ensure_test_output_dir
     implicit none

--- a/test/plot_types/vector/test_quiver_adversarial.f90
+++ b/test/plot_types/vector/test_quiver_adversarial.f90
@@ -9,7 +9,7 @@ program test_quiver_adversarial
     !! - add_quiver with all kwargs
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot, only: figure, quiver, add_quiver, xlabel, ylabel, title, savefig
+    use fortplot, only: figure, quiver, add_quiver, savefig
     use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 

--- a/test/plot_types/vector/test_streamline_integrator_resize.f90
+++ b/test/plot_types/vector/test_streamline_integrator_resize.f90
@@ -46,11 +46,15 @@ program test_streamline_integrator_resize
 contains
     real(wp) function u_const(x, y) result(u)
         real(wp), intent(in) :: x, y
+        associate (unused_x => x, unused_y => y)
+        end associate
         u = 1.0_wp
     end function u_const
 
     real(wp) function v_const(x, y) result(v)
         real(wp), intent(in) :: x, y
+        associate (unused_x => x, unused_y => y)
+        end associate
         v = 0.0_wp
     end function v_const
 

--- a/test/polar/test_polar_theta_offset.f90
+++ b/test/polar/test_polar_theta_offset.f90
@@ -1,7 +1,7 @@
 program test_polar_theta_offset
     !! Verify polar_to_cartesian uses theta_offset=0 by default (matplotlib compat)
     !! Issue #1742: polar default theta_offset was pi/2 (0 at top) instead of 0 (0 at east)
-    use fortplot_polar, only: polar_to_cartesian, PI, TWO_PI
+    use fortplot_polar, only: polar_to_cartesian, PI
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 

--- a/test/pyplot/test_matplotlib_margins.f90
+++ b/test/pyplot/test_matplotlib_margins.f90
@@ -2,7 +2,6 @@ program test_matplotlib_margins
     !! Test that our margin calculations match matplotlib exactly
     !! For 640x480: matplotlib produces x=80-576, y=58-427
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
     type(plot_margins_t) :: margins

--- a/test/pyplot/test_xscale_yscale_api.f90
+++ b/test/pyplot/test_xscale_yscale_api.f90
@@ -11,8 +11,7 @@ program test_xscale_yscale_api
     !!   7. base and linscale kwargs are accepted for symlog
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot, only: figure, xscale, yscale, set_xscale, set_yscale, plot, savefig, &
-                        get_global_figure
+    use fortplot, only: figure, xscale, yscale, set_xscale, set_yscale, get_global_figure
     use fortplot_figure_core, only: figure_t
 
     implicit none

--- a/test/raster/test_bitmap_rotation.f90
+++ b/test/raster/test_bitmap_rotation.f90
@@ -1,7 +1,6 @@
 program test_bitmap_rotation
     use fortplot_text, only: init_text_system, cleanup_text_system, calculate_text_width, calculate_text_height
     use fortplot_bitmap, only: render_text_to_bitmap, rotate_bitmap_90_cw
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
     integer(1), allocatable :: bitmap(:,:,:), rotated_bitmap(:,:,:)

--- a/test/raster/test_png_overflow.f90
+++ b/test/raster/test_png_overflow.f90
@@ -1,8 +1,6 @@
 program test_png_overflow
     !! Test PNG dimension overflow handling with automatic validation
-    use fortplot_context, only: plot_context
     use fortplot_matplotlib, only: figure, savefig, plot
-    use fortplot_utils, only: initialize_backend
     use fortplot_png_validation, only: validate_png_file
     use iso_fortran_env, only: wp => real64
     implicit none

--- a/test/regression/test_mathematical_edge_cases_875.f90
+++ b/test/regression/test_mathematical_edge_cases_875.f90
@@ -12,8 +12,7 @@ program test_mathematical_edge_cases_875
     use fortplot_scales, only: apply_scale_transform, transform_x_coordinate, &
         transform_y_coordinate, clamp_extreme_log_range
     use fortplot_color_conversions, only: rgb_to_hsv, rgb_to_lab
-    use fortplot_coordinate_validation, only: validate_coordinate_arrays, &
-        has_machine_precision_issues
+    use fortplot_coordinate_validation, only: has_machine_precision_issues
     use fortplot_parameter_validation, only: is_nan_safe, is_finite_safe
     implicit none
     

--- a/test/scale/test_log_scale_ticks.f90
+++ b/test/scale/test_log_scale_ticks.f90
@@ -184,10 +184,11 @@ contains
         
         found = .false.
         do i = 1, size(labels)
-            if (len_trim(labels(i)) > 0 .and. index(labels(i), "-") == 0 .and. &
-                trim(labels(i)) /= "0") then
-                found = .true.
-                exit
+            if (len_trim(labels(i)) > 0) then
+                if (index(labels(i), "-") == 0 .and. trim(labels(i)) /= "0") then
+                    found = .true.
+                    exit
+                end if
             end if
         end do
         

--- a/test/spec/test_spec.f90
+++ b/test/spec/test_spec.f90
@@ -2,17 +2,26 @@ program test_spec
     !! Test suite for Vega-Lite spec_t types, JSON serialization,
     !! builder API, and native spec rendering.
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot, only: spec_t, mark_t, encoding_t, channel_t, &
-                        data_t, data_column_t, scale_t, axis_t, layer_t, &
-                        vl_line, vl_point, vl_bar, vl_area, &
-                        vl_layer_add, vl_channel, &
+    use fortplot, only: spec_t, &
+                        mark_t, &
+                        channel_t, &
+                        data_t, &
+                        data_column_t, &
+                        scale_t, &
+                        axis_t, &
+                        layer_t, &
+                        vl_line, &
+                        vl_point, &
+                        vl_bar, &
+                        vl_area, &
+                        vl_layer_add, &
+                        vl_channel, &
                         spec_savefig, &
-                        spec_to_json, spec_to_json_file, &
+                        spec_to_json, &
+                        spec_to_json_file, &
                         json_to_spec, &
                         escape_json_string
-    use fortplot_validation, only: validate_file_exists, &
-                                   validate_png_format, validate_pdf_format, &
-                                   validation_result_t
+    use fortplot_validation, only: validate_png_format, validation_result_t
     use fortplot_test_output_helpers, only: ensure_test_output_dir
     implicit none
 

--- a/test/text/test_label_bounds_validation.f90
+++ b/test/text/test_label_bounds_validation.f90
@@ -3,7 +3,6 @@ program test_label_bounds_validation
     use fortplot
     use fortplot_constants, only: XLABEL_VERTICAL_OFFSET
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_text, only: calculate_text_height
     use fortplot_system_runtime, only: create_directory_runtime
     implicit none
 

--- a/test/text/test_text_width_measurements.f90
+++ b/test/text/test_text_width_measurements.f90
@@ -2,7 +2,6 @@ program test_text_width_measurements
     !! Unit test for calculate_text_width function focusing on narrow characters
     use fortplot_text, only: calculate_text_width, init_text_system
     use fortplot_text_rendering, only: render_text_to_image
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
     integer :: width_i, width_l, width_m, width_w

--- a/test/text/test_tick_vs_axis_labels.f90
+++ b/test/text/test_tick_vs_axis_labels.f90
@@ -2,7 +2,6 @@ program test_tick_vs_axis_labels
     !! Test that calculate_plot_area produces sane plot area geometry for
     !! a standard 640x480 canvas with default matplotlib margins.
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
     type(plot_margins_t) :: margins

--- a/test/text/test_utf8_text_preprocessing.f90
+++ b/test/text/test_utf8_text_preprocessing.f90
@@ -6,9 +6,8 @@ program test_utf8_text_preprocessing
     use fortplot_text_layout, only: preprocess_math_text
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_text_helpers, only: prepare_text_for_raster
-    use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
-    use fortplot, only: figure, subplots, suptitle, plot, ylabel, title, xlabel, savefig, &
-                        subplot
+    use fortplot_unicode, only: utf8_to_codepoint
+    use fortplot, only: figure, suptitle, plot, ylabel, title, savefig, subplot
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 

--- a/test/title/test_title_position_twiny.f90
+++ b/test/title/test_title_position_twiny.f90
@@ -3,7 +3,6 @@ program test_title_position_twiny
     !! Regression test for issue #1700: PNG backend twin axes tick label overlap
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_layout, only: plot_margins_t, plot_area_t, calculate_plot_area
-    use fortplot_constants, only: TITLE_VERTICAL_OFFSET, REFERENCE_DPI
     use fortplot_raster_axes, only: compute_title_position
 
     implicit none

--- a/test/validation/test_logging_system.f90
+++ b/test/validation/test_logging_system.f90
@@ -2,8 +2,11 @@ program test_logging_system
     !! Test program to validate the new logging system
     !! Demonstrates control over console output verbosity
     
-    use fortplot, only: set_log_level, LOG_LEVEL_SILENT, LOG_LEVEL_ERROR, &
-                        LOG_LEVEL_WARNING, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG
+    use fortplot, only: set_log_level, &
+                        LOG_LEVEL_SILENT, &
+                        LOG_LEVEL_WARNING, &
+                        LOG_LEVEL_INFO, &
+                        LOG_LEVEL_DEBUG
     use fortplot_logging, only: log_info, log_warning, log_error, log_debug
     
     implicit none

--- a/test/validation/test_parameter_forwarding.f90
+++ b/test/validation/test_parameter_forwarding.f90
@@ -4,7 +4,6 @@ program test_parameter_forwarding
     
     use iso_fortran_env, only: wp => real64
     use fortplot_matplotlib
-    use fortplot_figure_core, only: figure_t
     implicit none
     
     integer, parameter :: nx = 3, ny = 3

--- a/test/validation/test_parameter_validation_854.f90
+++ b/test/validation/test_parameter_validation_854.f90
@@ -6,7 +6,6 @@
 program test_parameter_validation_854
     use, intrinsic :: iso_fortran_env, only: wp => real64, output_unit
     use fortplot_parameter_validation
-    use fortplot_testing, only: assert_true
     implicit none
     
     integer :: test_count = 0, passed_tests = 0

--- a/test/workflow/test_core_functionality_fast.f90
+++ b/test/workflow/test_core_functionality_fast.f90
@@ -5,7 +5,7 @@ program test_core_functionality_fast
     
     use iso_fortran_env, only: wp => real64
     use fortplot
-    use fortplot_test_helpers, only: test_savefig, test_initialize_figure, test_get_temp_path
+    use fortplot_test_helpers, only: test_get_temp_path
     use fortplot_validation, only: validation_result_t, validate_file_exists, validate_file_size
     implicit none
     

--- a/test/workflow/test_new_modules_integration.f90
+++ b/test/workflow/test_new_modules_integration.f90
@@ -1,6 +1,6 @@
 program test_new_modules_integration
     !! Test integration of all new modules (bitmap, PNG encoder, Unicode)
-    use fortplot_bitmap, only: initialize_white_background, composite_image
+    use fortplot_bitmap, only: initialize_white_background
     use fortplot_png_encoder, only: bitmap_to_png_buffer  
     use fortplot_unicode, only: escape_unicode_for_raster, unicode_codepoint_to_ascii
     implicit none

--- a/test/workflow/test_no_error_stop.f90
+++ b/test/workflow/test_no_error_stop.f90
@@ -195,8 +195,11 @@ contains
         if (current_fig%plots(index)%plot_type /= PLOT_TYPE_BAR) then
             call fail_plot(operation, 'plot_type is not bar', passed)
         end if
-        if (.not. allocated(current_fig%plots(index)%bar_x) .or. &
-            .not. allocated(current_fig%plots(index)%bar_heights)) then
+        if (.not. allocated(current_fig%plots(index)%bar_x)) then
+            call fail_plot(operation, 'bar arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%bar_heights)) then
             call fail_plot(operation, 'bar arrays are not allocated', passed)
             return
         end if
@@ -223,8 +226,11 @@ contains
         if (current_fig%plots(index)%plot_type /= expected_type) then
             call fail_plot(operation, 'plot_type mismatch', passed)
         end if
-        if (.not. allocated(current_fig%plots(index)%x) .or. &
-            .not. allocated(current_fig%plots(index)%y)) then
+        if (.not. allocated(current_fig%plots(index)%x)) then
+            call fail_plot(operation, 'x/y arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%y)) then
             call fail_plot(operation, 'x/y arrays are not allocated', passed)
             return
         end if
@@ -253,12 +259,27 @@ contains
         if (current_fig%plots(index)%plot_type /= PLOT_TYPE_HISTOGRAM) then
             call fail_plot(operation, 'plot_type mismatch', passed)
         end if
-        if (.not. allocated(current_fig%plots(index)%hist_bin_edges) .or. &
-            .not. allocated(current_fig%plots(index)%hist_counts) .or. &
-            .not. allocated(current_fig%plots(index)%bar_x) .or. &
-            .not. allocated(current_fig%plots(index)%bar_heights) .or. &
-            .not. allocated(current_fig%plots(index)%x) .or. &
-            .not. allocated(current_fig%plots(index)%y)) then
+        if (.not. allocated(current_fig%plots(index)%hist_bin_edges)) then
+            call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%hist_counts)) then
+            call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%bar_x)) then
+            call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%bar_heights)) then
+            call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%x)) then
+            call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
+            return
+        end if
+        if (.not. allocated(current_fig%plots(index)%y)) then
             call fail_plot(operation, 'histogram storage arrays are not allocated', passed)
             return
         end if


### PR DESCRIPTION
## Verification
### Test fails on main
`fo lint` before this branch:
```text
246 unused import(s), 83 compiler warning(s)
```

### Test passes after fix
`fo lint`:
```text
no issues found
```

`fo`:
```text
Static: OK (636 modules, 335 changed, 335 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed
```

`make verify-artifacts`:
```text
Artifact verification passed.
```

`make test-ci`:
```text
CI essential test suite completed successfully
```
