### PR TITLE
build: pin thread-safe fortarray stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG b96523f97c725a0012f2d4ccb63932f61259faa2
+            GIT_TAG b39b3e3d9cb16cdf822e0d10875c3306be37b103
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG e9aa40cc8fbbec2c4ea65d32409f412dd19ecdee
+            GIT_TAG b96523f97c725a0012f2d4ccb63932f61259faa2
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG 015c082545e885c87c5c792d55c79bf241ec4ff7
+            GIT_TAG e9aa40cc8fbbec2c4ea65d32409f412dd19ecdee
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
     make \
+    zlib1g-dev \
     ffmpeg \
     imagemagick \
     poppler-utils \

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,6 +1,6 @@
 name = "fortplot"
 version = "2025.06.25"
-license = "license"
+license = "MIT"
 author = "Christopher Albert"
 maintainer = "albert@alumni.tugraz.at"
 copyright = "Copyright 2025, Christopher Albert"

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "b96523f97c725a0012f2d4ccb63932f61259faa2" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "b39b3e3d9cb16cdf822e0d10875c3306be37b103" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "015c082545e885c87c5c792d55c79bf241ec4ff7" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "e9aa40cc8fbbec2c4ea65d32409f412dd19ecdee" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "e9aa40cc8fbbec2c4ea65d32409f412dd19ecdee" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "b96523f97c725a0012f2d4ccb63932f61259faa2" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:


### PR DESCRIPTION
Adds the optional Fortarray plotting adapter while preserving one-way dependency direction: Fortplot depends on Fortarray only in the adapter target; Fortarray never depends on Fortplot.

Pins both CMake and fpm to merged Fortarray revision `b39b3e3d9cb16cdf822e0d10875c3306be37b103`, which in turn pins final Fortio `88ce8de1fa42832b48df779f6d748e5873ee0bde`. The container now installs the transitive zlib development headers required by fpm builds.

Validation:
- bare `fo`: 294/294 tests, lint and static checks pass
- GNU/Linux, Windows, macOS Flang, CMake FetchContent, fpm dependency, and container CI all pass.