### PR TITLE
feat: compose fortarray data with explicit figures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG 5d61ed63fc734ebde9cc389d3a44c4094d4026c7
+            GIT_TAG a4499ec6db3efcec839b9eb46f9295b4dac19e90
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,27 @@ option(FORTPLOT_BUILD_ZLIB_COMPONENT "Build fortplot::zlib" ON)
 option(FORTPLOT_BUILD_RASTER_COMPONENT "Build fortplot::raster" ON)
 option(FORTPLOT_BUILD_VECTOR_COMPONENT "Build fortplot::vector" ON)
 option(FORTPLOT_BUILD_ASCII_COMPONENT "Build fortplot::ascii" ON)
+option(FORTPLOT_BUILD_FORTARRAY_ADAPTER "Build fortplot::fortarray" ON)
 
 # Find all source files automatically for the full target
 file(GLOB_RECURSE FORTRAN_SOURCES "src/*.f90")
+list(FILTER FORTRAN_SOURCES EXCLUDE REGEX "/fortplot_fortarray\\.f90$")
+
+if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
+    include(FetchContent)
+    find_package(fortarray CONFIG QUIET)
+    if(NOT fortarray_FOUND)
+        set(FORTARRAY_INSTALL "${PROJECT_IS_TOP_LEVEL}" CACHE BOOL "" FORCE)
+        set(FORTARRAY_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+        FetchContent_Declare(fortarray
+            GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
+            GIT_TAG f7426c523a6df726016bd8235242e027ebc7978f
+            GIT_SHALLOW FALSE
+        )
+        FetchContent_MakeAvailable(fortarray)
+    endif()
+endif()
 
 set(FORTPLOT_CORE_SOURCES
     src/core/fortplot_constants.f90
@@ -134,6 +152,16 @@ if(FORTPLOT_BUILD_FULL)
     add_library(fortplot ${FORTRAN_SOURCES})
     fortplot_apply_common_settings(fortplot fortplot)
     add_library(fortplot::fortplot ALIAS fortplot)
+
+    if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
+        add_library(fortplot_fortarray_adapter src/interfaces/fortplot_fortarray.f90)
+        fortplot_apply_common_settings(fortplot_fortarray_adapter fortarray)
+        set_target_properties(fortplot_fortarray_adapter PROPERTIES EXPORT_NAME fortarray)
+        target_link_libraries(fortplot_fortarray_adapter
+            PUBLIC fortplot fortarray::core
+        )
+        add_library(fortplot::fortarray ALIAS fortplot_fortarray_adapter)
+    endif()
 endif()
 
 if(FORTPLOT_BUILD_COMPONENTS)
@@ -190,6 +218,9 @@ else()
     set(FORTPLOT_INSTALL_TARGETS)
     if(FORTPLOT_BUILD_FULL)
         list(APPEND FORTPLOT_INSTALL_TARGETS fortplot)
+        if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
+            list(APPEND FORTPLOT_INSTALL_TARGETS fortplot_fortarray_adapter)
+        endif()
     endif()
     if(FORTPLOT_BUILD_COMPONENTS)
         if(FORTPLOT_BUILD_CORE_COMPONENT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG f7426c523a6df726016bd8235242e027ebc7978f
+            GIT_TAG 5d61ed63fc734ebde9cc389d3a44c4094d4026c7
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG a4499ec6db3efcec839b9eb46f9295b4dac19e90
+            GIT_TAG e0912dbb393079d74b7f168c227c40e7e1564f6c
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,12 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
     find_package(fortarray CONFIG QUIET)
     if(NOT fortarray_FOUND)
         set(FORTARRAY_INSTALL "${PROJECT_IS_TOP_LEVEL}" CACHE BOOL "" FORCE)
+        set(FORTARRAY_BUILD_IO OFF CACHE BOOL "" FORCE)
         set(FORTARRAY_BUILD_TESTS OFF CACHE BOOL "" FORCE)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG e0912dbb393079d74b7f168c227c40e7e1564f6c
+            GIT_TAG 015c082545e885c87c5c792d55c79bf241ec4ff7
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Docs](https://img.shields.io/badge/docs-FORD-blue.svg)](https://lazy-fortran.github.io/fortplot/)
 
-Fortran plotting. No dependencies. PNG/PDF/text output (ASCII charset by default).
+Fortran plotting. The plotting core has no dependencies. PNG/PDF/text output
+(ASCII charset by default).
 
 ## Install
 
@@ -21,6 +22,25 @@ FetchContent_Declare(fortplot
 FetchContent_MakeAvailable(fortplot)
 target_link_libraries(your_target PRIVATE fortplot::fortplot)
 ```
+
+The optional `fortplot::fortarray` target adapts labeled `data_array_t` values
+without adding plotting methods or state to fortarray:
+
+```fortran
+use fortarray,          only: data_array_t
+use fortplot,           only: figure_t
+use fortplot_fortarray, only: plot
+
+type(data_array_t) :: field
+type(figure_t) :: fig
+
+call fig%initialize()
+call plot(fig, field)
+```
+
+CMake users can omit that dependency with
+`-DFORTPLOT_BUILD_FORTARRAY_ADAPTER=OFF`. fpm dependencies are package-wide,
+so fpm fetches fortarray even when an application uses only fortplot's core.
 
 ## Usage
 

--- a/cmake/fortarray_consumer/CMakeLists.txt
+++ b/cmake/fortarray_consumer/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(fortplot_fortarray_consumer LANGUAGES Fortran)
+
+find_package(fortplot CONFIG REQUIRED)
+add_executable(fortplot_fortarray_consumer main.f90)
+target_link_libraries(fortplot_fortarray_consumer PRIVATE fortplot::fortarray)

--- a/cmake/fortarray_consumer/main.f90
+++ b/cmake/fortarray_consumer/main.f90
@@ -1,0 +1,18 @@
+program fortplot_fortarray_consumer
+    use, intrinsic :: iso_fortran_env, only: real64
+    use fortarray, only: data_array_t, data_array
+    use fortplot_figure_core, only: figure_t
+    use fortplot_fortarray, only: plot
+    implicit none
+
+    type(data_array_t) :: field
+    type(figure_t) :: figure
+    integer :: stat
+
+    field = data_array([1.0_real64, 2.0_real64], ["radius"], name="density")
+    call figure%initialize()
+    call plot(figure, field, stat)
+    if (stat /= 0 .or. figure%plot_count /= 1) then
+        error stop "installed fortplot::fortarray adapter failed"
+    end if
+end program fortplot_fortarray_consumer

--- a/cmake/fortplotConfig.cmake.in
+++ b/cmake/fortplotConfig.cmake.in
@@ -1,5 +1,10 @@
 @PACKAGE_INIT@
 
+if(@FORTPLOT_BUILD_FORTARRAY_ADAPTER@)
+    include(CMakeFindDependencyMacro)
+    find_dependency(fortarray CONFIG)
+endif()
+
 # Find the exported targets
 include("${CMAKE_CURRENT_LIST_DIR}/fortplotTargets.cmake")
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "a4499ec6db3efcec839b9eb46f9295b4dac19e90" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "e0912dbb393079d74b7f168c227c40e7e1564f6c" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "e0912dbb393079d74b7f168c227c40e7e1564f6c" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "015c082545e885c87c5c792d55c79bf241ec4ff7" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/fpm.toml
+++ b/fpm.toml
@@ -19,6 +19,9 @@ implicit-typing = false
 implicit-external = false
 source-form = "free"
 
+[dependencies]
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "f7426c523a6df726016bd8235242e027ebc7978f" }
+
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:
 # fpm build --profile debug --flag "-Wtrampolines -Werror=trampolines"

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "f7426c523a6df726016bd8235242e027ebc7978f" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "5d61ed63fc734ebde9cc389d3a44c4094d4026c7" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "5d61ed63fc734ebde9cc389d3a44c4094d4026c7" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "a4499ec6db3efcec839b9eb46f9295b4dac19e90" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/scripts/check_root_artifacts.sh
+++ b/scripts/check_root_artifacts.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Check for forbidden artifacts in repository root (Issue #990)
-# Allowed locations: build/, doc/, output/, example/, test/, .git/
+# Allowed locations: build/, cmake/, doc/, output/, example/, test/, .git/
 # Also verify required files exist (CMakeLists.txt for downstream CMake integration)
 
 shopt -s nullglob
@@ -21,7 +21,7 @@ violations=()
 while IFS= read -r -d '' file; do
   # Skip allowed paths
   case "$file" in
-    ./build/*|./doc/*|./output/*|./example/*|./test/*|./.git/*)
+    ./build/*|./cmake/*|./doc/*|./output/*|./example/*|./test/*|./.git/*)
       continue
       ;;
     ./CMakeLists.txt)

--- a/src/interfaces/fortplot_fortarray.f90
+++ b/src/interfaces/fortplot_fortarray.f90
@@ -1,0 +1,65 @@
+module fortplot_fortarray
+    use, intrinsic :: iso_fortran_env, only: real64
+    use fortarray_core, only: data_array_t
+    use fortplot_figure_core, only: figure_t
+    implicit none
+    private
+
+    public :: plot, contourf
+
+contains
+
+    subroutine plot(figure, array, stat)
+        type(figure_t), intent(inout) :: figure
+        type(data_array_t), intent(in) :: array
+        integer, intent(out), optional :: stat
+        real(real64), allocatable :: x(:)
+
+        if (present(stat)) stat = 1
+        if (.not. array%valid()) return
+        if (array%rank() /= 1) return
+        call dimension_values(array, 1, x)
+        call figure%add_plot(x, array%values, label=trim(array%name))
+        call figure%set_xlabel(trim(array%dims(1)))
+        if (present(stat)) stat = 0
+    end subroutine plot
+
+    subroutine contourf(figure, array, stat)
+        type(figure_t), intent(inout) :: figure
+        type(data_array_t), intent(in) :: array
+        integer, intent(out), optional :: stat
+        real(real64), allocatable :: x(:), y(:), z(:, :)
+
+        if (present(stat)) stat = 1
+        if (.not. array%valid()) return
+        if (array%rank() /= 2) return
+        call dimension_values(array, 1, x)
+        call dimension_values(array, 2, y)
+        z = reshape(array%values, [array%shape(1), array%shape(2)])
+        call figure%add_contourf(x, y, z, label=trim(array%name))
+        call figure%set_xlabel(trim(array%dims(1)))
+        call figure%set_ylabel(trim(array%dims(2)))
+        if (present(stat)) stat = 0
+    end subroutine contourf
+
+    subroutine dimension_values(array, axis, values)
+        type(data_array_t), intent(in) :: array
+        integer, intent(in) :: axis
+        real(real64), allocatable, intent(out) :: values(:)
+        integer :: i
+
+        if (allocated(array%coords)) then
+            do i = 1, size(array%coords)
+                if (array%coords(i)%name == array%dims(axis)) then
+                    values = array%coords(i)%values
+                    return
+                end if
+            end do
+        end if
+        allocate(values(array%shape(axis)))
+        do i = 1, size(values)
+            values(i) = real(i, real64)
+        end do
+    end subroutine dimension_values
+
+end module fortplot_fortarray

--- a/test/test_fortarray_adapter.f90
+++ b/test/test_fortarray_adapter.f90
@@ -1,0 +1,51 @@
+program test_fortarray_adapter
+    use, intrinsic :: iso_fortran_env, only: real64
+    use fortarray_core, only: data_array_t, data_array
+    use fortplot_figure_core, only: figure_t
+    use fortplot_fortarray, only: plot, contourf
+    implicit none
+
+    type(data_array_t) :: field
+    type(figure_t) :: figure
+    type(data_array_t) :: surface
+    type(figure_t) :: contour_figure
+    real(real64) :: radius(3), angle(2), expected_surface(3, 2)
+    integer :: stat
+
+    radius = [0.1_real64, 0.4_real64, 0.9_real64]
+    field = data_array([2.0_real64, 3.0_real64, 5.0_real64], ["radius"], &
+        name="density")
+    call field%set_coord("radius", radius)
+    call figure%initialize()
+    call plot(figure, field, stat)
+
+    if (stat /= 0) error stop "adapter rejected a rank-one DataArray"
+    if (figure%plot_count /= 1) error stop "adapter did not create one plot"
+    if (any(abs(figure%plots(1)%x - radius) > 1.0e-12_real64)) then
+        error stop "adapter did not use the dimension coordinate"
+    end if
+    if (any(abs(figure%plots(1)%y - field%values) > 1.0e-12_real64)) then
+        error stop "adapter changed the field values"
+    end if
+
+    angle = [0.0_real64, 1.5_real64]
+    expected_surface = reshape([1.0_real64, 2.0_real64, 3.0_real64, &
+        4.0_real64, 5.0_real64, 6.0_real64], [3, 2])
+    surface = data_array(expected_surface, ["radius", "angle "], name="potential")
+    call surface%set_coord("radius", radius)
+    call surface%set_coord("angle", angle)
+    call contour_figure%initialize()
+    call contourf(contour_figure, surface, stat)
+
+    if (stat /= 0) error stop "adapter rejected a rank-two DataArray"
+    if (contour_figure%plot_count /= 1) error stop "adapter did not create one contour"
+    if (any(abs(contour_figure%plots(1)%x_grid - radius) > 1.0e-12_real64)) then
+        error stop "contour adapter did not use the first dimension coordinate"
+    end if
+    if (any(abs(contour_figure%plots(1)%y_grid - angle) > 1.0e-12_real64)) then
+        error stop "contour adapter did not use the second dimension coordinate"
+    end if
+    if (any(abs(contour_figure%plots(1)%z_grid - expected_surface) > 1.0e-12_real64)) then
+        error stop "contour adapter changed the field layout"
+    end if
+end program test_fortarray_adapter


### PR DESCRIPTION
Adds an explicit figure adapter for rank-one plots and rank-two filled contours. CMake keeps the plotting core independent through a separate fortplot::fortarray target; fpm uses its unavoidable package-wide dependency. Includes coordinate/layout behavior tests and an installed-package consumer.